### PR TITLE
Fix validation of new threshold when adding an owner

### DIFF
--- a/packages/safe-core-sdk/src/managers/ownerManager.ts
+++ b/packages/safe-core-sdk/src/managers/ownerManager.ts
@@ -71,7 +71,7 @@ class OwnerManager {
     const owners = await this.getOwners()
     this.validateAddressIsNotOwner(ownerAddress, owners)
     const newThreshold = threshold ?? (await this.getThreshold())
-    this.validateThreshold(newThreshold, owners.length)
+    this.validateThreshold(newThreshold, owners.length + 1)
     return this.#safeContract.encode('addOwnerWithThreshold', [ownerAddress, newThreshold])
   }
 

--- a/packages/safe-core-sdk/tests/ownerManager.test.ts
+++ b/packages/safe-core-sdk/tests/ownerManager.test.ts
@@ -236,7 +236,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const newThreshold = 1
+      const newThreshold = 2
       const initialOwners = await safeSdk.getOwners()
       chai.expect(initialOwners.length).to.be.eq(1)
       chai.expect(initialOwners[0]).to.be.eq(account1.address)


### PR DESCRIPTION
## What it solves
Resolves #95 

## How this PR fixes it
If fixes the validation of the new threshold by taking into account the new owner. This means that the amount of old owners plus the new ower is now the max value for the new threshold.

Tests were updated to check this use case.