### PR TITLE
Update web3 to 1.7.3

### DIFF
--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -72,7 +72,7 @@
     "prettier": "^2.6.2",
     "ts-generator": "^0.1.1",
     "typescript": "^4.6.3",
-    "web3": "^1.7.1",
+    "web3": "^1.7.3",
     "yargs": "^17.4.0"
   },
   "lint-staged": {


### PR DESCRIPTION
## What it solves
The current safe-core-sdk uses web3 1.7.1 which, along with 1.7.2, has a misconfigured "main" field in the package.json configuration with a nonexistent directory/file. This breaks the safe-ethers-adapter part of the safe-core-sdk

(https://github.com/ChainSafe/web3.js/issues/4926)

[Resolves #]

## How this PR fixes it
The issue with the web3 dependency solved in web3 1.7.3 