### PR TITLE
Update safe-deployments to v1.14.0

### DIFF
--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/bignumber": "^5.6.0",
     "@ethersproject/contracts": "^5.6.0",
-    "@gnosis.pm/safe-deployments": "^1.12.0",
+    "@gnosis.pm/safe-deployments": "^1.14.0",
     "web3-core": "^1.7.1"
   }
 }

--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "@ethersproject/solidity": "^5.6.0",
     "@gnosis.pm/safe-core-sdk-types": "^1.1.0",
-    "@gnosis.pm/safe-deployments": "^1.12.0",
+    "@gnosis.pm/safe-deployments": "^1.14.0",
     "ethereumjs-util": "^7.1.4",
     "semver": "^7.3.5",
     "web3-utils": "^1.7.1"

--- a/packages/safe-ethers-adapters/package.json
+++ b/packages/safe-ethers-adapters/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@gnosis.pm/safe-core-sdk": "^2.1.0",
     "@gnosis.pm/safe-core-sdk-types": "^1.1.0",
-    "@gnosis.pm/safe-deployments": "^1.12.0",
+    "@gnosis.pm/safe-deployments": "^1.14.0",
     "axios": "^0.26.1"
   }
 }


### PR DESCRIPTION
## What it solves
Resolves #
Adding version 1.14.0 of safe-deployment with Evmos Mainnet configuration
## How this PR fixes it
Unable to access features of SDK on Evmos network

https://github.com/safe-global/safe-deployments/pull/87

CC: @germartinez