### PR TITLE
Fix signTypedData

### DIFF
--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-core-sdk-types",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Safe Core SDK types",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -92,7 +92,7 @@ export interface Eip712MessageTypes {
 export interface GenerateTypedData {
   types: Eip712MessageTypes
   domain: {
-    chainId: number | undefined
+    chainId?: number
     verifyingContract: string
   }
   primaryType: string

--- a/packages/safe-core-sdk-utils/package.json
+++ b/packages/safe-core-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-core-sdk-utils",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Safe Core SDK Utilities",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -52,7 +52,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@gnosis.pm/safe-core-sdk-types": "^1.2.0",
+    "@gnosis.pm/safe-core-sdk-types": "^1.2.1",
     "semver": "^7.3.7",
     "web3-utils": "^1.7.1"
   }

--- a/packages/safe-core-sdk-utils/src/eip-712/index.ts
+++ b/packages/safe-core-sdk-utils/src/eip-712/index.ts
@@ -55,7 +55,6 @@ export function generateTypedData({
   const typedData: GenerateTypedData = {
     types: getEip712MessageTypes(safeVersion),
     domain: {
-      chainId: eip712WithChainId ? chainId : undefined,
       verifyingContract: safeAddress
     },
     primaryType: 'SafeTx',
@@ -67,6 +66,9 @@ export function generateTypedData({
       gasPrice: BigNumber.from(safeTransactionData.gasPrice),
       nonce: BigNumber.from(safeTransactionData.nonce)
     }
+  }
+  if (eip712WithChainId) {
+    typedData.domain.chainId = chainId
   }
   return typedData
 }

--- a/packages/safe-core-sdk-utils/src/eip-712/index.ts
+++ b/packages/safe-core-sdk-utils/src/eip-712/index.ts
@@ -4,14 +4,14 @@ import semverSatisfies from 'semver/functions/satisfies'
 
 const EQ_OR_GT_1_3_0 = '>=1.3.0'
 
-const EIP712_DOMAIN_BEFORE_V130 = [
+export const EIP712_DOMAIN_BEFORE_V130 = [
   {
     type: 'address',
     name: 'verifyingContract'
   }
 ]
 
-const EIP712_DOMAIN = [
+export const EIP712_DOMAIN = [
   {
     type: 'uint256',
     name: 'chainId'
@@ -23,7 +23,7 @@ const EIP712_DOMAIN = [
 ]
 
 // This function returns the types structure for signing off-chain messages according to EIP-712
-function getEip712MessageTypes(safeVersion: string): {
+export function getEip712MessageTypes(safeVersion: string): {
   EIP712Domain: typeof EIP712_DOMAIN | typeof EIP712_DOMAIN_BEFORE_V130
   SafeTx: Array<{ type: string; name: string }>
 } {

--- a/packages/safe-core-sdk-utils/tests/eip-712.test.ts
+++ b/packages/safe-core-sdk-utils/tests/eip-712.test.ts
@@ -1,0 +1,61 @@
+import { SafeTransactionData } from '@gnosis.pm/safe-core-sdk-types'
+import chai from 'chai'
+import {
+  EIP712_DOMAIN,
+  EIP712_DOMAIN_BEFORE_V130,
+  generateTypedData,
+  getEip712MessageTypes
+} from '../src'
+
+const safeAddress = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+const safeTransactionData: SafeTransactionData = {
+  to: '0x000',
+  value: '111',
+  data: '0x222',
+  operation: 333,
+  safeTxGas: 444,
+  baseGas: 555,
+  gasPrice: 666,
+  gasToken: '0x777',
+  refundReceiver: '0x888',
+  nonce: 999
+}
+
+describe('EIP-712 sign typed data', () => {
+  describe('getEip712MessageTypes', async () => {
+    it('should have the domain typed as EIP712_DOMAIN_BEFORE_V130 for Safes < v1.3.0', async () => {
+      const { EIP712Domain } = getEip712MessageTypes('1.2.0')
+      chai.expect(EIP712Domain).to.be.eq(EIP712_DOMAIN_BEFORE_V130)
+    })
+
+    it('should have the domain typed as EIP712_DOMAIN for Safes >= v1.3.0', async () => {
+      const { EIP712Domain } = getEip712MessageTypes('1.3.0')
+      chai.expect(EIP712Domain).to.be.eq(EIP712_DOMAIN)
+    })
+  })
+
+  describe('generateTypedData', async () => {
+    it('should generate the typed data for Safes < v1.3.0', async () => {
+      const { domain } = generateTypedData({
+        safeAddress,
+        safeVersion: '1.2.0',
+        chainId: 4,
+        safeTransactionData
+      })
+      chai.expect(domain.verifyingContract).to.be.eq(safeAddress)
+      chai.expect(domain.chainId).to.be.undefined
+    })
+
+    it('should generate the typed data for for Safes >= v1.3.0', async () => {
+      const chainId = 4
+      const { domain } = generateTypedData({
+        safeAddress,
+        safeVersion: '1.3.0',
+        chainId,
+        safeTransactionData
+      })
+      chai.expect(domain.verifyingContract).to.be.eq(safeAddress)
+      chai.expect(domain.chainId).to.be.eq(chainId)
+    })
+  })
+})

--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-core-sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Safe Core SDK",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -41,8 +41,8 @@
   "devDependencies": {
     "@gnosis.pm/safe-contracts-v1.2.0": "npm:@gnosis.pm/safe-contracts@1.2.0",
     "@gnosis.pm/safe-contracts-v1.3.0": "npm:@gnosis.pm/safe-contracts@1.3.0",
-    "@gnosis.pm/safe-ethers-lib": "^1.2.0",
-    "@gnosis.pm/safe-web3-lib": "^1.2.0",
+    "@gnosis.pm/safe-ethers-lib": "^1.2.1",
+    "@gnosis.pm/safe-web3-lib": "^1.2.1",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
     "@nomiclabs/hardhat-web3": "^2.0.0",
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "@ethersproject/solidity": "^5.6.0",
-    "@gnosis.pm/safe-core-sdk-types": "^1.2.0",
+    "@gnosis.pm/safe-core-sdk-types": "^1.2.1",
     "@gnosis.pm/safe-deployments": "1.12.0",
     "ethereumjs-util": "^7.1.4",
     "semver": "^7.3.5",

--- a/packages/safe-core-sdk/src/utils/signatures/index.ts
+++ b/packages/safe-core-sdk/src/utils/signatures/index.ts
@@ -109,6 +109,6 @@ export async function generateEIP712Signature(
 ): Promise<EthSignSignature> {
   const signerAddress = await ethAdapter.getSignerAddress()
   let signature = await ethAdapter.signTypedData(safeTransactionEIP712Args, methodVersion)
-  signature = adjustVInSignature('eth_signTypedData', signature.replace('0x', ''))
+  signature = adjustVInSignature('eth_signTypedData', signature)
   return new EthSignSignature(signerAddress, signature)
 }

--- a/packages/safe-ethers-lib/package.json
+++ b/packages/safe-ethers-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-ethers-lib",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Ethers library adapter to be used by Safe Core SDK",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -50,8 +50,8 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@gnosis.pm/safe-core-sdk-types": "^1.2.0",
-    "@gnosis.pm/safe-core-sdk-utils": "^1.2.0"
+    "@gnosis.pm/safe-core-sdk-types": "^1.2.1",
+    "@gnosis.pm/safe-core-sdk-utils": "^1.2.1"
   },
   "peerDependencies": {
     "ethers": "^5.6.2"

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -142,7 +142,7 @@ class EthersAdapter implements EthAdapter {
   async signTypedData(safeTransactionEIP712Args: SafeTransactionEIP712Args): Promise<string> {
     if (isTypedDataSigner(this.#signer)) {
       const typedData = generateTypedData(safeTransactionEIP712Args)
-      const signature = this.#signer._signTypedData(
+      const signature = await this.#signer._signTypedData(
         typedData.domain,
         { SafeTx: typedData.types.SafeTx },
         typedData.message

--- a/packages/safe-service-client/package.json
+++ b/packages/safe-service-client/package.json
@@ -36,8 +36,8 @@
   ],
   "homepage": "https://github.com/safe-global/safe-core-sdk#readme",
   "devDependencies": {
-    "@gnosis.pm/safe-ethers-lib": "^1.2.0",
-    "@gnosis.pm/safe-web3-lib": "^1.2.0",
+    "@gnosis.pm/safe-ethers-lib": "^1.2.1",
+    "@gnosis.pm/safe-web3-lib": "^1.2.1",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
     "@nomiclabs/hardhat-web3": "^2.0.0",
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.6.0",
-    "@gnosis.pm/safe-core-sdk-types": "^1.2.0",
+    "@gnosis.pm/safe-core-sdk-types": "^1.2.1",
     "node-fetch": "^2.6.6"
   }
 }

--- a/packages/safe-web3-lib/package.json
+++ b/packages/safe-web3-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-web3-lib",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Web3 library adapter to be used by Safe Core SDK",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -50,8 +50,8 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@gnosis.pm/safe-core-sdk-types": "^1.2.0",
-    "@gnosis.pm/safe-core-sdk-utils": "^1.2.0"
+    "@gnosis.pm/safe-core-sdk-types": "^1.2.1",
+    "@gnosis.pm/safe-core-sdk-utils": "^1.2.1"
   },
   "peerDependencies": {
     "web3": "^1.7.0"


### PR DESCRIPTION
## What it solves

Fixes the error `[Error: invalid BigNumber value (argument="value", value=undefined, code=INVALID_ARGUMENT, version=bignumber/5.6.2)](https://ethereum.stackexchange.com/questions/130776/error-invalid-bignumber-value-argument-value-value-undefined-code-invalid)` for Safes with version `<v1.3.0`.

This issue was caused because `chainId` had a wrong type making `signer._signTypedData()` complain about it.
