### PR TITLE
Add user nonce to TransactionOptions type

### DIFF
--- a/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
+++ b/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
@@ -28,8 +28,8 @@ export interface GetContractProps {
 export interface EthAdapter {
   isAddress(address: string): boolean
   getEip3770Address(fullAddress: string): Promise<Eip3770Address>
-  getBalance(address: string): Promise<BigNumber>
-  getNonce(address: string): Promise<number>
+  getBalance(address: string, defaultBlock?: string | number): Promise<BigNumber>
+  getNonce(address: string, defaultBlock?: string | number): Promise<number>
   getChainId(): Promise<number>
   getChecksummedAddress(address: string): string
   getSafeContract({
@@ -53,8 +53,8 @@ export interface EthAdapter {
     customContractAddress,
     customContractAbi
   }: GetContractProps): GnosisSafeProxyFactoryContract
-  getContractCode(address: string): Promise<string>
-  isContractDeployed(address: string): Promise<boolean>
+  getContractCode(address: string, defaultBlock?: string | number): Promise<string>
+  isContractDeployed(address: string, defaultBlock?: string | number): Promise<boolean>
   getTransaction(transactionHash: string): Promise<any>
   getSignerAddress(): Promise<string>
   signMessage(message: string): Promise<string>
@@ -66,6 +66,6 @@ export interface EthAdapter {
     transaction: EthAdapterTransaction,
     callback?: (error: Error, gas: number) => void
   ): Promise<number>
-  call(transaction: EthAdapterTransaction): Promise<string>
+  call(transaction: EthAdapterTransaction, defaultBlock?: string | number): Promise<string>
   encodeParameters(types: string[], values: any[]): string
 }

--- a/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
+++ b/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
@@ -29,6 +29,7 @@ export interface EthAdapter {
   isAddress(address: string): boolean
   getEip3770Address(fullAddress: string): Promise<Eip3770Address>
   getBalance(address: string): Promise<BigNumber>
+  getNonce(address: string): Promise<number>
   getChainId(): Promise<number>
   getChecksummedAddress(address: string): string
   getSafeContract({

--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -56,6 +56,7 @@ export interface TransactionOptions {
   gasPrice?: number | string
   maxFeePerGas?: number | string
   maxPriorityFeePerGas?: number | string
+  nonce?: number
 }
 
 export interface BaseTransactionResult {

--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -234,6 +234,7 @@ const options: Web3TransactionOptions = {
   gasPrice, // Optional
   maxFeePerGas, // Optional
   maxPriorityFeePerGas // Optional
+  nonce // Optional
 }
 ```
 ```js
@@ -243,6 +244,7 @@ const options: EthersTransactionOptions = {
   gasPrice, // Optional
   maxFeePerGas, // Optional
   maxPriorityFeePerGas // Optional
+  nonce // Optional
 }
 ```
 ```js
@@ -597,6 +599,7 @@ const options: Web3TransactionOptions = {
   gasPrice, // Optional
   maxFeePerGas, // Optional
   maxPriorityFeePerGas // Optional
+  nonce // Optional
 }
 ```
 ```js
@@ -606,6 +609,7 @@ const options: EthersTransactionOptions = {
   gasPrice, // Optional
   maxFeePerGas, // Optional
   maxPriorityFeePerGas // Optional
+  nonce // Optional
 }
 ```
 ```js
@@ -768,6 +772,7 @@ const options: Web3TransactionOptions = {
   gasPrice, // Optional
   maxFeePerGas, // Optional
   maxPriorityFeePerGas // Optional
+  nonce // Optional
 }
 ```
 ```js
@@ -777,6 +782,7 @@ const options: EthersTransactionOptions = {
   gasPrice, // Optional
   maxFeePerGas, // Optional
   maxPriorityFeePerGas // Optional
+  nonce // Optional
 }
 ```
 ```js

--- a/packages/safe-core-sdk/tests/execution.test.ts
+++ b/packages/safe-core-sdk/tests/execution.test.ts
@@ -518,7 +518,7 @@ describe('Transactions execution', () => {
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const currentNonce = await ethAdapter.getNonce(account1.address)
+      const currentNonce = await ethAdapter.getNonce(account1.address, 'pending')
       const tx = await safeSdk1.createTransaction(txDataPartial)
       const execOptions: EthersTransactionOptions = { nonce: currentNonce }
       const txResponse = await safeSdk1.executeTransaction(tx, execOptions)

--- a/packages/safe-core-sdk/tests/execution.test.ts
+++ b/packages/safe-core-sdk/tests/execution.test.ts
@@ -167,6 +167,32 @@ describe('Transactions execution', () => {
         .to.be.rejectedWith('Cannot specify gas and gasLimit together in transaction options')
     })
 
+    it('should fail if a user tries to execute a transaction with options: { nonce: <invalid_nonce> }', async () => {
+      const { accounts, contractNetworks } = await setupTests()
+      const [account1, account2] = accounts
+      const safe = await getSafeWithOwners([account1.address])
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeSdk1 = await Safe.create({
+        ethAdapter,
+        safeAddress: safe.address,
+        contractNetworks
+      })
+      await account1.signer.sendTransaction({
+        to: safe.address,
+        value: BigNumber.from('1000000000000000000') // 1 ETH
+      })
+      const txDataPartial: SafeTransactionDataPartial = {
+        to: account2.address,
+        value: '500000000000000000', // 0.5 ETH
+        data: '0x'
+      }
+      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const execOptions: EthersTransactionOptions = { nonce: 123456789 }
+      await chai
+        .expect(safeSdk1.executeTransaction(tx, execOptions))
+        .to.be.rejectedWith('Nonce too high')
+    })
+
     it('should execute a transaction with threshold 1', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1, account2] = accounts
@@ -472,6 +498,34 @@ describe('Transactions execution', () => {
           .to.be.eq(BigNumber.from(txConfirmed.maxPriorityFeePerGas))
       }
     )
+
+    it('should execute a transaction with options: { nonce }', async () => {
+      const { accounts, contractNetworks } = await setupTests()
+      const [account1, account2] = accounts
+      const safe = await getSafeWithOwners([account1.address])
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeSdk1 = await Safe.create({
+        ethAdapter,
+        safeAddress: safe.address,
+        contractNetworks
+      })
+      await account1.signer.sendTransaction({
+        to: safe.address,
+        value: BigNumber.from('1000000000000000000') // 1 ETH
+      })
+      const txDataPartial: SafeTransactionDataPartial = {
+        to: account2.address,
+        value: '500000000000000000', // 0.5 ETH
+        data: '0x'
+      }
+      const currentNonce = await ethAdapter.getNonce(account1.address)
+      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const execOptions: EthersTransactionOptions = { nonce: currentNonce }
+      const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
+      await waitSafeTxReceipt(txResponse)
+      const txConfirmed = await ethAdapter.getTransaction(txResponse.hash)
+      chai.expect(execOptions.nonce).to.be.eq(txConfirmed.nonce)
+    })
   })
 
   describe('executeTransaction (MultiSend)', async () => {

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -68,6 +68,10 @@ class EthersAdapter implements EthAdapter {
     return BigNumber.from(await this.#provider.getBalance(address))
   }
 
+  async getNonce(address: string): Promise<number> {
+    return this.#provider.getTransactionCount(address)
+  }
+
   async getChainId(): Promise<number> {
     return (await this.#provider.getNetwork()).chainId
   }

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -64,12 +64,12 @@ class EthersAdapter implements EthAdapter {
     return validateEip3770Address(fullAddress, chainId)
   }
 
-  async getBalance(address: string): Promise<BigNumber> {
-    return BigNumber.from(await this.#provider.getBalance(address))
+  async getBalance(address: string, blockTag?: string | number): Promise<BigNumber> {
+    return BigNumber.from(await this.#provider.getBalance(address, blockTag))
   }
 
-  async getNonce(address: string): Promise<number> {
-    return this.#provider.getTransactionCount(address)
+  async getNonce(address: string, blockTag?: string | number): Promise<number> {
+    return this.#provider.getTransactionCount(address, blockTag)
   }
 
   async getChainId(): Promise<number> {
@@ -125,12 +125,12 @@ class EthersAdapter implements EthAdapter {
     return getSafeProxyFactoryContractInstance(safeVersion, contractAddress, this.#signer)
   }
 
-  async getContractCode(address: string): Promise<string> {
-    return this.#provider.getCode(address)
+  async getContractCode(address: string, blockTag?: string | number): Promise<string> {
+    return this.#provider.getCode(address, blockTag)
   }
 
-  async isContractDeployed(address: string): Promise<boolean> {
-    const contractCode = await this.#provider.getCode(address)
+  async isContractDeployed(address: string, blockTag?: string | number): Promise<boolean> {
+    const contractCode = await this.#provider.getCode(address, blockTag)
     return contractCode !== '0x'
   }
 
@@ -164,8 +164,8 @@ class EthersAdapter implements EthAdapter {
     return (await this.#provider.estimateGas(transaction)).toNumber()
   }
 
-  call(transaction: EthAdapterTransaction): Promise<string> {
-    return this.#provider.call(transaction)
+  call(transaction: EthAdapterTransaction, blockTag?: string | number): Promise<string> {
+    return this.#provider.call(transaction, blockTag)
   }
 
   encodeParameters(types: string[], values: any[]) {

--- a/packages/safe-ethers-lib/src/types.ts
+++ b/packages/safe-ethers-lib/src/types.ts
@@ -7,6 +7,7 @@ export interface EthersTransactionOptions {
   gasPrice?: number | string
   maxFeePerGas?: number | string
   maxPriorityFeePerGas?: number | string
+  nonce?: number
 }
 
 export interface EthersTransactionResult extends BaseTransactionResult {

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -53,6 +53,10 @@ class Web3Adapter implements EthAdapter {
     return BigNumber.from(await this.#web3.eth.getBalance(address))
   }
 
+  async getNonce(address: string): Promise<number> {
+    return this.#web3.eth.getTransactionCount(address)
+  }
+
   async getChainId(): Promise<number> {
     return this.#web3.eth.getChainId()
   }

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -49,12 +49,18 @@ class Web3Adapter implements EthAdapter {
     return validateEip3770Address(fullAddress, chainId)
   }
 
-  async getBalance(address: string): Promise<BigNumber> {
-    return BigNumber.from(await this.#web3.eth.getBalance(address))
+  async getBalance(address: string, defaultBlock?: string | number): Promise<BigNumber> {
+    const balance = (defaultBlock)
+      ? await this.#web3.eth.getBalance(address, defaultBlock)
+      : await this.#web3.eth.getBalance(address)
+    return BigNumber.from(balance)
   }
 
-  async getNonce(address: string): Promise<number> {
-    return this.#web3.eth.getTransactionCount(address)
+  async getNonce(address: string, defaultBlock?: string | number): Promise<number> {
+    const nonce = (defaultBlock)
+      ? await this.#web3.eth.getTransactionCount(address, defaultBlock)
+      : await this.#web3.eth.getTransactionCount(address)
+    return nonce
   }
 
   async getChainId(): Promise<number> {
@@ -123,12 +129,15 @@ class Web3Adapter implements EthAdapter {
     return new this.#web3.eth.Contract(abi, address, options)
   }
 
-  async getContractCode(address: string): Promise<string> {
-    return this.#web3.eth.getCode(address)
+  async getContractCode(address: string, defaultBlock?: string | number): Promise<string> {
+    const code = (defaultBlock)
+      ? await this.#web3.eth.getCode(address, defaultBlock)
+      : await this.#web3.eth.getCode(address)
+    return code
   }
 
-  async isContractDeployed(address: string): Promise<boolean> {
-    const contractCode = await this.#web3.eth.getCode(address)
+  async isContractDeployed(address: string, defaultBlock?: string | number): Promise<boolean> {
+    const contractCode = await this.getContractCode(address, defaultBlock)
     return contractCode !== '0x'
   }
 
@@ -192,8 +201,8 @@ class Web3Adapter implements EthAdapter {
     return this.#web3.eth.estimateGas(transaction, callback)
   }
 
-  call(transaction: EthAdapterTransaction): Promise<string> {
-    return this.#web3.eth.call(transaction)
+  call(transaction: EthAdapterTransaction, defaultBlock?: string | number): Promise<string> {
+    return this.#web3.eth.call(transaction, defaultBlock)
   }
 
   encodeParameters(types: string[], values: any[]): string {

--- a/packages/safe-web3-lib/src/types.ts
+++ b/packages/safe-web3-lib/src/types.ts
@@ -7,6 +7,7 @@ export interface Web3TransactionOptions {
   gasPrice?: number | string
   maxFeePerGas?: number | string
   maxPriorityFeePerGas?: number | string
+  nonce?: number
 }
 
 export interface Web3TransactionResult extends BaseTransactionResult {


### PR DESCRIPTION
## What it solves
Allows to specify the nonce from the sender wallet when executing a Safe transaction via the Core SDK.