### PR TITLE
Make signTransaction method immutable

### DIFF
--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -395,11 +395,10 @@ class Safe {
     })
     signedSafeTransaction.addSignature(signature)
 
-    // TO-DO: Remove in v3.0.0 {
+    // TO-DO: Remove in v4.0.0 {
     console.warn(
-      `⚠️ the "signTransaction" method now returns a signed Safe transaction. Please update your code according to the new documentation: https://github.com/safe-global/safe-core-sdk/tree/main/packages/safe-core-sdk#signtransaction. In >=v3.0.0, the signature will be added only to the return transaction object, and not to the one passed as an argument.`
+      `⚠️ the "signTransaction" method now returns a signed Safe transaction without modifying the passed safeTransaction argument. Please check the new documentation: https://github.com/safe-global/safe-core-sdk/tree/main/packages/safe-core-sdk#signtransaction.`
     )
-    safeTransaction.addSignature(signature)
     // }
 
     return signedSafeTransaction


### PR DESCRIPTION
## What it solves
This PR makes immutable the `signTransaction` method from the Core SDK by not adding the signature to the passed `safeTransaction` argument.