### PR TITLE
Update documentation

### DIFF
--- a/packages/guides/integrating-the-safe-core-sdk.md
+++ b/packages/guides/integrating-the-safe-core-sdk.md
@@ -82,7 +82,10 @@ const contractNetworks: ContractNetworksConfig = {
   [id]: {
     multiSendAddress: '<MULTI_SEND_ADDRESS>',
     safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
-    safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>'
+    safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
+    multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+    safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+    safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
   }
 }
 

--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -172,7 +172,10 @@ const safeFactory = await SafeFactory.create({ ethAdapter })
     [id]: {
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
       safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
-      safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>'
+      safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
+      multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+      safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+      safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
     }
   }
 
@@ -295,7 +298,10 @@ const safeSdk = await Safe.create({ ethAdapter, safeAddress })
     [id]: {
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
       safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
-      safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>'
+      safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
+      multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+      safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+      safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
     }
   }
 

--- a/packages/safe-web3-lib/README.md
+++ b/packages/safe-web3-lib/README.md
@@ -39,7 +39,7 @@ If the app integrating the SDK is using `Web3`, create an instance of the `Web3A
 import Web3 from 'web3'
 import Web3Adapter from '@gnosis.pm/safe-web3-lib'
 
-const web3 = new Web3.providers.HttpProvider('http://localhost:8545')
+const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
 const safeOwner = '0x<address>'
 
 const ethAdapter = new Web3Adapter({


### PR DESCRIPTION
## What it solves
- Fixes how `web3` instance is initialized when using the `Web3Adapter` class
- Adds the optional ABI properties in `ContractNetworksConfig`