### PR TITLE
Support MultiSendCallOnly

### DIFF
--- a/packages/guides/integrating-the-safe-core-sdk.md
+++ b/packages/guides/integrating-the-safe-core-sdk.md
@@ -133,7 +133,7 @@ The Safe Core SDK supports the execution of single Safe transactions but also Mu
   ```js
   import { SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
 
-  const transaction: SafeTransactionDataPartial = {
+  const safeTransactionData: SafeTransactionDataPartial = {
     to,
     data,
     value,
@@ -146,7 +146,7 @@ The Safe Core SDK supports the execution of single Safe transactions but also Mu
     nonce // Optional
   }
 
-  const safeTransaction = await safeSdk.createTransaction(transaction)
+  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
   ```
 
 * **Create a MultiSend transaction**
@@ -157,7 +157,7 @@ The Safe Core SDK supports the execution of single Safe transactions but also Mu
   import { SafeTransactionOptionalProps } from '@gnosis.pm/safe-core-sdk'
   import { MetaTransactionData } from '@gnosis.pm/safe-core-sdk-types'
 
-  const transactions: MetaTransactionData[] = [
+  const safeTransactionData: MetaTransactionData[] = [
     {
       to,
       data,
@@ -182,7 +182,7 @@ The Safe Core SDK supports the execution of single Safe transactions but also Mu
     nonce // Optional
   }
 
-  const safeTransaction = await safeSdk.createTransaction(transactions, options)
+  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData, options })
   ```
 
 
@@ -311,7 +311,7 @@ const safeTransactionData: SafeTransactionData = {
   refundReceiver: transaction.refundReceiver,
   nonce: transaction.nonce
 }
-const safeTransaction = await safeSdk.createTransaction(safeTransactionData)
+const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
 transaction.confirmations.forEach(confirmation => {
   const signature = new EthSignSignature(confirmation.owner, confirmation.signature)
   safeTransaction.addSignature(signature)

--- a/packages/guides/integrating-the-safe-core-sdk.md
+++ b/packages/guides/integrating-the-safe-core-sdk.md
@@ -81,9 +81,11 @@ const id = await ethAdapter.getChainId()
 const contractNetworks: ContractNetworksConfig = {
   [id]: {
     multiSendAddress: '<MULTI_SEND_ADDRESS>',
+    multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
     safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
     safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
     multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+    multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js
     safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
     safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
   }

--- a/packages/safe-core-sdk-types/src/contracts/MultiSendCallOnlyContract.ts
+++ b/packages/safe-core-sdk-types/src/contracts/MultiSendCallOnlyContract.ts
@@ -1,0 +1,4 @@
+export interface MultiSendCallOnlyContract {
+  getAddress(): string
+  encode(methodName: any, params: any): string
+}

--- a/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
+++ b/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
@@ -3,6 +3,7 @@ import { SingletonDeployment } from '@gnosis.pm/safe-deployments'
 import { AbiItem } from 'web3-utils'
 import { GnosisSafeContract } from '../contracts/GnosisSafeContract'
 import { GnosisSafeProxyFactoryContract } from '../contracts/GnosisSafeProxyFactoryContract'
+import { MultiSendCallOnlyContract } from '../contracts/MultiSendCallOnlyContract'
 import { MultiSendContract } from '../contracts/MultiSendContract'
 import { Eip3770Address, SafeTransactionEIP712Args, SafeVersion } from '../types'
 
@@ -46,6 +47,13 @@ export interface EthAdapter {
     customContractAddress,
     customContractAbi
   }: GetContractProps): MultiSendContract
+  getMultiSendCallOnlyContract({
+    safeVersion,
+    chainId,
+    singletonDeployment,
+    customContractAddress,
+    customContractAbi
+  }: GetContractProps): MultiSendCallOnlyContract
   getSafeProxyFactoryContract({
     safeVersion,
     chainId,

--- a/packages/safe-core-sdk-types/src/index.ts
+++ b/packages/safe-core-sdk-types/src/index.ts
@@ -1,5 +1,6 @@
 export * from './contracts/GnosisSafeContract'
 export * from './contracts/GnosisSafeProxyFactoryContract'
+export * from './contracts/MultiSendCallOnlyContract'
 export * from './contracts/MultiSendContract'
 export * from './ethereumLibs/EthAdapter'
 export * from './types'

--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -171,9 +171,11 @@ const safeFactory = await SafeFactory.create({ ethAdapter })
   const contractNetworks: ContractNetworksConfig = {
     [id]: {
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
+      multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
       safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
       safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
       multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+      multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js
       safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
       safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
     }
@@ -297,9 +299,11 @@ const safeSdk = await Safe.create({ ethAdapter, safeAddress })
   const contractNetworks: ContractNetworksConfig = {
     [id]: {
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
+      multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
       safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
       safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
       multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+      multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js
       safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
       safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
     }
@@ -334,8 +338,13 @@ const safeSdk2 = await safeSdk.connect({ ethAdapter, safeAddress })
   const contractNetworks: ContractNetworksConfig = {
     [chainId]: {
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
+      multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
       safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
-      safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>'
+      safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
+      multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
+      multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js
+      safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+      safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>' // Optional. Only needed with web3.js
     }
   }
   const safeSdk = await Safe.connect({ ethAdapter, safeAddress, contractNetworks })

--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -91,12 +91,12 @@ Check the `create` method in the [API Reference](#sdk-api) for more details on a
 ```js
 import { SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
 
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   to: '0x<address>',
   value: '<eth_value_in_wei>',
   data: '0x<data>'
 }
-const safeTransaction = await safeSdk.createTransaction(transaction)
+const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
 ```
 
 Check the `createTransaction` method in the [API Reference](#sdk-api) for additional details on creating MultiSend transactions.
@@ -441,7 +441,7 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Sa
   ```js
   import { SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
 
-  const transaction: SafeTransactionDataPartial = {
+  const safeTransactionData: SafeTransactionDataPartial = {
     to,
     data,
     value,
@@ -453,7 +453,7 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Sa
     refundReceiver, // Optional
     nonce // Optional
   }
-  const safeTransaction = await safeSdk.createTransaction(transaction)
+  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
   ```
 
 * **MultiSend transactions**
@@ -461,7 +461,7 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Sa
   This method can take an array of `MetaTransactionData` objects that represent the multiple transactions we want to include in our MultiSend transaction. If we want to specify some of the optional properties in our MultiSend transaction, we can pass a second argument to the `createTransaction` method with the `SafeTransactionOptionalProps` object.
 
   ```js
-  const transactions: MetaTransactionData[] = [
+  const safeTransactionData: MetaTransactionData[] = [
     {
       to,
       data,
@@ -476,13 +476,13 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Sa
     },
     // ...
   ]
-  const safeTransaction = await safeSdk.createTransaction(transactions)
+  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
   ```
 
   This method can also receive the `options` parameter to set the optional properties in the MultiSend transaction:
 
   ```js
-  const transactions: MetaTransactionData[] = [
+  const safeTransactionData: MetaTransactionData[] = [
     {
       to,
       data,
@@ -505,7 +505,14 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Sa
     refundReceiver, // Optional
     nonce // Optional
   }
-  const safeTransaction = await safeSdk.createTransaction(transactions, options)
+  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData, options })
+  ```
+
+  In addition, the optional `callsOnly` parameter, that is false by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
+
+  ```js
+  const callsOnly = true
+  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData, options, callsOnly })
   ```
 
 If the optional properties are not manually set, the Safe transaction returned will have the default value for each one:
@@ -525,10 +532,10 @@ Read more about the [Safe transaction properties](https://docs.gnosis-safe.io/tu
 Returns a Safe transaction ready to be signed by the owners that invalidates the pending Safe transaction/s with a specific nonce.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction =  await safeSdk.createTransaction(transaction)
+const safeTransaction =  await safeSdk.createTransaction({ safeTransactionData })
 const rejectionTransaction = await safeSdk.createRejectionTransaction(safeTransaction.data.nonce)
 ```
 
@@ -537,10 +544,10 @@ const rejectionTransaction = await safeSdk.createRejectionTransaction(safeTransa
 Returns the transaction hash of a Safe transaction.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction =  await safeSdk.createTransaction(transaction)
+const safeTransaction =  await safeSdk.createTransaction({ safeTransactionData })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 ```
 
@@ -549,10 +556,10 @@ const txHash = await safeSdk.getTransactionHash(safeTransaction)
 Signs a hash using the current owner account.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction =  await safeSdk.createTransaction(transaction)
+const safeTransaction =  await safeSdk.createTransaction({ safeTransactionData })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const signature = await safeSdk.signTransactionHash(txHash)
 ```
@@ -562,10 +569,10 @@ const signature = await safeSdk.signTransactionHash(txHash)
 Signs a transaction according to the EIP-712 using the current signer account.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction = await safeSdk.createTransaction(transaction)
+const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
 const signature = await safeSdk.signTypedData(safeTransaction)
 ```
 
@@ -574,10 +581,10 @@ const signature = await safeSdk.signTypedData(safeTransaction)
 Returns a new `SafeTransaction` object that includes the signature of the current owner. `eth_sign` will be used by default to generate the signature.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction = await safeSdk.createTransaction(transaction)
+const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
 const signedSafeTransaction = await safeSdk.signTransaction(safeTransaction)
 ```
 
@@ -596,10 +603,10 @@ const signedSafeTransaction = await safeSdk.signTransaction(safeTransaction, 'et
 Approves a hash on-chain using the current owner account.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction =  await safeSdk.createTransaction(transaction)
+const safeTransaction =  await safeSdk.createTransaction({ safeTransactionData })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const txResponse = await safeSdk.approveTransactionHash(txHash)
 await txResponse.transactionResponse?.wait()
@@ -636,10 +643,10 @@ const txResponse = await safeSdk.approveTransactionHash(txHash, options)
 Returns a list of owners who have approved a specific Safe transaction.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction =  await safeSdk.createTransaction(transaction)
+const safeTransaction =  await safeSdk.createTransaction({ safeTransactionData })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const owners = await safeSdk.getOwnersWhoApprovedTx(txHash)
 ```
@@ -770,10 +777,10 @@ const safeTransaction = await safeSdk.getChangeThresholdTx(newThreshold, options
 Executes a Safe transaction.
 
 ```js
-const transaction: SafeTransactionDataPartial = {
+const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
-const safeTransaction =  await safeSdk.createTransaction(transaction)
+const safeTransaction =  await safeSdk.createTransaction({ safeTransactionData })
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```

--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -508,7 +508,7 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Sa
   const safeTransaction = await safeSdk.createTransaction({ safeTransactionData, options })
   ```
 
-  In addition, the optional `callsOnly` parameter, that is false by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
+  In addition, the optional `callsOnly` parameter, which is `false` by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
 
   ```js
   const callsOnly = true

--- a/packages/safe-core-sdk/contracts/Deps_V1_3_0.sol
+++ b/packages/safe-core-sdk/contracts/Deps_V1_3_0.sol
@@ -4,7 +4,9 @@ pragma solidity >=0.7.0 <0.9.0;
 import { GnosisSafeProxyFactory } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/proxies/GnosisSafeProxyFactory.sol";
 import { GnosisSafe } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/GnosisSafe.sol";
 import { MultiSend } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/libraries/MultiSend.sol";
+import { MultiSendCallOnly } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/libraries/MultiSendCallOnly.sol";
 
 contract ProxyFactory_SV1_3_0 is GnosisSafeProxyFactory {}
 contract GnosisSafe_SV1_3_0 is GnosisSafe {}
 contract MultiSend_SV1_3_0 is MultiSend {}
+contract MultiSendCallOnly_SV1_3_0 is MultiSendCallOnly {}

--- a/packages/safe-core-sdk/hardhat/deploy/deploy-contracts.ts
+++ b/packages/safe-core-sdk/hardhat/deploy/deploy-contracts.ts
@@ -24,8 +24,8 @@ const multiSendContracts = {
 
 const multiSendCallOnlyContracts = {
   '1.3.0': { name: 'MultiSendCallOnly_SV1_3_0' },
-  '1.2.0': { name: 'MultiSendCallOnly_SV1_2_0' },
-  '1.1.1': { name: 'MultiSendCallOnly_SV1_1_1' }
+  '1.2.0': { name: 'MultiSendCallOnly_SV1_3_0' },
+  '1.1.1': { name: 'MultiSendCallOnly_SV1_3_0' }
 }
 
 export const gnosisSafeDeployed = gnosisSafeContracts[safeVersionDeployed]

--- a/packages/safe-core-sdk/hardhat/deploy/deploy-contracts.ts
+++ b/packages/safe-core-sdk/hardhat/deploy/deploy-contracts.ts
@@ -22,9 +22,16 @@ const multiSendContracts = {
   '1.1.1': { name: 'MultiSend_SV1_1_1' }
 }
 
+const multiSendCallOnlyContracts = {
+  '1.3.0': { name: 'MultiSendCallOnly_SV1_3_0' },
+  '1.2.0': { name: 'MultiSendCallOnly_SV1_2_0' },
+  '1.1.1': { name: 'MultiSendCallOnly_SV1_1_1' }
+}
+
 export const gnosisSafeDeployed = gnosisSafeContracts[safeVersionDeployed]
 export const proxyFactoryDeployed = proxyFactoryContracts[safeVersionDeployed]
 export const multiSendDeployed = multiSendContracts[safeVersionDeployed]
+export const multiSendCallOnlyDeployed = multiSendCallOnlyContracts[safeVersionDeployed]
 
 const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment): Promise<void> => {
   const { deployments, getNamedAccounts } = hre
@@ -46,6 +53,13 @@ const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment): Promise<v
   })
 
   await deploy(multiSendDeployed.name, {
+    from: deployer,
+    args: [],
+    log: true,
+    deterministicDeployment: true
+  })
+
+  await deploy(multiSendCallOnlyDeployed.name, {
     from: deployer,
     args: [],
     log: true,

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -52,8 +52,11 @@ export interface ConnectSafeConfig {
 }
 
 export interface CreateTransactionProps {
+  /** safeTransactionData - The transaction or transaction array to process */
   safeTransactionData: SafeTransactionDataPartial | MetaTransactionData[]
+  /** options - The transaction array optional properties */
   options?: SafeTransactionOptionalProps
+  /** onlyCalls - Forces the execution of the transaction array with MultiSendCallOnly contract */
   onlyCalls?: boolean
 }
 
@@ -278,7 +281,7 @@ class Safe {
   /**
    * Returns a Safe transaction ready to be signed by the owners.
    *
-   * @param safeTransactions - The list of transactions to process
+   * @param createTransactionProps - The createTransaction props
    * @returns The Safe transaction
    * @throws "Invalid empty array of transactions"
    */

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -51,6 +51,12 @@ export interface ConnectSafeConfig {
   contractNetworks?: ContractNetworksConfig
 }
 
+export interface CreateTransactionProps {
+  safeTransactionData: SafeTransactionDataPartial | MetaTransactionData[]
+  options?: SafeTransactionOptionalProps
+  onlyCalls?: boolean
+}
+
 export interface AddOwnerTxParams {
   /** ownerAddress - The address of the new owner */
   ownerAddress: string
@@ -84,6 +90,7 @@ class Safe {
    * @returns The Safe Core SDK instance
    * @throws "Safe Proxy contract is not deployed on the current network"
    * @throws "MultiSend contract is not deployed on the current network"
+   * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
   static async create({
     ethAdapter,
@@ -177,6 +184,15 @@ class Safe {
   }
 
   /**
+   * Returns the address of the MultiSendCallOnly contract.
+   *
+   * @returns The address of the MultiSendCallOnly contract
+   */
+  getMultiSendCallOnlyAddress(): string {
+    return this.#contractManager.multiSendCallOnlyContract.getAddress()
+  }
+
+  /**
    * Returns the Safe Master Copy contract version.
    *
    * @returns The Safe Master Copy contract version
@@ -266,35 +282,34 @@ class Safe {
    * @returns The Safe transaction
    * @throws "Invalid empty array of transactions"
    */
-  async createTransaction(safeTransactions: SafeTransactionDataPartial): Promise<SafeTransaction>
-  async createTransaction(
-    safeTransactions: MetaTransactionData[],
-    options?: SafeTransactionOptionalProps
-  ): Promise<SafeTransaction>
-  async createTransaction(
-    safeTransactions: SafeTransactionDataPartial | MetaTransactionData[],
-    options?: SafeTransactionOptionalProps
-  ): Promise<SafeTransaction> {
-    if (isMetaTransactionArray(safeTransactions) && safeTransactions.length === 0) {
+  async createTransaction({
+    safeTransactionData,
+    onlyCalls = false,
+    options
+  }: CreateTransactionProps): Promise<SafeTransaction> {
+    if (isMetaTransactionArray(safeTransactionData) && safeTransactionData.length === 0) {
       throw new Error('Invalid empty array of transactions')
     }
     let newTransaction: SafeTransactionDataPartial
-    if (isMetaTransactionArray(safeTransactions) && safeTransactions.length > 1) {
+    if (isMetaTransactionArray(safeTransactionData) && safeTransactionData.length > 1) {
+      const multiSendContract = onlyCalls
+        ? this.#contractManager.multiSendCallOnlyContract
+        : this.#contractManager.multiSendContract
       const multiSendData = encodeMultiSendData(
-        safeTransactions.map(standardizeMetaTransactionData)
+        safeTransactionData.map(standardizeMetaTransactionData)
       )
       const multiSendTransaction = {
         ...options,
-        to: this.#contractManager.multiSendContract.getAddress(),
+        to: multiSendContract.getAddress(),
         value: '0',
-        data: this.#contractManager.multiSendContract.encode('multiSend', [multiSendData]),
+        data: multiSendContract.encode('multiSend', [multiSendData]),
         operation: OperationType.DelegateCall
       }
       newTransaction = multiSendTransaction
     } else {
-      newTransaction = isMetaTransactionArray(safeTransactions)
-        ? { ...options, ...safeTransactions[0] }
-        : safeTransactions
+      newTransaction = isMetaTransactionArray(safeTransactionData)
+        ? { ...options, ...safeTransactionData[0] }
+        : safeTransactionData
     }
     const standardizedTransaction = await standardizeSafeTransactionData(
       this.#contractManager.safeContract,
@@ -311,13 +326,14 @@ class Safe {
    * @returns The Safe transaction that invalidates the pending Safe transaction/s
    */
   async createRejectionTransaction(nonce: number): Promise<SafeTransaction> {
-    return this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       nonce,
       value: '0',
       data: '0x',
       safeTxGas: 0
-    })
+    }
+    return this.createTransaction({ safeTransactionData })
   }
 
   /**
@@ -389,7 +405,9 @@ class Safe {
       const txHash = await this.getTransactionHash(safeTransaction)
       signature = await this.signTransactionHash(txHash)
     }
-    const signedSafeTransaction = await this.createTransaction(safeTransaction.data)
+    const signedSafeTransaction = await this.createTransaction({
+      safeTransactionData: safeTransaction.data
+    })
     safeTransaction.signatures.forEach((signature) => {
       signedSafeTransaction.addSignature(signature)
     })
@@ -465,12 +483,13 @@ class Safe {
     moduleAddress: string,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
-    const safeTransaction = await this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       value: '0',
       data: await this.#moduleManager.encodeEnableModuleData(moduleAddress),
       ...options
-    })
+    }
+    const safeTransaction = await this.createTransaction({ safeTransactionData })
     return safeTransaction
   }
 
@@ -487,12 +506,13 @@ class Safe {
     moduleAddress: string,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
-    const safeTransaction = await this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       value: '0',
       data: await this.#moduleManager.encodeDisableModuleData(moduleAddress),
       ...options
-    })
+    }
+    const safeTransaction = await this.createTransaction({ safeTransactionData })
     return safeTransaction
   }
 
@@ -511,12 +531,13 @@ class Safe {
     { ownerAddress, threshold }: AddOwnerTxParams,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
-    const safeTransaction = await this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       value: '0',
       data: await this.#ownerManager.encodeAddOwnerWithThresholdData(ownerAddress, threshold),
       ...options
-    })
+    }
+    const safeTransaction = await this.createTransaction({ safeTransactionData })
     return safeTransaction
   }
 
@@ -535,12 +556,13 @@ class Safe {
     { ownerAddress, threshold }: RemoveOwnerTxParams,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
-    const safeTransaction = await this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       value: '0',
       data: await this.#ownerManager.encodeRemoveOwnerData(ownerAddress, threshold),
       ...options
-    })
+    }
+    const safeTransaction = await this.createTransaction({ safeTransactionData })
     return safeTransaction
   }
 
@@ -559,12 +581,13 @@ class Safe {
     { oldOwnerAddress, newOwnerAddress }: SwapOwnerTxParams,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
-    const safeTransaction = await this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       value: '0',
       data: await this.#ownerManager.encodeSwapOwnerData(oldOwnerAddress, newOwnerAddress),
       ...options
-    })
+    }
+    const safeTransaction = await this.createTransaction({ safeTransactionData })
     return safeTransaction
   }
 
@@ -581,12 +604,13 @@ class Safe {
     threshold: number,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
-    const safeTransaction = await this.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       to: this.getAddress(),
       value: '0',
       data: await this.#ownerManager.encodeChangeThresholdData(threshold),
       ...options
-    })
+    }
+    const safeTransaction = await this.createTransaction({ safeTransactionData })
     return safeTransaction
   }
 
@@ -604,7 +628,9 @@ class Safe {
     safeTransaction: SafeTransaction,
     options?: TransactionOptions
   ): Promise<TransactionResult> {
-    const signedSafeTransaction = await this.createTransaction(safeTransaction.data)
+    const signedSafeTransaction = await this.createTransaction({
+      safeTransactionData: safeTransaction.data
+    })
     safeTransaction.signatures.forEach((signature) => {
       signedSafeTransaction.addSignature(signature)
     })
@@ -641,10 +667,13 @@ class Safe {
     if (options?.gas && options?.gasLimit) {
       throw new Error('Cannot specify gas and gasLimit together in transaction options')
     }
-    const txResponse = await this.#contractManager.safeContract.execTransaction(signedSafeTransaction, {
-      from: signerAddress,
-      ...options
-    })
+    const txResponse = await this.#contractManager.safeContract.execTransaction(
+      signedSafeTransaction,
+      {
+        from: signerAddress,
+        ...options
+      }
+    )
     return txResponse
   }
 }

--- a/packages/safe-core-sdk/src/contracts/config.ts
+++ b/packages/safe-core-sdk/src/contracts/config.ts
@@ -9,7 +9,7 @@ type SafeDeploymentsVersions = {
     safeMasterCopyL2Version: string | undefined
     safeProxyFactoryVersion: string
     multiSendVersion: string
-    multiSendCallOnlyVersion: string | undefined
+    multiSendCallOnlyVersion: string
   }
 }
 
@@ -26,14 +26,14 @@ export const safeDeploymentsVersions: SafeDeploymentsVersions = {
     safeMasterCopyL2Version: undefined,
     safeProxyFactoryVersion: '1.1.1',
     multiSendVersion: '1.1.1',
-    multiSendCallOnlyVersion: undefined
+    multiSendCallOnlyVersion: '1.3.0'
   },
   '1.1.1': {
     safeMasterCopyVersion: '1.1.1',
     safeMasterCopyL2Version: undefined,
     safeProxyFactoryVersion: '1.1.1',
     multiSendVersion: '1.1.1',
-    multiSendCallOnlyVersion: undefined
+    multiSendCallOnlyVersion: '1.3.0'
   }
 }
 

--- a/packages/safe-core-sdk/src/contracts/config.ts
+++ b/packages/safe-core-sdk/src/contracts/config.ts
@@ -9,6 +9,7 @@ type SafeDeploymentsVersions = {
     safeMasterCopyL2Version: string | undefined
     safeProxyFactoryVersion: string
     multiSendVersion: string
+    multiSendCallOnlyVersion: string | undefined
   }
 }
 
@@ -17,19 +18,22 @@ export const safeDeploymentsVersions: SafeDeploymentsVersions = {
     safeMasterCopyVersion: '1.3.0',
     safeMasterCopyL2Version: '1.3.0',
     safeProxyFactoryVersion: '1.3.0',
-    multiSendVersion: '1.3.0'
+    multiSendVersion: '1.3.0',
+    multiSendCallOnlyVersion: '1.3.0'
   },
   '1.2.0': {
     safeMasterCopyVersion: '1.2.0',
     safeMasterCopyL2Version: undefined,
     safeProxyFactoryVersion: '1.1.1',
-    multiSendVersion: '1.1.1'
+    multiSendVersion: '1.1.1',
+    multiSendCallOnlyVersion: undefined
   },
   '1.1.1': {
     safeMasterCopyVersion: '1.1.1',
     safeMasterCopyL2Version: undefined,
     safeProxyFactoryVersion: '1.1.1',
-    multiSendVersion: '1.1.1'
+    multiSendVersion: '1.1.1',
+    multiSendCallOnlyVersion: undefined
   }
 }
 

--- a/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
+++ b/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
@@ -148,7 +148,9 @@ export async function getMultiSendCallOnlyContract({
     customContractAddress: customContracts?.multiSendAddress,
     customContractAbi: customContracts?.multiSendAbi
   })
-  const isContractDeployed = await ethAdapter.isContractDeployed(multiSendCallOnlyContract.getAddress())
+  const isContractDeployed = await ethAdapter.isContractDeployed(
+    multiSendCallOnlyContract.getAddress()
+  )
   if (!isContractDeployed) {
     throw new Error('MultiSendCallOnly contract is not deployed on the current network')
   }

--- a/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
+++ b/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
@@ -2,11 +2,13 @@ import {
   EthAdapter,
   GnosisSafeContract,
   GnosisSafeProxyFactoryContract,
+  MultiSendCallOnlyContract,
   MultiSendContract,
   SafeVersion
 } from '@gnosis.pm/safe-core-sdk-types'
 import {
   DeploymentFilter,
+  getMultiSendCallOnlyDeployment,
   getMultiSendDeployment,
   getProxyFactoryDeployment,
   getSafeL2SingletonDeployment,
@@ -39,6 +41,14 @@ export function getSafeContractDeployment(
     return getSafeSingletonDeployment(filters)
   }
   return getSafeL2SingletonDeployment(filters)
+}
+
+export function getMultiSendCallOnlyContractDeployment(
+  safeVersion: SafeVersion,
+  chainId: number
+): SingletonDeployment | undefined {
+  const version = safeDeploymentsVersions[safeVersion].multiSendCallOnlyVersion
+  return getMultiSendCallOnlyDeployment({ version, network: chainId.toString(), released: true })
 }
 
 export function getMultiSendContractDeployment(
@@ -122,4 +132,25 @@ export async function getMultiSendContract({
     throw new Error('Multi Send contract is not deployed on the current network')
   }
   return multiSendContract
+}
+
+export async function getMultiSendCallOnlyContract({
+  ethAdapter,
+  safeVersion,
+  chainId,
+  customContracts
+}: GetContractInstanceProps): Promise<MultiSendCallOnlyContract> {
+  const multiSendCallOnlyDeployment = getMultiSendCallOnlyContractDeployment(safeVersion, chainId)
+  const multiSendCallOnlyContract = await ethAdapter.getMultiSendCallOnlyContract({
+    safeVersion,
+    chainId,
+    singletonDeployment: multiSendCallOnlyDeployment,
+    customContractAddress: customContracts?.multiSendAddress,
+    customContractAbi: customContracts?.multiSendAbi
+  })
+  const isContractDeployed = await ethAdapter.isContractDeployed(multiSendCallOnlyContract.getAddress())
+  if (!isContractDeployed) {
+    throw new Error('MultiSendCallOnly contract is not deployed on the current network')
+  }
+  return multiSendCallOnlyContract
 }

--- a/packages/safe-core-sdk/src/index.ts
+++ b/packages/safe-core-sdk/src/index.ts
@@ -2,6 +2,7 @@ import ContractManager from './managers/contractManager'
 import Safe, {
   AddOwnerTxParams,
   ConnectSafeConfig,
+  CreateTransactionProps,
   RemoveOwnerTxParams,
   SafeConfig,
   SwapOwnerTxParams
@@ -31,6 +32,7 @@ export {
   ConnectSafeConfig,
   ContractNetworksConfig,
   SafeTransactionOptionalProps,
+  CreateTransactionProps,
   AddOwnerTxParams,
   RemoveOwnerTxParams,
   SwapOwnerTxParams,

--- a/packages/safe-core-sdk/src/managers/contractManager.ts
+++ b/packages/safe-core-sdk/src/managers/contractManager.ts
@@ -1,6 +1,14 @@
-import { GnosisSafeContract, MultiSendContract } from '@gnosis.pm/safe-core-sdk-types'
+import {
+  GnosisSafeContract,
+  MultiSendCallOnlyContract,
+  MultiSendContract
+} from '@gnosis.pm/safe-core-sdk-types'
 import { SAFE_LAST_VERSION } from '../contracts/config'
-import { getMultiSendContract, getSafeContract } from '../contracts/safeDeploymentContracts'
+import {
+  getMultiSendCallOnlyContract,
+  getMultiSendContract,
+  getSafeContract
+} from '../contracts/safeDeploymentContracts'
 import { SafeConfig } from '../Safe'
 import { ContractNetworksConfig } from '../types'
 
@@ -9,6 +17,7 @@ class ContractManager {
   #isL1SafeMasterCopy?: boolean
   #safeContract!: GnosisSafeContract
   #multiSendContract!: MultiSendContract
+  #multiSendCallOnlyContract!: MultiSendCallOnlyContract
 
   static async create({
     ethAdapter,
@@ -55,6 +64,12 @@ class ContractManager {
       chainId,
       customContracts
     })
+    this.#multiSendCallOnlyContract = await getMultiSendCallOnlyContract({
+      ethAdapter,
+      safeVersion,
+      chainId,
+      customContracts
+    })
   }
 
   get contractNetworks(): ContractNetworksConfig | undefined {
@@ -71,6 +86,10 @@ class ContractManager {
 
   get multiSendContract(): MultiSendContract {
     return this.#multiSendContract
+  }
+
+  get multiSendCallOnlyContract(): MultiSendCallOnlyContract {
+    return this.#multiSendCallOnlyContract
   }
 }
 

--- a/packages/safe-core-sdk/src/types/index.ts
+++ b/packages/safe-core-sdk/src/types/index.ts
@@ -5,6 +5,10 @@ export interface ContractNetworkConfig {
   multiSendAddress: string
   /** multiSendAbi - Abi of the MultiSend contract deployed on a specific network */
   multiSendAbi?: AbiItem | AbiItem[]
+  /** multiSendCallOnlyAddress - Address of the MultiSendCallOnly contract deployed on a specific network */
+  multiSendCallOnlyAddress: string
+  /** multiSendCallOnlyAbi - Abi of the MultiSendCallOnly contract deployed on a specific network */
+  multiSendCallOnlyAbi?: AbiItem | AbiItem[]
   /** safeMasterCopyAddress - Address of the Gnosis Safe Master Copy contract deployed on a specific network */
   safeMasterCopyAddress: string
   /** safeMasterCopyAbi - Abi of the Gnosis Safe Master Copy contract deployed on a specific network */

--- a/packages/safe-core-sdk/tests/contractManager.test.ts
+++ b/packages/safe-core-sdk/tests/contractManager.test.ts
@@ -7,6 +7,7 @@ import { getContractNetworks } from './utils/setupContractNetworks'
 import {
   getFactory,
   getMultiSend,
+  getMultiSendCallOnly,
   getSafeSingleton,
   getSafeWithOwners
 } from './utils/setupContracts'
@@ -69,6 +70,8 @@ describe('Safe contracts manager', () => {
         [chainId]: {
           multiSendAddress: ZERO_ADDRESS,
           multiSendAbi: (await getMultiSend()).abi,
+          multiSendCallOnlyAddress: ZERO_ADDRESS,
+          multiSendCallOnlyAbi: (await getMultiSendCallOnly()).abi,
           safeMasterCopyAddress: ZERO_ADDRESS,
           safeMasterCopyAbi: (await getSafeSingleton()).abi,
           safeProxyFactoryAddress: ZERO_ADDRESS,

--- a/packages/safe-core-sdk/tests/core.test.ts
+++ b/packages/safe-core-sdk/tests/core.test.ts
@@ -115,12 +115,12 @@ describe('Safe Info', () => {
         contractNetworks
       })
       chai.expect(await safeSdk.getNonce()).to.be.eq(0)
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction(txDataPartial)
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       chai.expect(await safeSdk.getNonce()).to.be.eq(1)

--- a/packages/safe-core-sdk/tests/createTransaction.test.ts
+++ b/packages/safe-core-sdk/tests/createTransaction.test.ts
@@ -176,7 +176,7 @@ describe('Transactions creation', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x',
@@ -187,7 +187,7 @@ describe('Transactions creation', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.createTransaction(txDataPartial)
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -209,7 +209,7 @@ describe('Transactions creation', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x',
@@ -220,7 +220,7 @@ describe('Transactions creation', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.createTransaction(txDataPartial)
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -242,14 +242,14 @@ describe('Transactions creation', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const metaTransactions: MetaTransactionData[] = [
+      const safeTransactionData: MetaTransactionData[] = [
         {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
       ]
-      const tx = await safeSdk.createTransaction(metaTransactions)
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -265,7 +265,7 @@ describe('Transactions creation', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const metaTransactions: MetaTransactionData[] = [
+      const safeTransactionData: MetaTransactionData[] = [
         {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
@@ -280,7 +280,7 @@ describe('Transactions creation', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.createTransaction(metaTransactions, options)
+      const tx = await safeSdk.createTransaction({ safeTransactionData, options })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -302,8 +302,8 @@ describe('Transactions creation', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const txs: MetaTransactionData[] = []
-      const tx = safeSdk.createTransaction(txs)
+      const safeTransactionData: MetaTransactionData[] = []
+      const tx = safeSdk.createTransaction({ safeTransactionData })
       await chai.expect(tx).to.be.rejectedWith('Invalid empty array of transactions')
     })
 
@@ -317,7 +317,7 @@ describe('Transactions creation', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const txs: MetaTransactionData[] = [
+      const safeTransactionData: MetaTransactionData[] = [
         {
           to: erc20Mintable.address,
           value: '0',
@@ -335,7 +335,7 @@ describe('Transactions creation', () => {
           ])
         }
       ]
-      const multiSendTx = await safeSdk.createTransaction(txs)
+      const multiSendTx = await safeSdk.createTransaction({ safeTransactionData })
       chai.expect(multiSendTx.data.to).to.be.eq(contractNetworks[chainId].multiSendAddress)
     })
 
@@ -357,7 +357,7 @@ describe('Transactions creation', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const txs: MetaTransactionData[] = [
+      const safeTransactionData: MetaTransactionData[] = [
         {
           to: erc20Mintable.address,
           value: '0',
@@ -375,7 +375,7 @@ describe('Transactions creation', () => {
           ])
         }
       ]
-      const multiSendTx = await safeSdk.createTransaction(txs, options)
+      const multiSendTx = await safeSdk.createTransaction({ safeTransactionData, options })
       chai.expect(multiSendTx.data.to).to.be.eq(contractNetworks[chainId].multiSendAddress)
       chai.expect(multiSendTx.data.value).to.be.eq('0')
       chai.expect(multiSendTx.data.baseGas).to.be.eq(111)

--- a/packages/safe-core-sdk/tests/ethAdapters.test.ts
+++ b/packages/safe-core-sdk/tests/ethAdapters.test.ts
@@ -3,12 +3,13 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments, waffle } from 'hardhat'
 import {
+  getMultiSendCallOnlyContractDeployment,
   getMultiSendContractDeployment,
   getSafeContractDeployment,
   getSafeProxyFactoryContractDeployment
 } from '../src/contracts/safeDeploymentContracts'
 import { getContractNetworks } from './utils/setupContractNetworks'
-import { getFactory, getMultiSend, getSafeSingleton } from './utils/setupContracts'
+import { getFactory, getMultiSend, getMultiSendCallOnly, getSafeSingleton } from './utils/setupContracts'
 import { getEthAdapter } from './utils/setupEthAdapter'
 import { getAccounts } from './utils/setupTestNetwork'
 
@@ -135,6 +136,42 @@ describe('Safe contracts', () => {
       chai
         .expect(await multiSendContract.getAddress())
         .to.be.eq((await getMultiSend()).contract.address)
+    })
+  })
+
+  describe('getMultiSendCallOnlyContract', async () => {
+    it('should return a MultiSendCallOnly contract from safe-deployments', async () => {
+      const { accounts } = await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeVersion: SafeVersion = '1.3.0'
+      const chainId = 1
+      const singletonDeployment = getMultiSendCallOnlyContractDeployment(safeVersion, chainId)
+      const multiSendCallOnlyContract = await ethAdapter.getMultiSendCallOnlyContract({
+        safeVersion,
+        chainId,
+        singletonDeployment
+      })
+      chai
+        .expect(await multiSendCallOnlyContract.getAddress())
+        .to.be.eq('0x40A2aCCbd92BCA938b02010E17A5b8929b49130D')
+    })
+
+    it('should return a MultiSendCallOnly contract from the custom addresses', async () => {
+      const { accounts, contractNetworks, chainId } = await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeVersion: SafeVersion = '1.3.0'
+      const customContract = contractNetworks[chainId]
+      const multiSendCallOnlyContract = await ethAdapter.getMultiSendCallOnlyContract({
+        safeVersion,
+        chainId,
+        customContractAddress: customContract.multiSendCallOnlyAddress,
+        customContractAbi: customContract.multiSendCallOnlyAbi
+      })
+      chai
+        .expect(await multiSendCallOnlyContract.getAddress())
+        .to.be.eq((await getMultiSendCallOnly()).contract.address)
     })
   })
 

--- a/packages/safe-core-sdk/tests/execution.test.ts
+++ b/packages/safe-core-sdk/tests/execution.test.ts
@@ -47,12 +47,12 @@ describe('Transactions execution', () => {
       })
       const safeInitialBalance = await safeSdk1.getBalance()
       chai.expect(safeInitialBalance.toString()).to.be.eq('0')
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       await chai
         .expect(safeSdk1.executeTransaction(tx))
         .to.be.rejectedWith('Not enough Ether funds')
@@ -70,12 +70,12 @@ describe('Transactions execution', () => {
       })
       const ethAdapter2 = await getEthAdapter(account2.signer)
       const safeSdk2 = await safeSdk1.connect({ ethAdapter: ethAdapter2 })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const signedTx = await safeSdk1.signTransaction(tx)
       const txHash = await safeSdk2.getTransactionHash(tx)
       const txResponse = await safeSdk2.approveTransactionHash(txHash)
@@ -95,12 +95,12 @@ describe('Transactions execution', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       await chai
         .expect(safeSdk1.executeTransaction(tx))
         .to.be.rejectedWith('There are 2 signatures missing')
@@ -125,12 +125,12 @@ describe('Transactions execution', () => {
         to: safe.address,
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const rejectTx = await safeSdk1.createRejectionTransaction(tx.data.nonce)
       const signedRejectTx = await safeSdk1.signTransaction(rejectTx)
       const txRejectResponse = await safeSdk2.executeTransaction(signedRejectTx)
@@ -155,12 +155,12 @@ describe('Transactions execution', () => {
         to: safe.address,
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const options: TransactionOptions = { gas: 123456, gasLimit: 123456 }
       await chai
         .expect(safeSdk1.executeTransaction(tx, options))
@@ -181,12 +181,12 @@ describe('Transactions execution', () => {
         to: safe.address,
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const execOptions: EthersTransactionOptions = { nonce: 123456789 }
       await chai
         .expect(safeSdk1.executeTransaction(tx, execOptions))
@@ -208,12 +208,12 @@ describe('Transactions execution', () => {
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const initNumSignatures = tx.signatures.size
       const txResponse = await safeSdk1.executeTransaction(tx)
       const finalNumSignatures = tx.signatures.size
@@ -244,12 +244,12 @@ describe('Transactions execution', () => {
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const signedTx = await safeSdk1.signTransaction(tx)
       const txHash = await safeSdk2.getTransactionHash(tx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)
@@ -280,12 +280,12 @@ describe('Transactions execution', () => {
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const signedTx = await safeSdk1.signTransaction(tx)
       const txHash = await safeSdk2.getTransactionHash(tx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)
@@ -314,12 +314,12 @@ describe('Transactions execution', () => {
           to: safe.address,
           value: BigNumber.from('1000000000000000000') // 1 ETH
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const safeTransactionData: SafeTransactionDataPartial = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction(txDataPartial)
+        const tx = await safeSdk1.createTransaction({ safeTransactionData })
         const execOptions: EthersTransactionOptions = { gasLimit: 123456 }
         const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
         await waitSafeTxReceipt(txResponse)
@@ -344,12 +344,12 @@ describe('Transactions execution', () => {
           to: safe.address,
           value: BigNumber.from('1000000000000000000') // 1 ETH
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const safeTransactionData: SafeTransactionDataPartial = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction(txDataPartial)
+        const tx = await safeSdk1.createTransaction({ safeTransactionData })
         const execOptions: EthersTransactionOptions = {
           gasLimit: 123456,
           gasPrice: 170000000
@@ -378,12 +378,12 @@ describe('Transactions execution', () => {
           to: safe.address,
           value: BigNumber.from('1000000000000000000') // 1 ETH
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const safeTransactionData: SafeTransactionDataPartial = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction(txDataPartial)
+        const tx = await safeSdk1.createTransaction({ safeTransactionData })
         const execOptions: EthersTransactionOptions = {
           maxFeePerGas: 200000000, //higher than hardhat's block baseFeePerGas
           maxPriorityFeePerGas: 1
@@ -416,12 +416,12 @@ describe('Transactions execution', () => {
           to: safe.address,
           value: BigNumber.from('1000000000000000000') // 1 ETH
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const safeTransactionData: SafeTransactionDataPartial = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction(txDataPartial)
+        const tx = await safeSdk1.createTransaction({ safeTransactionData })
         const execOptions: Web3TransactionOptions = { gas: 123456 }
         const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
         await waitSafeTxReceipt(txResponse)
@@ -446,12 +446,12 @@ describe('Transactions execution', () => {
           to: safe.address,
           value: BigNumber.from('1000000000000000000') // 1 ETH
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const safeTransactionData: SafeTransactionDataPartial = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction(txDataPartial)
+        const tx = await safeSdk1.createTransaction({ safeTransactionData })
         const execOptions: Web3TransactionOptions = {
           gas: 123456,
           gasPrice: 170000000
@@ -480,12 +480,12 @@ describe('Transactions execution', () => {
           to: safe.address,
           value: BigNumber.from('1000000000000000000') // 1 ETH
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const safeTransactionData: SafeTransactionDataPartial = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction(txDataPartial)
+        const tx = await safeSdk1.createTransaction({ safeTransactionData })
         const execOptions: Web3TransactionOptions = {
           maxFeePerGas: 200000000, //higher than hardhat's block baseFeePerGas
           maxPriorityFeePerGas: 1
@@ -516,13 +516,13 @@ describe('Transactions execution', () => {
         to: safe.address,
         value: BigNumber.from('1000000000000000000') // 1 ETH
       })
-      const txDataPartial: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
       const currentNonce = await ethAdapter.getNonce(account1.address, 'pending')
-      const tx = await safeSdk1.createTransaction(txDataPartial)
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const execOptions: EthersTransactionOptions = { nonce: currentNonce }
       const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
       await waitSafeTxReceipt(txResponse)
@@ -551,7 +551,7 @@ describe('Transactions execution', () => {
         value: BigNumber.from('2000000000000000000') // 2 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const txs: MetaTransactionData[] = [
+      const safeTransactionData: MetaTransactionData[] = [
         {
           to: account2.address,
           value: '1100000000000000000', // 1.1 ETH
@@ -563,7 +563,7 @@ describe('Transactions execution', () => {
           data: '0x'
         }
       ]
-      const multiSendTx = await safeSdk1.createTransaction(txs)
+      const multiSendTx = await safeSdk1.createTransaction({ safeTransactionData })
       const signedMultiSendTx = await safeSdk1.signTransaction(multiSendTx)
       const txHash = await safeSdk2.getTransactionHash(multiSendTx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)
@@ -575,8 +575,8 @@ describe('Transactions execution', () => {
         .expect(safeInitialBalance.toString())
         .to.be.eq(
           safeFinalBalance
-            .add(BigNumber.from(txs[0].value))
-            .add(BigNumber.from(txs[1].value))
+            .add(BigNumber.from(safeTransactionData[0].value))
+            .add(BigNumber.from(safeTransactionData[1].value))
             .toString()
         )
     })
@@ -602,7 +602,7 @@ describe('Transactions execution', () => {
       const accountInitialERC20Balance = await erc20Mintable.balanceOf(account2.address)
       chai.expect(accountInitialERC20Balance.toString()).to.be.eq('0') // 0 ERC20
 
-      const txs: MetaTransactionData[] = [
+      const safeTransactionData: MetaTransactionData[] = [
         {
           to: erc20Mintable.address,
           value: '0',
@@ -620,7 +620,7 @@ describe('Transactions execution', () => {
           ])
         }
       ]
-      const multiSendTx = await safeSdk1.createTransaction(txs)
+      const multiSendTx = await safeSdk1.createTransaction({ safeTransactionData })
       const signedMultiSendTx = await safeSdk1.signTransaction(multiSendTx)
       const txHash = await safeSdk2.getTransactionHash(multiSendTx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)

--- a/packages/safe-core-sdk/tests/offChainSignatures.test.ts
+++ b/packages/safe-core-sdk/tests/offChainSignatures.test.ts
@@ -1,3 +1,4 @@
+import { SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments, waffle } from 'hardhat'
@@ -32,11 +33,12 @@ describe('Off-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
-      })
+      }
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       const txHash = await safeSdk.getTransactionHash(tx)
       const signature = await safeSdk.signTransactionHash(txHash)
       chai.expect(signature.staticPart().length).to.be.eq(132)
@@ -53,11 +55,12 @@ describe('Off-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
-        data: '0x'
-      })
+        data: '0x'  
+      }
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       await chai
         .expect(safeSdk.signTransaction(tx))
         .to.be.rejectedWith('Transactions can only be signed by Safe owners')
@@ -72,11 +75,12 @@ describe('Off-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
-        data: '0x'
-      })
+        data: '0x'  
+      }
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       chai.expect(tx.signatures.size).to.be.eq(0)
       const signedTx = await safeSdk.signTransaction(tx)
       // TO-DO: Uncomment in v3.0.0 {
@@ -94,11 +98,12 @@ describe('Off-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
-        data: '0x'
-      })
+        data: '0x'  
+      }
+      const tx = await safeSdk.createTransaction({ safeTransactionData })
       chai.expect(tx.signatures.size).to.be.eq(0)
       const signedTx1 = await safeSdk.signTransaction(tx)
       chai.expect(signedTx1.signatures.size).to.be.eq(1)

--- a/packages/safe-core-sdk/tests/onChainSignatures.test.ts
+++ b/packages/safe-core-sdk/tests/onChainSignatures.test.ts
@@ -1,3 +1,4 @@
+import { SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments, waffle } from 'hardhat'
@@ -33,11 +34,12 @@ describe('On-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk1.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
-      })
+      }
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const hash = await safeSdk1.getTransactionHash(tx)
       await chai
         .expect(safeSdk1.approveTransactionHash(hash))
@@ -53,11 +55,12 @@ describe('On-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk1.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
-      })
+      }
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const txHash = await safeSdk1.getTransactionHash(tx)
       const txResponse = await safeSdk1.approveTransactionHash(txHash)
       await waitSafeTxReceipt(txResponse)
@@ -73,11 +76,12 @@ describe('On-chain signatures', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = await safeSdk1.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
-      })
+      }
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const txHash = await safeSdk1.getTransactionHash(tx)
       chai.expect(await safe.approvedHashes(account1.address, txHash)).to.be.equal(0)
       const txResponse1 = await safeSdk1.approveTransactionHash(txHash)
@@ -101,11 +105,12 @@ describe('On-chain signatures', () => {
       })
       const ethAdapter2 = await getEthAdapter(account2.signer)
       const safeSdk2 = await safeSdk1.connect({ ethAdapter: ethAdapter2 })
-      const tx = await safeSdk1.createTransaction({
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safe.address,
         value: '0',
         data: '0x'
-      })
+      }
+      const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const txHash = await safeSdk1.getTransactionHash(tx)
       const ownersWhoApproved0 = await safeSdk1.getOwnersWhoApprovedTx(txHash)
       chai.expect(ownersWhoApproved0.length).to.be.eq(0)

--- a/packages/safe-core-sdk/tests/safeFactory.test.ts
+++ b/packages/safe-core-sdk/tests/safeFactory.test.ts
@@ -14,7 +14,7 @@ import { SAFE_LAST_VERSION } from '../src/contracts/config'
 import { ZERO_ADDRESS } from '../src/utils/constants'
 import { itif } from './utils/helpers'
 import { getContractNetworks } from './utils/setupContractNetworks'
-import { getFactory, getMultiSend, getSafeSingleton } from './utils/setupContracts'
+import { getFactory, getMultiSend, getMultiSendCallOnly, getSafeSingleton } from './utils/setupContracts'
 import { getEthAdapter } from './utils/setupEthAdapter'
 import { getAccounts } from './utils/setupTestNetwork'
 
@@ -51,6 +51,8 @@ describe('Safe Proxy Factory', () => {
         [chainId]: {
           multiSendAddress: ZERO_ADDRESS,
           multiSendAbi: (await getMultiSend()).abi,
+          multiSendCallOnlyAddress: ZERO_ADDRESS,
+          multiSendCallOnlyAbi: (await getMultiSendCallOnly()).abi,
           safeMasterCopyAddress: ZERO_ADDRESS,
           safeMasterCopyAbi: (await getSafeSingleton()).abi,
           safeProxyFactoryAddress: ZERO_ADDRESS,

--- a/packages/safe-core-sdk/tests/utils/setupContractNetworks.ts
+++ b/packages/safe-core-sdk/tests/utils/setupContractNetworks.ts
@@ -1,11 +1,13 @@
 import { ContractNetworksConfig } from '../../src'
-import { getFactory, getMultiSend, getSafeSingleton } from './setupContracts'
+import { getFactory, getMultiSend, getMultiSendCallOnly, getSafeSingleton } from './setupContracts'
 
 export async function getContractNetworks(chainId: number): Promise<ContractNetworksConfig> {
   return {
     [chainId]: {
       multiSendAddress: (await getMultiSend()).contract.address,
       multiSendAbi: (await getMultiSend()).abi,
+      multiSendCallOnlyAddress: (await getMultiSendCallOnly()).contract.address,
+      multiSendCallOnlyAbi: (await getMultiSendCallOnly()).abi,
       safeMasterCopyAddress: (await getSafeSingleton()).contract.address,
       safeMasterCopyAbi: (await getSafeSingleton()).abi,
       safeProxyFactoryAddress: (await getFactory()).contract.address,

--- a/packages/safe-core-sdk/tests/utils/setupContracts.ts
+++ b/packages/safe-core-sdk/tests/utils/setupContracts.ts
@@ -8,6 +8,7 @@ import { GnosisSafe as GnosisSafe_V1_2_0 } from '@gnosis.pm/safe-ethers-lib/type
 import {
   GnosisSafe as GnosisSafe_V1_3_0,
   MultiSend as MultiSend_V1_3_0,
+  MultiSendCallOnly as MultiSendCallOnly_V1_3_0,
   ProxyFactory as ProxyFactory_V1_3_0
 } from '@gnosis.pm/safe-ethers-lib/typechain/src/ethers-v5/v1.3.0/'
 import {
@@ -19,6 +20,7 @@ import { deployments, ethers } from 'hardhat'
 import { AbiItem } from 'web3-utils'
 import {
   gnosisSafeDeployed,
+  multiSendCallOnlyDeployed,
   multiSendDeployed,
   proxyFactoryDeployed
 } from '../../hardhat/deploy/deploy-contracts'
@@ -90,6 +92,20 @@ export const getMultiSend = async (): Promise<{
   return {
     contract: MultiSend.attach(MultiSendDeployment.address) as MultiSend_V1_3_0 | MultiSend_V1_1_1,
     abi: MultiSendDeployment.abi
+  }
+}
+
+export const getMultiSendCallOnly = async (): Promise<{
+  contract: MultiSendCallOnly_V1_3_0
+  abi: AbiItem | AbiItem[]
+}> => {
+  const MultiSendCallOnlyDeployment = await deployments.get(multiSendCallOnlyDeployed.name)
+  const MultiSendCallOnly = await ethers.getContractFactory(multiSendCallOnlyDeployed.name)
+  return {
+    contract: MultiSendCallOnly.attach(
+      MultiSendCallOnlyDeployment.address
+    ) as MultiSendCallOnly_V1_3_0,
+    abi: MultiSendCallOnlyDeployment.abi
   }
 }
 

--- a/packages/safe-ethers-adapters/src/signer.ts
+++ b/packages/safe-ethers-adapters/src/signer.ts
@@ -8,7 +8,7 @@ import { VoidSigner } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Deferrable } from '@ethersproject/properties'
 import Safe from '@gnosis.pm/safe-core-sdk'
-import { OperationType, SafeTransactionData } from '@gnosis.pm/safe-core-sdk-types'
+import { OperationType, SafeTransactionData, SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
 import { SafeService } from './service'
 import { createLibAddress, createLibInterface, mapReceipt } from './utils'
 
@@ -117,10 +117,11 @@ export class SafeEthersSigner extends VoidSigner {
     }
     const safeTxGas = await this.service.estimateSafeTx(this.address, baseTx)
     const connectedSafe = await this.safe
-    const safeTx = await connectedSafe.createTransaction({
+    const safeTransactionData: SafeTransactionDataPartial = {
       ...baseTx,
       safeTxGas: safeTxGas.toNumber()
-    })
+    }
+    const safeTx = await connectedSafe.createTransaction({ safeTransactionData })
     const safeTxHash = await connectedSafe.getTransactionHash(safeTx)
     const signature = await connectedSafe.signTransactionHash(safeTxHash)
     await this.service.proposeTx(this.address, safeTxHash, safeTx, signature)

--- a/packages/safe-ethers-lib/contracts/Deps_V1_3_0.sol
+++ b/packages/safe-ethers-lib/contracts/Deps_V1_3_0.sol
@@ -4,7 +4,9 @@ pragma solidity >=0.7.0 <0.9.0;
 import { GnosisSafeProxyFactory } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/proxies/GnosisSafeProxyFactory.sol";
 import { GnosisSafe } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/GnosisSafe.sol";
 import { MultiSend } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/libraries/MultiSend.sol";
+import { MultiSendCallOnly } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/libraries/MultiSendCallOnly.sol";
 
 contract ProxyFactory_SV1_3_0 is GnosisSafeProxyFactory {}
 contract GnosisSafe_SV1_3_0 is GnosisSafe {}
 contract MultiSend_SV1_3_0 is MultiSend {}
+contract MultiSendCallOnly_SV1_3_0 is MultiSendCallOnly {}

--- a/packages/safe-ethers-lib/scripts/generateTypechainFiles.ts
+++ b/packages/safe-ethers-lib/scripts/generateTypechainFiles.ts
@@ -18,7 +18,8 @@ const safeContractsPath = '../../node_modules/@gnosis.pm/safe-deployments/dist/a
 const safeContracts_V1_3_0 = [
   `${safeContractsPath}/v1.3.0/gnosis_safe.json`,
   `${safeContractsPath}/v1.3.0/proxy_factory.json`,
-  `${safeContractsPath}/v1.3.0/multi_send.json`
+  `${safeContractsPath}/v1.3.0/multi_send.json`,
+  `${safeContractsPath}/v1.3.0/multi_send_call_only.json`
 ].join(' ')
 const safeContracts_V1_2_0 = [`${safeContractsPath}/v1.2.0/gnosis_safe.json`].join(' ')
 const safeContracts_V1_1_1 = [

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -12,7 +12,9 @@ import {
 import { generateTypedData, validateEip3770Address } from '@gnosis.pm/safe-core-sdk-utils'
 import { ethers } from 'ethers'
 import {
-  getMultiSendCallOnlyContractInstance, getMultiSendContractInstance, getSafeContractInstance,
+  getMultiSendCallOnlyContractInstance,
+  getMultiSendContractInstance,
+  getSafeContractInstance,
   getSafeProxyFactoryContractInstance
 } from './contracts/contractInstancesEthers'
 import GnosisSafeContractEthers from './contracts/GnosisSafe/GnosisSafeContractEthers'

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -12,13 +12,13 @@ import {
 import { generateTypedData, validateEip3770Address } from '@gnosis.pm/safe-core-sdk-utils'
 import { ethers } from 'ethers'
 import {
-  getMultiSendContractInstance,
-  getSafeContractInstance,
+  getMultiSendCallOnlyContractInstance, getMultiSendContractInstance, getSafeContractInstance,
   getSafeProxyFactoryContractInstance
 } from './contracts/contractInstancesEthers'
 import GnosisSafeContractEthers from './contracts/GnosisSafe/GnosisSafeContractEthers'
 import GnosisSafeProxyFactoryEthersContract from './contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryEthersContract'
 import MultiSendEthersContract from './contracts/MultiSend/MultiSendEthersContract'
+import MultiSendCallOnlyEthersContract from './contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract'
 import { isTypedDataSigner } from './utils'
 
 type Ethers = typeof ethers
@@ -108,6 +108,21 @@ class EthersAdapter implements EthAdapter {
       throw new Error('Invalid Multi Send contract address')
     }
     return getMultiSendContractInstance(safeVersion, contractAddress, this.#signer)
+  }
+
+  getMultiSendCallOnlyContract({
+    safeVersion,
+    chainId,
+    singletonDeployment,
+    customContractAddress
+  }: GetContractProps): MultiSendCallOnlyEthersContract {
+    const contractAddress = customContractAddress
+      ? customContractAddress
+      : singletonDeployment?.networkAddresses[chainId]
+    if (!contractAddress) {
+      throw new Error('Invalid MultiSendCallOnly contract address')
+    }
+    return getMultiSendCallOnlyContractInstance(safeVersion, contractAddress, this.#signer)
   }
 
   getSafeProxyFactoryContract({

--- a/packages/safe-ethers-lib/src/contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract.ts
+++ b/packages/safe-ethers-lib/src/contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract.ts
@@ -1,0 +1,19 @@
+import { MultiSendCallOnlyContract } from '@gnosis.pm/safe-core-sdk-types'
+import {
+  MultiSendCallOnly as MultiSendCallOnly_V1_3_0,
+  MultiSendCallOnlyInterface
+} from '../../../typechain/src/ethers-v5/v1.3.0/MultiSendCallOnly'
+
+abstract class MultiSendCallOnlyEthersContract implements MultiSendCallOnlyContract {
+  constructor(public contract: MultiSendCallOnly_V1_3_0) {}
+
+  getAddress(): string {
+    return this.contract.address
+  }
+
+  encode: MultiSendCallOnlyInterface['encodeFunctionData'] = (methodName: any, params: any): string => {
+    return this.contract.interface.encodeFunctionData(methodName, params)
+  }
+}
+
+export default MultiSendCallOnlyEthersContract

--- a/packages/safe-ethers-lib/src/contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract.ts
+++ b/packages/safe-ethers-lib/src/contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract.ts
@@ -11,7 +11,10 @@ abstract class MultiSendCallOnlyEthersContract implements MultiSendCallOnlyContr
     return this.contract.address
   }
 
-  encode: MultiSendCallOnlyInterface['encodeFunctionData'] = (methodName: any, params: any): string => {
+  encode: MultiSendCallOnlyInterface['encodeFunctionData'] = (
+    methodName: any,
+    params: any
+  ): string => {
     return this.contract.interface.encodeFunctionData(methodName, params)
   }
 }

--- a/packages/safe-ethers-lib/src/contracts/MultiSendCallOnly/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Ethers.ts
+++ b/packages/safe-ethers-lib/src/contracts/MultiSendCallOnly/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Ethers.ts
@@ -1,0 +1,10 @@
+import { MultiSendCallOnly } from '../../../../typechain/src/ethers-v5/v1.3.0/MultiSendCallOnly'
+import MultiSendCallOnlyEthersContract from '../MultiSendCallOnlyEthersContract'
+
+class MultiSendCallOnlyContract_V1_3_0_Ethers extends MultiSendCallOnlyEthersContract {
+  constructor(public contract: MultiSendCallOnly) {
+    super(contract)
+  }
+}
+
+export default MultiSendCallOnlyContract_V1_3_0_Ethers

--- a/packages/safe-ethers-lib/src/contracts/contractInstancesEthers.ts
+++ b/packages/safe-ethers-lib/src/contracts/contractInstancesEthers.ts
@@ -68,10 +68,10 @@ export function getMultiSendCallOnlyContractInstance(
   let multiSendCallOnlyContract
   switch (safeVersion) {
     case '1.3.0':
-      multiSendCallOnlyContract = MultiSendCallOnly_V1_3_0.connect(contractAddress, signer)
-      return new MultiSendCallOnlyContract_V1_3_0_Ethers(multiSendCallOnlyContract)
     case '1.2.0':
     case '1.1.1':
+      multiSendCallOnlyContract = MultiSendCallOnly_V1_3_0.connect(contractAddress, signer)
+      return new MultiSendCallOnlyContract_V1_3_0_Ethers(multiSendCallOnlyContract)
     default:
       throw new Error('Invalid Safe version')
   }

--- a/packages/safe-ethers-lib/src/contracts/contractInstancesEthers.ts
+++ b/packages/safe-ethers-lib/src/contracts/contractInstancesEthers.ts
@@ -5,6 +5,7 @@ import { MultiSend__factory as MultiSend_V1_1_1 } from '../../typechain/src/ethe
 import { ProxyFactory__factory as SafeProxyFactory_V1_1_1 } from '../../typechain/src/ethers-v5/v1.1.1/factories/ProxyFactory__factory'
 import { GnosisSafe__factory as SafeMasterCopy_V1_2_0 } from '../../typechain/src/ethers-v5/v1.2.0/factories/GnosisSafe__factory'
 import { GnosisSafe__factory as SafeMasterCopy_V1_3_0 } from '../../typechain/src/ethers-v5/v1.3.0/factories/GnosisSafe__factory'
+import { MultiSendCallOnly__factory as MultiSendCallOnly_V1_3_0 } from '../../typechain/src/ethers-v5/v1.3.0/factories/MultiSendCallOnly__factory'
 import { MultiSend__factory as MultiSend_V1_3_0 } from '../../typechain/src/ethers-v5/v1.3.0/factories/MultiSend__factory'
 import { ProxyFactory__factory as SafeProxyFactory_V1_3_0 } from '../../typechain/src/ethers-v5/v1.3.0/factories/ProxyFactory__factory'
 import GnosisSafeContract_V1_1_1_Ethers from './GnosisSafe/v1.1.1/GnosisSafeContract_V1_1_1_Ethers'
@@ -14,6 +15,7 @@ import GnosisSafeProxyFactoryContract_V1_1_1_Ethers from './GnosisSafeProxyFacto
 import GnosisSafeProxyFactoryContract_V1_3_0_Ethers from './GnosisSafeProxyFactory/v1.3.0/GnosisSafeProxyFactoryContract_V1_3_0_Ethers'
 import MultiSendContract_V1_1_1_Ethers from './MultiSend/v1.1.1/MultiSendContract_V1_1_1_Ethers'
 import MultiSendContract_V1_3_0_Ethers from './MultiSend/v1.3.0/MultiSendContract_V1_3_0_Ethers'
+import MultiSendCallOnlyContract_V1_3_0_Ethers from './MultiSendCallOnly/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Ethers'
 
 export function getSafeContractInstance(
   safeVersion: SafeVersion,
@@ -53,6 +55,23 @@ export function getMultiSendContractInstance(
     case '1.1.1':
       multiSendContract = MultiSend_V1_1_1.connect(contractAddress, signer)
       return new MultiSendContract_V1_1_1_Ethers(multiSendContract)
+    default:
+      throw new Error('Invalid Safe version')
+  }
+}
+
+export function getMultiSendCallOnlyContractInstance(
+  safeVersion: SafeVersion,
+  contractAddress: string,
+  signer: Signer
+): MultiSendCallOnlyContract_V1_3_0_Ethers {
+  let multiSendCallOnlyContract
+  switch (safeVersion) {
+    case '1.3.0':
+      multiSendCallOnlyContract = MultiSendCallOnly_V1_3_0.connect(contractAddress, signer)
+      return new MultiSendCallOnlyContract_V1_3_0_Ethers(multiSendCallOnlyContract)
+    case '1.2.0':
+    case '1.1.1':
     default:
       throw new Error('Invalid Safe version')
   }

--- a/packages/safe-service-client/tests/endpoint/index.test.ts
+++ b/packages/safe-service-client/tests/endpoint/index.test.ts
@@ -402,7 +402,7 @@ describe('Endpoint tests', () => {
         url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/multisig-transactions/`,
         method: 'post',
         body: {
-          ...safeTxData,
+          ...safeTransactionData,
           contractTransactionHash: safeTxHash,
           sender: signerAddress,
           signature: senderSignature.data,
@@ -445,7 +445,7 @@ describe('Endpoint tests', () => {
         url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/multisig-transactions/`,
         method: 'post',
         body: {
-          ...safeTxData,
+          ...safeTransactionData,
           contractTransactionHash: safeTxHash,
           sender: signerAddress,
           signature: senderSignature.data,

--- a/packages/safe-service-client/tests/endpoint/index.test.ts
+++ b/packages/safe-service-client/tests/endpoint/index.test.ts
@@ -369,7 +369,7 @@ describe('Endpoint tests', () => {
     })
 
     it('proposeTransaction', async () => {
-      const safeTxData: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safeAddress,
         data: '0x',
         value: '123456789',
@@ -384,7 +384,7 @@ describe('Endpoint tests', () => {
       const origin = 'Safe Core SDK: Safe Service Client'
       const signerAddress = await signer.getAddress()
       const safeSdk = await Safe.create({ ethAdapter, safeAddress })
-      const safeTransaction = await safeSdk.createTransaction(safeTxData)
+      const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
       const senderSignature = await safeSdk.signTransactionHash(safeTxHash)
       await chai
         .expect(
@@ -412,7 +412,7 @@ describe('Endpoint tests', () => {
     })
 
     it('proposeTransaction EIP-3770', async () => {
-      const safeTxData: SafeTransactionDataPartial = {
+      const safeTransactionData: SafeTransactionDataPartial = {
         to: safeAddress,
         data: '0x',
         value: '123456789',
@@ -427,7 +427,7 @@ describe('Endpoint tests', () => {
       const origin = 'Safe Core SDK: Safe Service Client'
       const signerAddress = await signer.getAddress()
       const safeSdk = await Safe.create({ ethAdapter, safeAddress })
-      const safeTransaction = await safeSdk.createTransaction(safeTxData)
+      const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
       const senderSignature = await safeSdk.signTransactionHash(safeTxHash)
       await chai
         .expect(

--- a/packages/safe-web3-lib/contracts/Deps_V1_3_0.sol
+++ b/packages/safe-web3-lib/contracts/Deps_V1_3_0.sol
@@ -4,7 +4,9 @@ pragma solidity >=0.7.0 <0.9.0;
 import { GnosisSafeProxyFactory } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/proxies/GnosisSafeProxyFactory.sol";
 import { GnosisSafe } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/GnosisSafe.sol";
 import { MultiSend } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/libraries/MultiSend.sol";
+import { MultiSendCallOnly } from "@gnosis.pm/safe-contracts-v1.3.0/contracts/libraries/MultiSendCallOnly.sol";
 
 contract ProxyFactory_SV1_3_0 is GnosisSafeProxyFactory {}
 contract GnosisSafe_SV1_3_0 is GnosisSafe {}
 contract MultiSend_SV1_3_0 is MultiSend {}
+contract MultiSendCallOnly_SV1_3_0 is MultiSendCallOnly {}

--- a/packages/safe-web3-lib/scripts/generateTypechainFiles.ts
+++ b/packages/safe-web3-lib/scripts/generateTypechainFiles.ts
@@ -18,7 +18,8 @@ const safeContractsPath = '../../node_modules/@gnosis.pm/safe-deployments/dist/a
 const safeContracts_V1_3_0 = [
   `${safeContractsPath}/v1.3.0/gnosis_safe.json`,
   `${safeContractsPath}/v1.3.0/proxy_factory.json`,
-  `${safeContractsPath}/v1.3.0/multi_send.json`
+  `${safeContractsPath}/v1.3.0/multi_send.json`,
+  `${safeContractsPath}/v1.3.0/multi_send_call_only.json`
 ].join(' ')
 const safeContracts_V1_2_0 = [`${safeContractsPath}/v1.2.0/gnosis_safe.json`].join(' ')
 const safeContracts_V1_1_1 = [

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -52,14 +52,14 @@ class Web3Adapter implements EthAdapter {
   }
 
   async getBalance(address: string, defaultBlock?: string | number): Promise<BigNumber> {
-    const balance = (defaultBlock)
+    const balance = defaultBlock
       ? await this.#web3.eth.getBalance(address, defaultBlock)
       : await this.#web3.eth.getBalance(address)
     return BigNumber.from(balance)
   }
 
   async getNonce(address: string, defaultBlock?: string | number): Promise<number> {
-    const nonce = (defaultBlock)
+    const nonce = defaultBlock
       ? await this.#web3.eth.getTransactionCount(address, defaultBlock)
       : await this.#web3.eth.getTransactionCount(address)
     return nonce
@@ -150,7 +150,7 @@ class Web3Adapter implements EthAdapter {
   }
 
   async getContractCode(address: string, defaultBlock?: string | number): Promise<string> {
-    const code = (defaultBlock)
+    const code = defaultBlock
       ? await this.#web3.eth.getCode(address, defaultBlock)
       : await this.#web3.eth.getCode(address)
     return code

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -14,12 +14,14 @@ import { AbiItem } from 'web3-utils'
 import type { JsonRPCResponse, Provider } from 'web3/providers'
 import {
   getGnosisSafeProxyFactoryContractInstance,
+  getMultiSendCallOnlyContractInstance,
   getMultiSendContractInstance,
   getSafeContractInstance
 } from './contracts/contractInstancesWeb3'
 import GnosisSafeContractWeb3 from './contracts/GnosisSafe/GnosisSafeContractWeb3'
 import GnosisSafeProxyFactoryWeb3Contract from './contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryWeb3Contract'
 import MultiSendWeb3Contract from './contracts/MultiSend/MultiSendWeb3Contract'
+import MultiSendCallOnlyWeb3Contract from './contracts/MultiSendCallOnly/MultiSendCallOnlyWeb3Contract'
 
 export interface Web3AdapterConfig {
   /** web3 - Web3 library */
@@ -105,6 +107,24 @@ class Web3Adapter implements EthAdapter {
       customContractAbi ?? (singletonDeployment?.abi as AbiItem[])
     )
     return getMultiSendContractInstance(safeVersion, multiSendContract)
+  }
+
+  getMultiSendCallOnlyContract({
+    safeVersion,
+    chainId,
+    singletonDeployment,
+    customContractAddress,
+    customContractAbi
+  }: GetContractProps): MultiSendCallOnlyWeb3Contract {
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
+    if (!contractAddress) {
+      throw new Error('Invalid MultiSendCallOnly contract address')
+    }
+    const multiSendContract = this.getContract(
+      contractAddress,
+      customContractAbi ?? (singletonDeployment?.abi as AbiItem[])
+    )
+    return getMultiSendCallOnlyContractInstance(safeVersion, multiSendContract)
   }
 
   getSafeProxyFactoryContract({

--- a/packages/safe-web3-lib/src/contracts/MultiSendCallOnly/MultiSendCallOnlyWeb3Contract.ts
+++ b/packages/safe-web3-lib/src/contracts/MultiSendCallOnly/MultiSendCallOnlyWeb3Contract.ts
@@ -1,0 +1,16 @@
+import { MultiSendCallOnlyContract } from '@gnosis.pm/safe-core-sdk-types'
+import { MultiSendCallOnly as MultiSendCallOnly_V1_3_0 } from '../../../typechain/src/web3-v1/v1.3.0/multi_send_call_only'
+
+abstract class MultiSendCallOnlyWeb3Contract implements MultiSendCallOnlyContract {
+  constructor(public contract: MultiSendCallOnly_V1_3_0) {}
+
+  getAddress(): string {
+    return this.contract.options.address
+  }
+
+  encode(methodName: string, params: any[]): string {
+    return (this.contract as any).methods[methodName](...params).encodeABI()
+  }
+}
+
+export default MultiSendCallOnlyWeb3Contract

--- a/packages/safe-web3-lib/src/contracts/MultiSendCallOnly/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Web3.ts
+++ b/packages/safe-web3-lib/src/contracts/MultiSendCallOnly/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Web3.ts
@@ -1,0 +1,10 @@
+import { MultiSendCallOnly } from '../../../../typechain/src/web3-v1/v1.3.0/multi_send_call_only'
+import MultiSendCallOnlyWeb3Contract from '../MultiSendCallOnlyWeb3Contract'
+
+class MultiSendCallOnlyContract_V1_3_0_Web3 extends MultiSendCallOnlyWeb3Contract {
+  constructor(public contract: MultiSendCallOnly) {
+    super(contract)
+  }
+}
+
+export default MultiSendCallOnlyContract_V1_3_0_Web3

--- a/packages/safe-web3-lib/src/contracts/contractInstancesWeb3.ts
+++ b/packages/safe-web3-lib/src/contracts/contractInstancesWeb3.ts
@@ -5,6 +5,7 @@ import { ProxyFactory as GnosisSafeProxyFactory_V1_1_1 } from '../../typechain/s
 import { GnosisSafe as SafeMasterCopy_V1_2_0 } from '../../typechain/src/web3-v1/v1.2.0/gnosis_safe'
 import { GnosisSafe as SafeMasterCopy_V1_3_0 } from '../../typechain/src/web3-v1/v1.3.0/gnosis_safe'
 import { MultiSend as MultiSend_V1_3_0 } from '../../typechain/src/web3-v1/v1.3.0/multi_send'
+import { MultiSendCallOnly as MultiSendCallOnly_V1_3_0 } from '../../typechain/src/web3-v1/v1.3.0/multi_send_call_only'
 import { ProxyFactory as GnosisSafeProxyFactory_V1_3_0 } from '../../typechain/src/web3-v1/v1.3.0/proxy_factory'
 import GnosisSafeContract_V1_1_1_Web3 from './GnosisSafe/v1.1.1/GnosisSafeContract_V1_1_1_Web3'
 import GnosisSafeContract_V1_2_0_Web3 from './GnosisSafe/v1.2.0/GnosisSafeContract_V1_2_0_Web3'
@@ -13,6 +14,7 @@ import GnosisSafeProxyFactoryContract_V1_1_1_Web3 from './GnosisSafeProxyFactory
 import GnosisSafeProxyFactoryContract_V1_3_0_Web3 from './GnosisSafeProxyFactory/v1.3.0/GnosisSafeProxyFactoryContract_V1_3_0_Web3'
 import MultiSendContract_V1_1_1_Web3 from './MultiSend/v1.1.1/MultiSendContract_V1_1_1_Web3'
 import MultiSendContract_V1_3_0_Web3 from './MultiSend/v1.3.0/MultiSendContract_V1_3_0_Web3'
+import MultiSendCallOnlyContract_V1_3_0_Web3 from './MultiSendCallOnly/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Web3'
 
 export function getSafeContractInstance(
   safeVersion: SafeVersion,
@@ -43,6 +45,20 @@ export function getMultiSendContractInstance(
     case '1.2.0':
     case '1.1.1':
       return new MultiSendContract_V1_1_1_Web3(multiSendContract as MultiSend_V1_1_1)
+    default:
+      throw new Error('Invalid Safe version')
+  }
+}
+
+export function getMultiSendCallOnlyContractInstance(
+  safeVersion: SafeVersion,
+  multiSendCallOnlyContract: MultiSendCallOnly_V1_3_0
+): MultiSendCallOnlyContract_V1_3_0_Web3 {
+  switch (safeVersion) {
+    case '1.3.0':
+      return new MultiSendCallOnlyContract_V1_3_0_Web3(multiSendCallOnlyContract as MultiSendCallOnly_V1_3_0)
+    case '1.2.0':
+    case '1.1.1':
     default:
       throw new Error('Invalid Safe version')
   }

--- a/packages/safe-web3-lib/src/contracts/contractInstancesWeb3.ts
+++ b/packages/safe-web3-lib/src/contracts/contractInstancesWeb3.ts
@@ -56,7 +56,9 @@ export function getMultiSendCallOnlyContractInstance(
 ): MultiSendCallOnlyContract_V1_3_0_Web3 {
   switch (safeVersion) {
     case '1.3.0':
-      return new MultiSendCallOnlyContract_V1_3_0_Web3(multiSendCallOnlyContract as MultiSendCallOnly_V1_3_0)
+      return new MultiSendCallOnlyContract_V1_3_0_Web3(
+        multiSendCallOnlyContract as MultiSendCallOnly_V1_3_0
+      )
     case '1.2.0':
     case '1.1.1':
     default:

--- a/packages/safe-web3-lib/src/contracts/contractInstancesWeb3.ts
+++ b/packages/safe-web3-lib/src/contracts/contractInstancesWeb3.ts
@@ -56,11 +56,11 @@ export function getMultiSendCallOnlyContractInstance(
 ): MultiSendCallOnlyContract_V1_3_0_Web3 {
   switch (safeVersion) {
     case '1.3.0':
+    case '1.2.0':
+    case '1.1.1':
       return new MultiSendCallOnlyContract_V1_3_0_Web3(
         multiSendCallOnlyContract as MultiSendCallOnly_V1_3_0
       )
-    case '1.2.0':
-    case '1.1.1':
     default:
       throw new Error('Invalid Safe version')
   }


### PR DESCRIPTION
## What it solves
- Update config files to:
  - Generate MultiSendCallOnly typechain files.
  - Deploy MultiSendCallOnly contract with hardhat for testing.
- Update `createTransaction` method signature and logic to optionally use MultiSendCallOnly contract.
  Logic includes:
  - Handle MultiSendCallOnly contract instances.
  - Add `multisendCallOnly` in the ContractManager class.
- Update docs accordingly.
- Update tests accordingly.