### PR TITLE
Rename methods and error messages

### DIFF
--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -352,7 +352,7 @@ const safeSdk2 = await safeSdk.connect({ ethAdapter, safeAddress })
 
 ### getAddress
 
-Returns the address of the current Safe Proxy contract.
+Returns the address of the current SafeProxy contract.
 
 ```js
 const address = safeSdk.getAddress()

--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -651,12 +651,12 @@ const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const owners = await safeSdk.getOwnersWhoApprovedTx(txHash)
 ```
 
-### getEnableModuleTx
+### createEnableModuleTx
 
 Returns a Safe transaction ready to be signed that will enable a Safe module.
 
 ```js
-const safeTransaction = await safeSdk.getEnableModuleTx(moduleAddress)
+const safeTransaction = await safeSdk.createEnableModuleTx(moduleAddress)
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```
@@ -672,15 +672,15 @@ const options: SafeTransactionOptionalProps = {
   refundReceiver, // Optional
   nonce // Optional
 }
-const safeTransaction = await safeSdk.getEnableModuleTx(moduleAddress, options)
+const safeTransaction = await safeSdk.createEnableModuleTx(moduleAddress, options)
 ```
 
-### getDisableModuleTx
+### createDisableModuleTx
 
 Returns a Safe transaction ready to be signed that will disable a Safe module.
 
 ```js
-const safeTransaction = await safeSdk.getDisableModuleTx(moduleAddress)
+const safeTransaction = await safeSdk.createDisableModuleTx(moduleAddress)
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```
@@ -689,10 +689,10 @@ This method can optionally receive the `options` parameter:
 
 ```js
 const options: SafeTransactionOptionalProps = { ... }
-const safeTransaction = await safeSdk.getDisableModuleTx(moduleAddress, options)
+const safeTransaction = await safeSdk.createDisableModuleTx(moduleAddress, options)
 ```
 
-### getAddOwnerTx
+### createAddOwnerTx
 
 Returns the Safe transaction to add an owner and optionally change the threshold.
 
@@ -701,7 +701,7 @@ const params: AddOwnerTxParams = {
   ownerAddress,
   threshold // Optional. If `threshold` is not provided the current threshold will not change.
 }
-const safeTransaction = await safeSdk.getAddOwnerTx(params)
+const safeTransaction = await safeSdk.createAddOwnerTx(params)
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```
@@ -710,10 +710,10 @@ This method can optionally receive the `options` parameter:
 
 ```js
 const options: SafeTransactionOptionalProps = { ... }
-const safeTransaction = await safeSdk.getAddOwnerTx(params, options)
+const safeTransaction = await safeSdk.createAddOwnerTx(params, options)
 ```
 
-### getRemoveOwnerTx
+### createRemoveOwnerTx
 
 Returns the Safe transaction to remove an owner and optionally change the threshold.
 
@@ -722,7 +722,7 @@ const params: RemoveOwnerTxParams = {
   ownerAddress,
   newThreshold // Optional. If `newThreshold` is not provided, the current threshold will be decreased by one.
 }
-const safeTransaction = await safeSdk.getRemoveOwnerTx(params)
+const safeTransaction = await safeSdk.createRemoveOwnerTx(params)
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```
@@ -731,10 +731,10 @@ This method can optionally receive the `options` parameter:
 
 ```js
 const options: SafeTransactionOptionalProps = { ... }
-const safeTransaction = await safeSdk.getRemoveOwnerTx(params, options)
+const safeTransaction = await safeSdk.createRemoveOwnerTx(params, options)
 ```
 
-### getSwapOwnerTx
+### createSwapOwnerTx
 
 Returns the Safe transaction to replace an owner of the Safe with a new one.
 
@@ -743,7 +743,7 @@ const params: SwapOwnerTxParams = {
   oldOwnerAddress,
   newOwnerAddress
 }
-const safeTransaction = await safeSdk.getSwapOwnerTx(params)
+const safeTransaction = await safeSdk.createSwapOwnerTx(params)
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```
@@ -752,15 +752,15 @@ This method can optionally receive the `options` parameter:
 
 ```js
 const options: SafeTransactionOptionalProps = { ... }
-const safeTransaction = await safeSdk.getSwapOwnerTx(params, options)
+const safeTransaction = await safeSdk.createSwapOwnerTx(params, options)
 ```
 
-### getChangeThresholdTx
+### createChangeThresholdTx
 
 Returns the Safe transaction to change the threshold.
 
 ```js
-const safeTransaction = await safeSdk.getChangeThresholdTx(newThreshold)
+const safeTransaction = await safeSdk.createChangeThresholdTx(newThreshold)
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```
@@ -769,7 +769,7 @@ This method can optionally receive the `options` parameter:
 
 ```js
 const options: SafeTransactionOptionalProps = { ... }
-const safeTransaction = await safeSdk.getChangeThresholdTx(newThreshold, options)
+const safeTransaction = await safeSdk.createChangeThresholdTx(newThreshold, options)
 ```
 
 ### executeTransaction

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -484,7 +484,7 @@ class Safe {
    * @throws "Invalid module address provided"
    * @throws "Module provided is already enabled"
    */
-  async getEnableModuleTx(
+  async createEnableModuleTx(
     moduleAddress: string,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
@@ -507,7 +507,7 @@ class Safe {
    * @throws "Invalid module address provided"
    * @throws "Module provided is not enabled already"
    */
-  async getDisableModuleTx(
+  async createDisableModuleTx(
     moduleAddress: string,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
@@ -532,7 +532,7 @@ class Safe {
    * @throws "Threshold needs to be greater than 0"
    * @throws "Threshold cannot exceed owner count"
    */
-  async getAddOwnerTx(
+  async createAddOwnerTx(
     { ownerAddress, threshold }: AddOwnerTxParams,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
@@ -557,7 +557,7 @@ class Safe {
    * @throws "Threshold needs to be greater than 0"
    * @throws "Threshold cannot exceed owner count"
    */
-  async getRemoveOwnerTx(
+  async createRemoveOwnerTx(
     { ownerAddress, threshold }: RemoveOwnerTxParams,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
@@ -582,7 +582,7 @@ class Safe {
    * @throws "New address provided is already an owner"
    * @throws "Old address provided is not an owner"
    */
-  async getSwapOwnerTx(
+  async createSwapOwnerTx(
     { oldOwnerAddress, newOwnerAddress }: SwapOwnerTxParams,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {
@@ -605,7 +605,7 @@ class Safe {
    * @throws "Threshold needs to be greater than 0"
    * @throws "Threshold cannot exceed owner count"
    */
-  async getChangeThresholdTx(
+  async createChangeThresholdTx(
     threshold: number,
     options?: SafeTransactionOptionalProps
   ): Promise<SafeTransaction> {

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -91,7 +91,7 @@ class Safe {
    * Creates an instance of the Safe Core SDK.
    * @param config - Ethers Safe configuration
    * @returns The Safe Core SDK instance
-   * @throws "Safe Proxy contract is not deployed on the current network"
+   * @throws "SafeProxy contract is not deployed on the current network"
    * @throws "MultiSend contract is not deployed on the current network"
    * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
@@ -110,8 +110,9 @@ class Safe {
    * Initializes the Safe Core SDK instance.
    * @param config - Safe configuration
    * @throws "Signer must be connected to a provider"
-   * @throws "Safe Proxy contract is not deployed on the current network"
+   * @throws "SafeProxy contract is not deployed on the current network"
    * @throws "MultiSend contract is not deployed on the current network"
+   * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
   private async init({
     ethAdapter,
@@ -133,8 +134,9 @@ class Safe {
   /**
    * Returns a new instance of the Safe Core SDK.
    * @param config - Connect Safe configuration
-   * @throws "Safe Proxy contract is not deployed on the current network"
+   * @throws "SafeProxy contract is not deployed on the current network"
    * @throws "MultiSend contract is not deployed on the current network"
+   * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
   async connect({
     ethAdapter,
@@ -151,9 +153,9 @@ class Safe {
   }
 
   /**
-   * Returns the address of the current Safe Proxy contract.
+   * Returns the address of the current SafeProxy contract.
    *
-   * @returns The address of the Safe Proxy contract
+   * @returns The address of the SafeProxy contract
    */
   getAddress(): string {
     return this.#contractManager.safeContract.getAddress()

--- a/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
+++ b/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
@@ -85,7 +85,7 @@ export async function getSafeContract({
   })
   const isContractDeployed = await ethAdapter.isContractDeployed(gnosisSafeContract.getAddress())
   if (!isContractDeployed) {
-    throw new Error('Safe Proxy contract is not deployed on the current network')
+    throw new Error('SafeProxy contract is not deployed on the current network')
   }
   return gnosisSafeContract
 }
@@ -108,7 +108,7 @@ export async function getProxyFactoryContract({
     safeProxyFactoryContract.getAddress()
   )
   if (!isContractDeployed) {
-    throw new Error('Safe Proxy Factory contract is not deployed on the current network')
+    throw new Error('SafeProxyFactory contract is not deployed on the current network')
   }
   return safeProxyFactoryContract
 }
@@ -129,7 +129,7 @@ export async function getMultiSendContract({
   })
   const isContractDeployed = await ethAdapter.isContractDeployed(multiSendContract.getAddress())
   if (!isContractDeployed) {
-    throw new Error('Multi Send contract is not deployed on the current network')
+    throw new Error('MultiSend contract is not deployed on the current network')
   }
   return multiSendContract
 }

--- a/packages/safe-core-sdk/src/safeFactory/index.ts
+++ b/packages/safe-core-sdk/src/safeFactory/index.ts
@@ -207,7 +207,7 @@ class SafeFactory {
     })
     const isContractDeployed = await this.#ethAdapter.isContractDeployed(safeAddress)
     if (!isContractDeployed) {
-      throw new Error('Safe Proxy contract is not deployed on the current network')
+      throw new Error('SafeProxy contract is not deployed on the current network')
     }
     const safe = await Safe.create({
       ethAdapter: this.#ethAdapter,

--- a/packages/safe-core-sdk/src/types/index.ts
+++ b/packages/safe-core-sdk/src/types/index.ts
@@ -13,9 +13,9 @@ export interface ContractNetworkConfig {
   safeMasterCopyAddress: string
   /** safeMasterCopyAbi - Abi of the Gnosis Safe Master Copy contract deployed on a specific network */
   safeMasterCopyAbi?: AbiItem | AbiItem[]
-  /** safeProxyFactoryAddress - Address of the Gnosis Safe Proxy Factory contract deployed on a specific network */
+  /** safeProxyFactoryAddress - Address of the Gnosis SafeProxyFactory contract deployed on a specific network */
   safeProxyFactoryAddress: string
-  /** safeProxyFactoryAbi - Abi of the Gnosis Safe Proxy Factory contract deployed on a specific network */
+  /** safeProxyFactoryAbi - Abi of the Gnosis SafeProxyFactory contract deployed on a specific network */
   safeProxyFactoryAbi?: AbiItem | AbiItem[]
 }
 

--- a/packages/safe-core-sdk/tests/contractManager.test.ts
+++ b/packages/safe-core-sdk/tests/contractManager.test.ts
@@ -45,11 +45,11 @@ describe('Safe contracts manager', () => {
         .to.be.rejectedWith(
           process.env.ETH_LIB === 'web3'
             ? 'You must provide the json interface of the contract when instantiating a contract object'
-            : 'Invalid Multi Send contract address'
+            : 'Invalid MultiSend contract address'
         )
     })
 
-    it('should fail if Safe Proxy contract is not deployed on the current network', async () => {
+    it('should fail if SafeProxy contract is not deployed on the current network', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)
@@ -61,7 +61,7 @@ describe('Safe contracts manager', () => {
             contractNetworks
           })
         )
-        .to.be.rejectedWith('Safe Proxy contract is not deployed on the current network')
+        .to.be.rejectedWith('SafeProxy contract is not deployed on the current network')
     })
 
     it('should fail if MultiSend contract is specified in contractNetworks but not deployed', async () => {
@@ -88,7 +88,7 @@ describe('Safe contracts manager', () => {
             contractNetworks: customContractNetworks
           })
         )
-        .to.be.rejectedWith('Multi Send contract is not deployed on the current network')
+        .to.be.rejectedWith('MultiSend contract is not deployed on the current network')
     })
 
     it('should set the MultiSend contract available on the current network', async () => {

--- a/packages/safe-core-sdk/tests/ethAdapters.test.ts
+++ b/packages/safe-core-sdk/tests/ethAdapters.test.ts
@@ -104,7 +104,7 @@ describe('Safe contracts', () => {
   })
 
   describe('getMultiSendContract', async () => {
-    it('should return a Multi Send contract from safe-deployments', async () => {
+    it('should return a MultiSend contract from safe-deployments', async () => {
       const { accounts } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)
@@ -121,7 +121,7 @@ describe('Safe contracts', () => {
         .to.be.eq('0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761')
     })
 
-    it('should return a Multi Send contract from the custom addresses', async () => {
+    it('should return a MultiSend contract from the custom addresses', async () => {
       const { accounts, contractNetworks, chainId } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)
@@ -176,7 +176,7 @@ describe('Safe contracts', () => {
   })
 
   describe('getSafeProxyFactoryContract', async () => {
-    it('should return a Safe Proxy Factory contract from safe-deployments', async () => {
+    it('should return a SafeProxyFactory contract from safe-deployments', async () => {
       const { accounts } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)
@@ -193,7 +193,7 @@ describe('Safe contracts', () => {
         .to.be.eq('0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2')
     })
 
-    it('should return a Safe Proxy Factory contract from the custom addresses', async () => {
+    it('should return a SafeProxyFactory contract from the custom addresses', async () => {
       const { accounts, contractNetworks, chainId } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)

--- a/packages/safe-core-sdk/tests/moduleManager.test.ts
+++ b/packages/safe-core-sdk/tests/moduleManager.test.ts
@@ -41,7 +41,7 @@ describe('Safe modules manager', () => {
         contractNetworks
       })
       chai.expect((await safeSdk.getModules()).length).to.be.eq(0)
-      const tx = await safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx = await safeSdk.createEnableModuleTx(dailyLimitModule.address)
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       chai.expect((await safeSdk.getModules()).length).to.be.eq(1)
@@ -59,14 +59,14 @@ describe('Safe modules manager', () => {
         contractNetworks
       })
       chai.expect(await safeSdk.isModuleEnabled(dailyLimitModule.address)).to.be.false
-      const tx = await safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx = await safeSdk.createEnableModuleTx(dailyLimitModule.address)
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       chai.expect(await safeSdk.isModuleEnabled(dailyLimitModule.address)).to.be.true
     })
   })
 
-  describe('getEnableModuleTx', async () => {
+  describe('createEnableModuleTx', async () => {
     it('should fail if address is invalid', async () => {
       const { safe, accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
@@ -76,7 +76,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getEnableModuleTx('0x123')
+      const tx = safeSdk.createEnableModuleTx('0x123')
       await chai.expect(tx).to.be.rejectedWith('Invalid module address provided')
     })
 
@@ -89,7 +89,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getEnableModuleTx(SENTINEL_ADDRESS)
+      const tx = safeSdk.createEnableModuleTx(SENTINEL_ADDRESS)
       await chai.expect(tx).to.be.rejectedWith('Invalid module address provided')
     })
 
@@ -102,7 +102,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getEnableModuleTx(ZERO_ADDRESS)
+      const tx = safeSdk.createEnableModuleTx(ZERO_ADDRESS)
       await chai.expect(tx).to.be.rejectedWith('Invalid module address provided')
     })
 
@@ -115,10 +115,10 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx1 = await safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx1 = await safeSdk.createEnableModuleTx(dailyLimitModule.address)
       const txResponse = await safeSdk.executeTransaction(tx1)
       await waitSafeTxReceipt(txResponse)
-      const tx2 = safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx2 = safeSdk.createEnableModuleTx(dailyLimitModule.address)
       await chai.expect(tx2).to.be.rejectedWith('Module provided is already enabled')
     })
 
@@ -139,7 +139,7 @@ describe('Safe modules manager', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.getEnableModuleTx(dailyLimitModule.address, options)
+      const tx = await safeSdk.createEnableModuleTx(dailyLimitModule.address, options)
       chai.expect(tx.data.baseGas).to.be.eq(111)
       chai.expect(tx.data.gasPrice).to.be.eq(222)
       chai.expect(tx.data.gasToken).to.be.eq('0x333')
@@ -159,7 +159,7 @@ describe('Safe modules manager', () => {
       })
       chai.expect((await safeSdk.getModules()).length).to.be.eq(0)
       chai.expect(await safeSdk.isModuleEnabled(dailyLimitModule.address)).to.be.false
-      const tx = await safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx = await safeSdk.createEnableModuleTx(dailyLimitModule.address)
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       chai.expect((await safeSdk.getModules()).length).to.be.eq(1)
@@ -167,7 +167,7 @@ describe('Safe modules manager', () => {
     })
   })
 
-  describe('getDisableModuleTx', async () => {
+  describe('createDisableModuleTx', async () => {
     it('should fail if address is invalid', async () => {
       const { safe, accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
@@ -177,7 +177,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getDisableModuleTx('0x123')
+      const tx = safeSdk.createDisableModuleTx('0x123')
       await chai.expect(tx).to.be.rejectedWith('Invalid module address provided')
     })
 
@@ -190,7 +190,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getDisableModuleTx(SENTINEL_ADDRESS)
+      const tx = safeSdk.createDisableModuleTx(SENTINEL_ADDRESS)
       await chai.expect(tx).to.be.rejectedWith('Invalid module address provided')
     })
 
@@ -203,7 +203,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getDisableModuleTx(ZERO_ADDRESS)
+      const tx = safeSdk.createDisableModuleTx(ZERO_ADDRESS)
       await chai.expect(tx).to.be.rejectedWith('Invalid module address provided')
     })
 
@@ -216,7 +216,7 @@ describe('Safe modules manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getDisableModuleTx(dailyLimitModule.address)
+      const tx = safeSdk.createDisableModuleTx(dailyLimitModule.address)
       await chai.expect(tx).to.be.rejectedWith('Module provided is not enabled already')
     })
 
@@ -231,7 +231,7 @@ describe('Safe modules manager', () => {
         contractNetworks
       })
 
-      const tx1 = await safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx1 = await safeSdk.createEnableModuleTx(dailyLimitModule.address)
       const txResponse1 = await safeSdk.executeTransaction(tx1)
       await waitSafeTxReceipt(txResponse1)
       chai.expect((await safeSdk.getModules()).length).to.be.eq(1)
@@ -245,7 +245,7 @@ describe('Safe modules manager', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx2 = await safeSdk.getDisableModuleTx(dailyLimitModule.address, options)
+      const tx2 = await safeSdk.createDisableModuleTx(dailyLimitModule.address, options)
       chai.expect(tx2.data.baseGas).to.be.eq(111)
       chai.expect(tx2.data.gasPrice).to.be.eq(222)
       chai.expect(tx2.data.gasToken).to.be.eq('0x333')
@@ -266,24 +266,24 @@ describe('Safe modules manager', () => {
         contractNetworks
       })
 
-      const tx1 = await safeSdk.getEnableModuleTx(dailyLimitModule.address)
+      const tx1 = await safeSdk.createEnableModuleTx(dailyLimitModule.address)
       const txResponse1 = await safeSdk.executeTransaction(tx1)
       await waitSafeTxReceipt(txResponse1)
-      const tx2 = await safeSdk.getEnableModuleTx(socialRecoveryModule.address)
+      const tx2 = await safeSdk.createEnableModuleTx(socialRecoveryModule.address)
       const txResponse2 = await safeSdk.executeTransaction(tx2)
       await waitSafeTxReceipt(txResponse2)
       chai.expect((await safeSdk.getModules()).length).to.be.eq(2)
       chai.expect(await safeSdk.isModuleEnabled(dailyLimitModule.address)).to.be.true
       chai.expect(await safeSdk.isModuleEnabled(socialRecoveryModule.address)).to.be.true
 
-      const tx3 = await safeSdk.getDisableModuleTx(dailyLimitModule.address)
+      const tx3 = await safeSdk.createDisableModuleTx(dailyLimitModule.address)
       const txResponse3 = await safeSdk.executeTransaction(tx3)
       await waitSafeTxReceipt(txResponse3)
       chai.expect((await safeSdk.getModules()).length).to.be.eq(1)
       chai.expect(await safeSdk.isModuleEnabled(dailyLimitModule.address)).to.be.false
       chai.expect(await safeSdk.isModuleEnabled(socialRecoveryModule.address)).to.be.true
 
-      const tx4 = await safeSdk.getDisableModuleTx(socialRecoveryModule.address)
+      const tx4 = await safeSdk.createDisableModuleTx(socialRecoveryModule.address)
       const txResponse4 = await safeSdk.executeTransaction(tx4)
       await waitSafeTxReceipt(txResponse4)
       chai.expect((await safeSdk.getModules()).length).to.be.eq(0)

--- a/packages/safe-core-sdk/tests/ownerManager.test.ts
+++ b/packages/safe-core-sdk/tests/ownerManager.test.ts
@@ -76,7 +76,7 @@ describe('Safe owners manager', () => {
     })
   })
 
-  describe('getAddOwnerTx', async () => {
+  describe('createAddOwnerTx', async () => {
     it('should fail if address is invalid', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
@@ -87,7 +87,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getAddOwnerTx({ ownerAddress: '0x123' })
+      const tx = safeSdk.createAddOwnerTx({ ownerAddress: '0x123' })
       await chai.expect(tx).to.be.rejectedWith('Invalid owner address provided')
     })
 
@@ -101,7 +101,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getAddOwnerTx({ ownerAddress: SENTINEL_ADDRESS })
+      const tx = safeSdk.createAddOwnerTx({ ownerAddress: SENTINEL_ADDRESS })
       await chai.expect(tx).to.be.rejectedWith('Invalid owner address provided')
     })
 
@@ -115,7 +115,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getAddOwnerTx({ ownerAddress: ZERO_ADDRESS })
+      const tx = safeSdk.createAddOwnerTx({ ownerAddress: ZERO_ADDRESS })
       await chai.expect(tx).to.be.rejectedWith('Invalid owner address provided')
     })
 
@@ -129,7 +129,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getAddOwnerTx({ ownerAddress: account1.address })
+      const tx = safeSdk.createAddOwnerTx({ ownerAddress: account1.address })
       await chai.expect(tx).to.be.rejectedWith('Address provided is already an owner')
     })
 
@@ -146,7 +146,7 @@ describe('Safe owners manager', () => {
       const newThreshold = 3
       const numOwners = (await safeSdk.getOwners()).length
       chai.expect(newThreshold).to.be.gt(numOwners)
-      const tx = safeSdk.getAddOwnerTx({ ownerAddress: account2.address, threshold: newThreshold })
+      const tx = safeSdk.createAddOwnerTx({ ownerAddress: account2.address, threshold: newThreshold })
       await chai.expect(tx).to.be.rejectedWith('Threshold cannot exceed owner count')
     })
 
@@ -160,7 +160,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getAddOwnerTx({ ownerAddress: account2.address, threshold: 0 })
+      const tx = safeSdk.createAddOwnerTx({ ownerAddress: account2.address, threshold: 0 })
       await chai.expect(tx).to.be.rejectedWith('Threshold needs to be greater than 0')
     })
 
@@ -182,7 +182,7 @@ describe('Safe owners manager', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.getAddOwnerTx({ ownerAddress: account2.address }, options)
+      const tx = await safeSdk.createAddOwnerTx({ ownerAddress: account2.address }, options)
       chai.expect(tx.data.baseGas).to.be.eq(111)
       chai.expect(tx.data.gasPrice).to.be.eq(222)
       chai.expect(tx.data.gasToken).to.be.eq('0x333')
@@ -205,7 +205,7 @@ describe('Safe owners manager', () => {
       const initialOwners = await safeSdk.getOwners()
       chai.expect(initialOwners.length).to.be.eq(1)
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
-      const tx = await safeSdk.getAddOwnerTx({ ownerAddress: account2.address })
+      const tx = await safeSdk.createAddOwnerTx({ ownerAddress: account2.address })
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       const finalThreshold = await safeSdk.getThreshold()
@@ -230,7 +230,7 @@ describe('Safe owners manager', () => {
       const initialOwners = await safeSdk.getOwners()
       chai.expect(initialOwners.length).to.be.eq(1)
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
-      const tx = await safeSdk.getAddOwnerTx({
+      const tx = await safeSdk.createAddOwnerTx({
         ownerAddress: account2.address,
         threshold: newThreshold
       })
@@ -244,7 +244,7 @@ describe('Safe owners manager', () => {
     })
   })
 
-  describe('getRemoveOwnerTx', async () => {
+  describe('createRemoveOwnerTx', async () => {
     it('should fail if address is invalid', async () => {
       const { safe, accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
@@ -254,7 +254,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getRemoveOwnerTx({ ownerAddress: '0x123' })
+      const tx = safeSdk.createRemoveOwnerTx({ ownerAddress: '0x123' })
       await chai.expect(tx).to.be.rejectedWith('Invalid owner address provided')
     })
 
@@ -267,7 +267,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getRemoveOwnerTx({ ownerAddress: SENTINEL_ADDRESS })
+      const tx = safeSdk.createRemoveOwnerTx({ ownerAddress: SENTINEL_ADDRESS })
       await chai.expect(tx).to.be.rejectedWith('Invalid owner address provided')
     })
 
@@ -280,7 +280,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getRemoveOwnerTx({ ownerAddress: ZERO_ADDRESS })
+      const tx = safeSdk.createRemoveOwnerTx({ ownerAddress: ZERO_ADDRESS })
       await chai.expect(tx).to.be.rejectedWith('Invalid owner address provided')
     })
 
@@ -293,7 +293,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getRemoveOwnerTx({ ownerAddress: account4.address })
+      const tx = safeSdk.createRemoveOwnerTx({ ownerAddress: account4.address })
       await chai.expect(tx).to.be.rejectedWith('Address provided is not an owner')
     })
 
@@ -309,7 +309,7 @@ describe('Safe owners manager', () => {
       const newThreshold = 3
       const numOwners = (await safeSdk.getOwners()).length
       chai.expect(newThreshold).to.be.gt(numOwners - 1)
-      const tx = safeSdk.getRemoveOwnerTx({
+      const tx = safeSdk.createRemoveOwnerTx({
         ownerAddress: account1.address,
         threshold: newThreshold
       })
@@ -325,7 +325,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getRemoveOwnerTx({ ownerAddress: account1.address, threshold: 0 })
+      const tx = safeSdk.createRemoveOwnerTx({ ownerAddress: account1.address, threshold: 0 })
       await chai.expect(tx).to.be.rejectedWith('Threshold needs to be greater than 0')
     })
 
@@ -346,7 +346,7 @@ describe('Safe owners manager', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk1.getRemoveOwnerTx({ ownerAddress: account1.address }, options)
+      const tx = await safeSdk1.createRemoveOwnerTx({ ownerAddress: account1.address }, options)
       chai.expect(tx.data.baseGas).to.be.eq(111)
       chai.expect(tx.data.gasPrice).to.be.eq(222)
       chai.expect(tx.data.gasToken).to.be.eq('0x333')
@@ -374,7 +374,7 @@ describe('Safe owners manager', () => {
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
       chai.expect(initialOwners[1]).to.be.eq(account2.address)
       chai.expect(initialOwners[2]).to.be.eq(account3.address)
-      const tx = await safeSdk1.getRemoveOwnerTx({ ownerAddress: account1.address })
+      const tx = await safeSdk1.createRemoveOwnerTx({ ownerAddress: account1.address })
       const signedTx1 = await safeSdk2.signTransaction(tx)
       const signedTx2 = await safeSdk3.signTransaction(signedTx1)
       const txResponse = await safeSdk1.executeTransaction(signedTx2)
@@ -409,7 +409,7 @@ describe('Safe owners manager', () => {
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
       chai.expect(initialOwners[1]).to.be.eq(account2.address)
       chai.expect(initialOwners[2]).to.be.eq(account3.address)
-      const tx = await safeSdk1.getRemoveOwnerTx({ ownerAddress: account2.address })
+      const tx = await safeSdk1.createRemoveOwnerTx({ ownerAddress: account2.address })
       const signedTx1 = await safeSdk2.signTransaction(tx)
       const signedTx2 = await safeSdk3.signTransaction(signedTx1)
       const txResponse = await safeSdk1.executeTransaction(signedTx2)
@@ -441,7 +441,7 @@ describe('Safe owners manager', () => {
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
       chai.expect(initialOwners[1]).to.be.eq(account2.address)
       chai.expect(initialOwners[2]).to.be.eq(account3.address)
-      const tx = await safeSdk1.getRemoveOwnerTx({
+      const tx = await safeSdk1.createRemoveOwnerTx({
         ownerAddress: account1.address,
         threshold: newThreshold
       })
@@ -457,7 +457,7 @@ describe('Safe owners manager', () => {
     })
   })
 
-  describe('getSwapOwnerTx', async () => {
+  describe('createSwapOwnerTx', async () => {
     it('should fail if old address is invalid', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1, account2] = accounts
@@ -468,7 +468,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: '0x123',
         newOwnerAddress: account2.address
       })
@@ -485,7 +485,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: account1.address,
         newOwnerAddress: '0x123'
       })
@@ -502,7 +502,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: SENTINEL_ADDRESS,
         newOwnerAddress: account2.address
       })
@@ -519,7 +519,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: account1.address,
         newOwnerAddress: SENTINEL_ADDRESS
       })
@@ -536,7 +536,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: ZERO_ADDRESS,
         newOwnerAddress: account2.address
       })
@@ -553,7 +553,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: account1.address,
         newOwnerAddress: ZERO_ADDRESS
       })
@@ -570,7 +570,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: account4.address,
         newOwnerAddress: account2.address
       })
@@ -587,7 +587,7 @@ describe('Safe owners manager', () => {
         safeAddress: safe.address,
         contractNetworks
       })
-      const tx = safeSdk.getSwapOwnerTx({
+      const tx = safeSdk.createSwapOwnerTx({
         oldOwnerAddress: account1.address,
         newOwnerAddress: account1.address
       })
@@ -612,7 +612,7 @@ describe('Safe owners manager', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.getSwapOwnerTx(
+      const tx = await safeSdk.createSwapOwnerTx(
         { oldOwnerAddress: account1.address, newOwnerAddress: account2.address },
         options
       )
@@ -637,7 +637,7 @@ describe('Safe owners manager', () => {
       const initialOwners = await safeSdk.getOwners()
       chai.expect(initialOwners.length).to.be.eq(1)
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
-      const tx = await safeSdk.getSwapOwnerTx({
+      const tx = await safeSdk.createSwapOwnerTx({
         oldOwnerAddress: account1.address,
         newOwnerAddress: account2.address
       })
@@ -666,7 +666,7 @@ describe('Safe owners manager', () => {
       chai.expect(initialOwners[0]).to.be.eq(account1.address)
       chai.expect(initialOwners[1]).to.be.eq(account2.address)
       chai.expect(initialOwners[2]).to.be.eq(account3.address)
-      const tx = await safeSdk1.getSwapOwnerTx({
+      const tx = await safeSdk1.createSwapOwnerTx({
         oldOwnerAddress: account2.address,
         newOwnerAddress: account4.address
       })

--- a/packages/safe-core-sdk/tests/safeFactory.test.ts
+++ b/packages/safe-core-sdk/tests/safeFactory.test.ts
@@ -20,7 +20,7 @@ import { getAccounts } from './utils/setupTestNetwork'
 
 chai.use(chaiAsPromised)
 
-describe('Safe Proxy Factory', () => {
+describe('SafeProxyFactory', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     await deployments.fixture()
     const accounts = await getAccounts()
@@ -40,7 +40,7 @@ describe('Safe Proxy Factory', () => {
       const ethAdapter = await getEthAdapter(account1.signer)
       chai
         .expect(SafeFactory.create({ ethAdapter }))
-        .rejectedWith('Invalid Safe Proxy Factory contract')
+        .rejectedWith('Invalid SafeProxyFactory contract')
     })
 
     it('should fail if the contractNetworks provided are not deployed', async () => {
@@ -61,10 +61,10 @@ describe('Safe Proxy Factory', () => {
       }
       chai
         .expect(SafeFactory.create({ ethAdapter, contractNetworks }))
-        .rejectedWith('Safe Proxy Factory contract is not deployed on the current network')
+        .rejectedWith('SafeProxyFactory contract is not deployed on the current network')
     })
 
-    it('should instantiate the Safe Proxy Factory', async () => {
+    it('should instantiate the SafeProxyFactory', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)

--- a/packages/safe-core-sdk/tests/threshold.test.ts
+++ b/packages/safe-core-sdk/tests/threshold.test.ts
@@ -37,7 +37,7 @@ describe('Safe Threshold', () => {
     })
   })
 
-  describe('getChangeThresholdTx', async () => {
+  describe('createChangeThresholdTx', async () => {
     it('should fail if the threshold is bigger than the number of owners', async () => {
       const { safe, accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
@@ -51,7 +51,7 @@ describe('Safe Threshold', () => {
       const numOwners = (await safeSdk.getOwners()).length
       chai.expect(newThreshold).to.be.gt(numOwners)
       await chai
-        .expect(safeSdk.getChangeThresholdTx(newThreshold))
+        .expect(safeSdk.createChangeThresholdTx(newThreshold))
         .to.be.rejectedWith('Threshold cannot exceed owner count')
     })
 
@@ -66,7 +66,7 @@ describe('Safe Threshold', () => {
       })
       const newThreshold = 0
       await chai
-        .expect(safeSdk.getChangeThresholdTx(newThreshold))
+        .expect(safeSdk.createChangeThresholdTx(newThreshold))
         .to.be.rejectedWith('Threshold needs to be greater than 0')
     })
 
@@ -90,7 +90,7 @@ describe('Safe Threshold', () => {
         nonce: 555,
         safeTxGas: 666
       }
-      const tx = await safeSdk.getChangeThresholdTx(newThreshold, options)
+      const tx = await safeSdk.createChangeThresholdTx(newThreshold, options)
       chai.expect(tx.data.baseGas).to.be.eq(111)
       chai.expect(tx.data.gasPrice).to.be.eq(222)
       chai.expect(tx.data.gasToken).to.be.eq('0x333')
@@ -111,7 +111,7 @@ describe('Safe Threshold', () => {
       })
       const newThreshold = 2
       chai.expect(await safeSdk.getThreshold()).to.be.not.eq(newThreshold)
-      const tx = await safeSdk.getChangeThresholdTx(newThreshold)
+      const tx = await safeSdk.createChangeThresholdTx(newThreshold)
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       chai.expect(await safeSdk.getThreshold()).to.be.eq(newThreshold)

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -92,7 +92,7 @@ class EthersAdapter implements EthAdapter {
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
-      throw new Error('Invalid Safe Proxy contract address')
+      throw new Error('Invalid SafeProxy contract address')
     }
     return getSafeContractInstance(safeVersion, contractAddress, this.#signer)
   }
@@ -107,7 +107,7 @@ class EthersAdapter implements EthAdapter {
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
-      throw new Error('Invalid Multi Send contract address')
+      throw new Error('Invalid MultiSend contract address')
     }
     return getMultiSendContractInstance(safeVersion, contractAddress, this.#signer)
   }
@@ -137,7 +137,7 @@ class EthersAdapter implements EthAdapter {
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
-      throw new Error('Invalid Safe Proxy Factory contract address')
+      throw new Error('Invalid SafeProxyFactory contract address')
     }
     return getSafeProxyFactoryContractInstance(safeVersion, contractAddress, this.#signer)
   }

--- a/packages/safe-ethers-lib/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryEthersContract.ts
+++ b/packages/safe-ethers-lib/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryEthersContract.ts
@@ -53,7 +53,7 @@ class GnosisSafeProxyFactoryEthersContract implements GnosisSafeProxyFactoryCont
           ({ event }: Event) => event === 'ProxyCreation'
         )
         if (!proxyCreationEvent || !proxyCreationEvent.args) {
-          throw new Error('Safe Proxy was not deployed correctly')
+          throw new Error('SafeProxy was not deployed correctly')
         }
         const proxyAddress: string = proxyCreationEvent.args[0]
         return proxyAddress

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -82,7 +82,7 @@ class Web3Adapter implements EthAdapter {
   }: GetContractProps): GnosisSafeContractWeb3 {
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
-      throw new Error('Invalid Safe Proxy contract address')
+      throw new Error('Invalid SafeProxy contract address')
     }
     const safeContract = this.getContract(
       contractAddress,
@@ -100,7 +100,7 @@ class Web3Adapter implements EthAdapter {
   }: GetContractProps): MultiSendWeb3Contract {
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
-      throw new Error('Invalid Multi Send contract addresss')
+      throw new Error('Invalid MultiSend contract address')
     }
     const multiSendContract = this.getContract(
       contractAddress,
@@ -136,7 +136,7 @@ class Web3Adapter implements EthAdapter {
   }: GetContractProps): GnosisSafeProxyFactoryWeb3Contract {
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
-      throw new Error('Invalid Safe Proxy Factory contract address')
+      throw new Error('Invalid SafeProxyFactory contract address')
     }
     const proxyFactoryContract = this.getContract(
       contractAddress,

--- a/packages/safe-web3-lib/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryWeb3Contract.ts
+++ b/packages/safe-web3-lib/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryWeb3Contract.ts
@@ -57,7 +57,7 @@ class GnosisSafeProxyFactoryWeb3Contract implements GnosisSafeProxyFactoryContra
     )
     const proxyAddress = txResult.events?.ProxyCreation?.returnValues?.proxy
     if (!proxyAddress) {
-      throw new Error('Safe Proxy was not deployed correctly')
+      throw new Error('SafeProxy was not deployed correctly')
     }
     return proxyAddress
   }


### PR DESCRIPTION
## What it solves
Taking advantage of the next mayor release, this PR:
- Renames methods that return a Safe transaction that modifies the Safe settings.
  Example: `const safeTx = getAddOwnerTx(...)` -> `const safeTx = createAddOwnerTx(...)`
- Renames contract names in error messages
  Example: `Error: [...] Multi Send contract [...]` -> `Error: [...] MultiSend contract [...]`
- Updates tests and documentation accordingly