### PR TITLE
Update nonce type in `TransactionOptions`

### DIFF
--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -56,7 +56,7 @@ export interface TransactionOptions {
   gasPrice?: number | string
   maxFeePerGas?: number | string
   maxPriorityFeePerGas?: number | string
-  nonce?: number
+  nonce?: number | string
 }
 
 export interface BaseTransactionResult {


### PR DESCRIPTION
## What it solves
Updates the type of the `nonce` property inside `TransactionOptions` from `number` to `number | string` to increase the flexibility.
