### PR TITLE
Initialize EthAdapter with signers or providers

### DIFF
--- a/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
+++ b/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
@@ -64,7 +64,7 @@ export interface EthAdapter {
   getContractCode(address: string, defaultBlock?: string | number): Promise<string>
   isContractDeployed(address: string, defaultBlock?: string | number): Promise<boolean>
   getTransaction(transactionHash: string): Promise<any>
-  getSignerAddress(): Promise<string>
+  getSignerAddress(): Promise<string | undefined>
   signMessage(message: string): Promise<string>
   signTypedData(
     safeTransactionEIP712Args: SafeTransactionEIP712Args,

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -397,6 +397,9 @@ class Safe {
   ): Promise<SafeTransaction> {
     const owners = await this.getOwners()
     const signerAddress = await this.#ethAdapter.getSignerAddress()
+    if (!signerAddress) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     const addressIsOwner = owners.find(
       (owner: string) => signerAddress && sameString(owner, signerAddress)
     )
@@ -442,6 +445,9 @@ class Safe {
   ): Promise<TransactionResult> {
     const owners = await this.getOwners()
     const signerAddress = await this.#ethAdapter.getSignerAddress()
+    if (!signerAddress) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     const addressIsOwner = owners.find(
       (owner: string) => signerAddress && sameString(owner, signerAddress)
     )
@@ -647,6 +653,9 @@ class Safe {
     }
     const owners = await this.getOwners()
     const signerAddress = await this.#ethAdapter.getSignerAddress()
+    if (!signerAddress) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     if (owners.includes(signerAddress)) {
       signedSafeTransaction.addSignature(generatePreValidatedSignature(signerAddress))
     }

--- a/packages/safe-core-sdk/src/safeFactory/index.ts
+++ b/packages/safe-core-sdk/src/safeFactory/index.ts
@@ -187,6 +187,9 @@ class SafeFactory {
       validateSafeDeploymentConfig(safeDeploymentConfig)
     }
     const signerAddress = await this.#ethAdapter.getSignerAddress()
+    if (!signerAddress) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     const initializer = await this.encodeSetupCallData(safeAccountConfig)
     const saltNonce =
       safeDeploymentConfig?.saltNonce ??

--- a/packages/safe-core-sdk/src/utils/signatures/index.ts
+++ b/packages/safe-core-sdk/src/utils/signatures/index.ts
@@ -97,6 +97,9 @@ export async function generateSignature(
   hash: string
 ): Promise<EthSignSignature> {
   const signerAddress = await ethAdapter.getSignerAddress()
+  if (!signerAddress) {
+    throw new Error('EthAdapter must be initialized with a signer to use this method')
+  }
   let signature = await ethAdapter.signMessage(hash)
   signature = adjustVInSignature('eth_sign', signature, hash, signerAddress)
   return new EthSignSignature(signerAddress, signature)
@@ -108,6 +111,9 @@ export async function generateEIP712Signature(
   methodVersion?: 'v3' | 'v4'
 ): Promise<EthSignSignature> {
   const signerAddress = await ethAdapter.getSignerAddress()
+  if (!signerAddress) {
+    throw new Error('EthAdapter must be initialized with a signer to use this method')
+  }
   let signature = await ethAdapter.signTypedData(safeTransactionEIP712Args, methodVersion)
   signature = adjustVInSignature('eth_signTypedData', signature)
   return new EthSignSignature(signerAddress, signature)

--- a/packages/safe-core-sdk/tests/utils/setupEthAdapter.ts
+++ b/packages/safe-core-sdk/tests/utils/setupEthAdapter.ts
@@ -1,19 +1,22 @@
 import { Signer } from '@ethersproject/abstract-signer'
+import { Provider } from '@ethersproject/providers'
 import { EthAdapter } from '@gnosis.pm/safe-core-sdk-types'
 import EthersAdapter, { EthersAdapterConfig } from '@gnosis.pm/safe-ethers-lib'
 import Web3Adapter, { Web3AdapterConfig } from '@gnosis.pm/safe-web3-lib'
 import { ethers, web3 } from 'hardhat'
 
-export async function getEthAdapter(signer: Signer): Promise<EthAdapter> {
+export async function getEthAdapter(signerOrProvider: Signer | Provider): Promise<EthAdapter> {
   let ethAdapter: EthAdapter
   switch (process.env.ETH_LIB) {
     case 'web3':
-      const signerAddress = await signer.getAddress()
+      const signerAddress = (signerOrProvider instanceof Signer)
+        ? await signerOrProvider.getAddress()
+        : undefined
       const web3AdapterConfig: Web3AdapterConfig = { web3: web3 as any, signerAddress }
       ethAdapter = new Web3Adapter(web3AdapterConfig)
       break
     case 'ethers':
-      const ethersAdapterConfig: EthersAdapterConfig = { ethers, signer }
+      const ethersAdapterConfig: EthersAdapterConfig = { ethers, signerOrProvider }
       ethAdapter = new EthersAdapter(ethersAdapterConfig)
       break
     default:

--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -28,32 +28,37 @@ type Ethers = typeof ethers
 export interface EthersAdapterConfig {
   /** ethers - Ethers v5 library */
   ethers: Ethers
-  /** signer - Ethers signer */
-  signer: Signer
+  /** signerOrProvider - Ethers signer or provider */
+  signerOrProvider: Signer | Provider
 }
 
 class EthersAdapter implements EthAdapter {
   #ethers: Ethers
-  #signer: Signer
+  #signer?: Signer
   #provider: Provider
 
-  constructor({ ethers, signer }: EthersAdapterConfig) {
+  constructor({ ethers, signerOrProvider }: EthersAdapterConfig) {
     if (!ethers) {
       throw new Error('ethers property missing from options')
     }
-    if (!signer.provider) {
-      throw new Error('Signer must be connected to a provider')
-    }
-    this.#signer = signer
-    this.#provider = signer.provider
     this.#ethers = ethers
+    const isSigner = signerOrProvider instanceof Signer
+    if (isSigner) {
+      if (!signerOrProvider.provider) {
+        throw new Error('Signer must be connected to a provider')
+      }
+      this.#provider = signerOrProvider.provider
+      this.#signer = signerOrProvider
+    } else {
+      this.#provider = signerOrProvider
+    }
   }
 
   getProvider(): Provider {
     return this.#provider
   }
 
-  getSigner(): Signer {
+  getSigner(): Signer | undefined {
     return this.#signer
   }
 
@@ -94,7 +99,8 @@ class EthersAdapter implements EthAdapter {
     if (!contractAddress) {
       throw new Error('Invalid SafeProxy contract address')
     }
-    return getSafeContractInstance(safeVersion, contractAddress, this.#signer)
+    const signerOrProvider = this.#signer || this.#provider
+    return getSafeContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
   getMultiSendContract({
@@ -109,7 +115,8 @@ class EthersAdapter implements EthAdapter {
     if (!contractAddress) {
       throw new Error('Invalid MultiSend contract address')
     }
-    return getMultiSendContractInstance(safeVersion, contractAddress, this.#signer)
+    const signerOrProvider = this.#signer || this.#provider
+    return getMultiSendContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
   getMultiSendCallOnlyContract({
@@ -124,7 +131,8 @@ class EthersAdapter implements EthAdapter {
     if (!contractAddress) {
       throw new Error('Invalid MultiSendCallOnly contract address')
     }
-    return getMultiSendCallOnlyContractInstance(safeVersion, contractAddress, this.#signer)
+    const signerOrProvider = this.#signer || this.#provider
+    return getMultiSendCallOnlyContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
   getSafeProxyFactoryContract({
@@ -139,7 +147,8 @@ class EthersAdapter implements EthAdapter {
     if (!contractAddress) {
       throw new Error('Invalid SafeProxyFactory contract address')
     }
-    return getSafeProxyFactoryContractInstance(safeVersion, contractAddress, this.#signer)
+    const signerOrProvider = this.#signer || this.#provider
+    return getSafeProxyFactoryContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
   async getContractCode(address: string, blockTag?: string | number): Promise<string> {
@@ -155,16 +164,22 @@ class EthersAdapter implements EthAdapter {
     return this.#provider.getTransaction(transactionHash)
   }
 
-  async getSignerAddress(): Promise<string> {
-    return this.#signer.getAddress()
+  async getSignerAddress(): Promise<string | undefined> {
+    return this.#signer?.getAddress()
   }
 
   signMessage(message: string): Promise<string> {
+    if (!this.#signer) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     const messageArray = this.#ethers.utils.arrayify(message)
     return this.#signer.signMessage(messageArray)
   }
 
   async signTypedData(safeTransactionEIP712Args: SafeTransactionEIP712Args): Promise<string> {
+    if (!this.#signer) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     if (isTypedDataSigner(this.#signer)) {
       const typedData = generateTypedData(safeTransactionEIP712Args)
       const signature = await this.#signer._signTypedData(

--- a/packages/safe-ethers-lib/src/contracts/contractInstancesEthers.ts
+++ b/packages/safe-ethers-lib/src/contracts/contractInstancesEthers.ts
@@ -1,4 +1,5 @@
 import { Signer } from '@ethersproject/abstract-signer'
+import { Provider } from '@ethersproject/providers'
 import { SafeVersion } from '@gnosis.pm/safe-core-sdk-types'
 import { Gnosis_safe__factory as SafeMasterCopy_V1_1_1 } from '../../typechain/src/ethers-v5/v1.1.1/factories/Gnosis_safe__factory'
 import { Multi_send__factory as MultiSend_V1_1_1 } from '../../typechain/src/ethers-v5/v1.1.1/factories/Multi_send__factory'
@@ -20,7 +21,7 @@ import MultiSendCallOnlyContract_V1_3_0_Ethers from './MultiSendCallOnly/v1.3.0/
 export function getSafeContractInstance(
   safeVersion: SafeVersion,
   contractAddress: string,
-  signer: Signer
+  signerOrProvider: Signer | Provider
 ):
   | GnosisSafeContract_V1_3_0_Ethers
   | GnosisSafeContract_V1_2_0_Ethers
@@ -28,13 +29,13 @@ export function getSafeContractInstance(
   let safeContract
   switch (safeVersion) {
     case '1.3.0':
-      safeContract = SafeMasterCopy_V1_3_0.connect(contractAddress, signer)
+      safeContract = SafeMasterCopy_V1_3_0.connect(contractAddress, signerOrProvider)
       return new GnosisSafeContract_V1_3_0_Ethers(safeContract)
     case '1.2.0':
-      safeContract = SafeMasterCopy_V1_2_0.connect(contractAddress, signer)
+      safeContract = SafeMasterCopy_V1_2_0.connect(contractAddress, signerOrProvider)
       return new GnosisSafeContract_V1_2_0_Ethers(safeContract)
     case '1.1.1':
-      safeContract = SafeMasterCopy_V1_1_1.connect(contractAddress, signer)
+      safeContract = SafeMasterCopy_V1_1_1.connect(contractAddress, signerOrProvider)
       return new GnosisSafeContract_V1_1_1_Ethers(safeContract)
     default:
       throw new Error('Invalid Safe version')
@@ -44,16 +45,16 @@ export function getSafeContractInstance(
 export function getMultiSendContractInstance(
   safeVersion: SafeVersion,
   contractAddress: string,
-  signer: Signer
+  signerOrProvider: Signer | Provider
 ): MultiSendContract_V1_3_0_Ethers | MultiSendContract_V1_1_1_Ethers {
   let multiSendContract
   switch (safeVersion) {
     case '1.3.0':
-      multiSendContract = MultiSend_V1_3_0.connect(contractAddress, signer)
+      multiSendContract = MultiSend_V1_3_0.connect(contractAddress, signerOrProvider)
       return new MultiSendContract_V1_3_0_Ethers(multiSendContract)
     case '1.2.0':
     case '1.1.1':
-      multiSendContract = MultiSend_V1_1_1.connect(contractAddress, signer)
+      multiSendContract = MultiSend_V1_1_1.connect(contractAddress, signerOrProvider)
       return new MultiSendContract_V1_1_1_Ethers(multiSendContract)
     default:
       throw new Error('Invalid Safe version')
@@ -63,14 +64,14 @@ export function getMultiSendContractInstance(
 export function getMultiSendCallOnlyContractInstance(
   safeVersion: SafeVersion,
   contractAddress: string,
-  signer: Signer
+  signerOrProvider: Signer | Provider
 ): MultiSendCallOnlyContract_V1_3_0_Ethers {
   let multiSendCallOnlyContract
   switch (safeVersion) {
     case '1.3.0':
     case '1.2.0':
     case '1.1.1':
-      multiSendCallOnlyContract = MultiSendCallOnly_V1_3_0.connect(contractAddress, signer)
+      multiSendCallOnlyContract = MultiSendCallOnly_V1_3_0.connect(contractAddress, signerOrProvider)
       return new MultiSendCallOnlyContract_V1_3_0_Ethers(multiSendCallOnlyContract)
     default:
       throw new Error('Invalid Safe version')
@@ -80,16 +81,16 @@ export function getMultiSendCallOnlyContractInstance(
 export function getSafeProxyFactoryContractInstance(
   safeVersion: SafeVersion,
   contractAddress: string,
-  signer: Signer
+  signerOrProvider: Signer | Provider
 ): GnosisSafeProxyFactoryContract_V1_3_0_Ethers | GnosisSafeProxyFactoryContract_V1_1_1_Ethers {
   let gnosisSafeProxyFactoryContract
   switch (safeVersion) {
     case '1.3.0':
-      gnosisSafeProxyFactoryContract = SafeProxyFactory_V1_3_0.connect(contractAddress, signer)
+      gnosisSafeProxyFactoryContract = SafeProxyFactory_V1_3_0.connect(contractAddress, signerOrProvider)
       return new GnosisSafeProxyFactoryContract_V1_3_0_Ethers(gnosisSafeProxyFactoryContract)
     case '1.2.0':
     case '1.1.1':
-      gnosisSafeProxyFactoryContract = SafeProxyFactory_V1_1_1.connect(contractAddress, signer)
+      gnosisSafeProxyFactoryContract = SafeProxyFactory_V1_1_1.connect(contractAddress, signerOrProvider)
       return new GnosisSafeProxyFactoryContract_V1_1_1_Ethers(gnosisSafeProxyFactoryContract)
     default:
       throw new Error('Invalid Safe version')

--- a/packages/safe-service-client/tests/utils/setupEthAdapter.ts
+++ b/packages/safe-service-client/tests/utils/setupEthAdapter.ts
@@ -1,19 +1,22 @@
 import { Signer } from '@ethersproject/abstract-signer'
+import { Provider } from '@ethersproject/providers'
 import { EthAdapter } from '@gnosis.pm/safe-core-sdk-types'
 import EthersAdapter, { EthersAdapterConfig } from '@gnosis.pm/safe-ethers-lib'
 import Web3Adapter, { Web3AdapterConfig } from '@gnosis.pm/safe-web3-lib'
 import { ethers, web3 } from 'hardhat'
 
-export async function getEthAdapter(signer: Signer): Promise<EthAdapter> {
+export async function getEthAdapter(signerOrProvider: Signer | Provider): Promise<EthAdapter> {
   let ethAdapter: EthAdapter
   switch (process.env.ETH_LIB) {
     case 'web3':
-      const signerAddress = await signer.getAddress()
+      const signerAddress = (signerOrProvider instanceof Signer)
+        ? await signerOrProvider.getAddress()
+        : undefined
       const web3AdapterConfig: Web3AdapterConfig = { web3: web3 as any, signerAddress }
       ethAdapter = new Web3Adapter(web3AdapterConfig)
       break
     case 'ethers':
-      const ethersAdapterConfig: EthersAdapterConfig = { ethers, signer }
+      const ethersAdapterConfig: EthersAdapterConfig = { ethers, signerOrProvider }
       ethAdapter = new EthersAdapter(ethersAdapterConfig)
       break
     default:

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -27,12 +27,12 @@ export interface Web3AdapterConfig {
   /** web3 - Web3 library */
   web3: Web3
   /** signerAddress - Address of the signer */
-  signerAddress: string
+  signerAddress?: string
 }
 
 class Web3Adapter implements EthAdapter {
   #web3: Web3
-  #signerAddress: string
+  #signerAddress?: string
 
   constructor({ web3, signerAddress }: Web3AdapterConfig) {
     if (!web3) {
@@ -165,11 +165,14 @@ class Web3Adapter implements EthAdapter {
     return this.#web3.eth.getTransaction(transactionHash)
   }
 
-  async getSignerAddress(): Promise<string> {
+  async getSignerAddress(): Promise<string | undefined> {
     return this.#signerAddress
   }
 
   signMessage(message: string): Promise<string> {
+    if (!this.#signerAddress) {
+      throw new Error('EthAdapter must be initialized with a signer to use this method')
+    }
     return this.#web3.eth.sign(message, this.#signerAddress)
   }
 
@@ -177,6 +180,9 @@ class Web3Adapter implements EthAdapter {
     safeTransactionEIP712Args: SafeTransactionEIP712Args,
     methodVersion?: 'v3' | 'v4'
   ): Promise<string> {
+    if (!this.#signerAddress) {
+      throw new Error('This method requires a signer')
+    }
     const typedData = generateTypedData(safeTransactionEIP712Args)
     let method = 'eth_signTypedData_v3'
     if (methodVersion === 'v4') {


### PR DESCRIPTION
## What it solves
So far new instances of the `EthAdapter` class required a signer in the constructor. This PR allows to pass just a provider, restricting some of the methods for the ethAdapters that were initialized with a signer.

This logic was also expanded to the Safe Core SDK and the Safe Service Client.

**TO DO:**
- [ ] Update README files and the guides

- [ ] Add more tests
