### PR TITLE
Update Mainnet Transaction Service URL (do not merge yet!)

### DIFF
--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -48,7 +48,7 @@ As stated in the introduction, the [Safe Service Client](https://github.com/safe
 ```js
 import SafeServiceClient from '@gnosis.pm/safe-service-client'
 
-const txServiceUrl = 'https://safe-transaction.gnosis.io'
+const txServiceUrl = 'https://safe-transaction-mainnet.safe.global'
 const safeService = new SafeServiceClient({ txServiceUrl, ethAdapter })
 ```
 

--- a/packages/safe-ethers-adapters/README.md
+++ b/packages/safe-ethers-adapters/README.md
@@ -19,7 +19,7 @@ An example for such an account would be the private key of one of the owners tha
 const signer = new Wallet("some_private_key", ethereumProvider)
 ```
 
-It is also necessary to specify a service instance that should be used to publish the Safe transactions. An example for this would be the Mainnet instance of the [Safe Transaction Service](https://safe-transaction.gnosis.io/): `https://safe-transaction.gnosis.io/`
+It is also necessary to specify a service instance that should be used to publish the Safe transactions. An example for this would be the Mainnet instance of the [Safe Transaction Service](https://safe-transaction-mainnet.safe.global/): `https://safe-transaction-mainnet.safe.global/`
 
 ```js
 const service = new SafeService("some_service_url")

--- a/packages/safe-service-client/README.md
+++ b/packages/safe-service-client/README.md
@@ -51,7 +51,7 @@ Once the instance of `EthersAdapter` or `Web3Adapter` is created, it can be used
 import SafeServiceClient from '@gnosis.pm/safe-service-client'
 
 const safeService = new SafeServiceClient({
-  txServiceUrl: 'https://safe-transaction.gnosis.io',
+  txServiceUrl: 'https://safe-transaction-mainnet.safe.global',
   ethAdapter
 })
 ```


### PR DESCRIPTION
## What it solves
Safe Transaction Service URL's are being migrated during the month of October.

Specifically for Mainnet:
```
safe-transaction.mainnet.gnosis.io   -> safe-transaction-mainnet.safe.global  (DATE: 22-10-24 - 9am CEST)
safe-transaction.gnosis.io           -> safe-transaction-mainnet.safe.global  (DATE: 22-10-24 - 9am CEST)
```

## How this PR fixes it
This PR updates the old URLs with the new ones.

## Notes
Do not merge before the 24th of October!
