### PR TITLE
Update README.md for safe-ethers-adapters

### DIFF
--- a/packages/safe-ethers-adapters/README.md
+++ b/packages/safe-ethers-adapters/README.md
@@ -30,7 +30,8 @@ It may be obtained with:
 
 ```js
 import { ethers } from "ethers"
-import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
+import Safe from "@gnosis.pm/safe-core-sdk"
+import EthersAdapter from "@gnosis.pm/safe-ethers-lib"
 
 const safe = await Safe.create({
   ethAdapter: new EthersAdapter({ ethers, signer }),

--- a/packages/safe-ethers-adapters/README.md
+++ b/packages/safe-ethers-adapters/README.md
@@ -25,13 +25,26 @@ It is also necessary to specify a service instance that should be used to publis
 const service = new SafeService("some_service_url")
 ```
 
+A Safe instance must also be created before obtaining the signer.
+It may be obtained with:
+
+```js
+import { ethers } from "ethers"
+import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
+
+const safe = await Safe.create({
+  ethAdapter: new EthersAdapter({ ethers, signer }),
+  safeAddress: "some_safe_address"
+})
+```
+
 Using these components it is possible to create an instance of the `SafeEthersSigner`
 
 ```js
-const safeSigner = await SafeEthersSigner.create("some_safe_address", signer, service)
+const safeSigner = new SafeEthersSigner(safe, service, provider)
 ```
 
-See [examples](./examples) for more information.
+See [examples](/packages/safe-ethers-adapters/examples) for more information.
 
 ## Installation
 


### PR DESCRIPTION
## What it solves
- Updates the instructions for the safe-ethers-adapters package, using the correct types/values.
- Fixes the examples link. Currently, in NPM, it redirects to the `/examples` root directory of the repo rather than the package's /examples.
