### PR TITLE
respect passed safeTxGas if the safe is 1.3.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   parserOptions: {

--- a/packages/safe-core-sdk/src/utils/transactions/utils.ts
+++ b/packages/safe-core-sdk/src/utils/transactions/utils.ts
@@ -59,7 +59,6 @@ export async function standardizeSafeTransactionData(
       standardizedTxs.operation
     )
   }
-  console.log({safeTxGas})
   return {
     ...standardizedTxs,
     safeTxGas

--- a/packages/safe-core-sdk/src/utils/transactions/utils.ts
+++ b/packages/safe-core-sdk/src/utils/transactions/utils.ts
@@ -34,13 +34,19 @@ export async function standardizeSafeTransactionData(
     operation: tx.operation ?? OperationType.Call,
     baseGas: tx.baseGas ?? 0,
     gasPrice: tx.gasPrice ?? 0,
+    safeTxGas: tx.safeTxGas ?? 0,
     gasToken: tx.gasToken || ZERO_ADDRESS,
     refundReceiver: tx.refundReceiver || ZERO_ADDRESS,
     nonce: tx.nonce ?? (await safeContract.getNonce())
   }
   let safeTxGas: number
   const safeVersion = await safeContract.getVersion()
-  if (hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, safeVersion) && standardizedTxs.gasPrice === 0) {
+
+  if (
+    hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, safeVersion) &&
+    standardizedTxs.gasPrice === 0 &&
+    standardizedTxs.safeTxGas === 0
+  ) {
     safeTxGas = 0
   } else {
     safeTxGas =

--- a/packages/safe-core-sdk/src/utils/transactions/utils.ts
+++ b/packages/safe-core-sdk/src/utils/transactions/utils.ts
@@ -34,32 +34,32 @@ export async function standardizeSafeTransactionData(
     operation: tx.operation ?? OperationType.Call,
     baseGas: tx.baseGas ?? 0,
     gasPrice: tx.gasPrice ?? 0,
-    safeTxGas: tx.safeTxGas ?? 0,
     gasToken: tx.gasToken || ZERO_ADDRESS,
     refundReceiver: tx.refundReceiver || ZERO_ADDRESS,
     nonce: tx.nonce ?? (await safeContract.getNonce())
   }
   let safeTxGas: number
-  const safeVersion = await safeContract.getVersion()
 
-  if (
-    hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, safeVersion) &&
-    standardizedTxs.gasPrice === 0 &&
-    standardizedTxs.safeTxGas === 0
-  ) {
+  if (tx.safeTxGas) {
+    return {
+      ...standardizedTxs,
+      safeTxGas: tx.safeTxGas
+    }
+  }
+  const safeVersion = await safeContract.getVersion()
+  if (hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, safeVersion) && standardizedTxs.gasPrice === 0) {
     safeTxGas = 0
   } else {
-    safeTxGas =
-      tx.safeTxGas ??
-      (await estimateTxGas(
-        safeContract,
-        ethAdapter,
-        standardizedTxs.to,
-        standardizedTxs.value,
-        standardizedTxs.data,
-        standardizedTxs.operation
-      ))
+    safeTxGas = await estimateTxGas(
+      safeContract,
+      ethAdapter,
+      standardizedTxs.to,
+      standardizedTxs.value,
+      standardizedTxs.data,
+      standardizedTxs.operation
+    )
   }
+  console.log({safeTxGas})
   return {
     ...standardizedTxs,
     safeTxGas

--- a/packages/safe-core-sdk/tests/createTransaction.test.ts
+++ b/packages/safe-core-sdk/tests/createTransaction.test.ts
@@ -386,4 +386,29 @@ describe('Transactions creation', () => {
       chai.expect(multiSendTx.data.safeTxGas).to.be.eq(666)
     })
   })
+
+  it('should respect passed safeTxGas option', async () => {
+    const { accounts, contractNetworks, chainId } = await setupTests()
+    const [account1] = accounts
+    const safe = await getSafeWithOwners([account1.address])
+    const ethAdapter = await getEthAdapter(account1.signer)
+    const safeSdk = await Safe.create({
+      ethAdapter,
+      safeAddress: safe.address,
+      contractNetworks
+    })
+    const options: SafeTransactionOptionalProps = {
+      safeTxGas: 666
+    }
+    const safeTransactionData: MetaTransactionData[] = [
+      {
+        to: `0xbeef${'0'.repeat(38)}`,
+        value: '0',
+        data: '0x'
+      }
+    ]
+    const multiSendTx = await safeSdk.createTransaction({ safeTransactionData, options })
+
+    chai.expect(multiSendTx.data.safeTxGas).to.be.eq(options.safeTxGas)
+  })
 })

--- a/packages/safe-core-sdk/tests/createTransaction.test.ts
+++ b/packages/safe-core-sdk/tests/createTransaction.test.ts
@@ -82,7 +82,7 @@ describe('Transactions creation', () => {
     )
 
     itif(safeVersionDeployed >= '1.3.0')(
-      'should return a transaction with defined safeTxGas if safeVersion>=1.3.0 and gasPrice>0',
+      'should return a transaction with defined safeTxGas if safeVersion>=1.3.0',
       async () => {
         const { accounts, contractNetworks } = await setupTests()
         const [account1, account2] = accounts
@@ -98,8 +98,7 @@ describe('Transactions creation', () => {
           to: account2.address,
           value: '0',
           data: '0x',
-          safeTxGas,
-          gasPrice: 123
+          safeTxGas
         }
         const safeTxData = await standardizeSafeTransactionData(
           safeSdk.getContractManager().safeContract,
@@ -196,7 +195,7 @@ describe('Transactions creation', () => {
       chai.expect(tx.data.gasToken).to.be.eq('0x333')
       chai.expect(tx.data.refundReceiver).to.be.eq('0x444')
       chai.expect(tx.data.nonce).to.be.eq(555)
-      chai.expect(tx.data.safeTxGas).to.be.eq(safeVersionDeployed >= '1.3.0' ? 0 : 666)
+      chai.expect(tx.data.safeTxGas).to.be.eq(666)
     })
 
     it('should create a single transaction with gasPrice>0', async () => {
@@ -385,30 +384,5 @@ describe('Transactions creation', () => {
       chai.expect(multiSendTx.data.nonce).to.be.eq(555)
       chai.expect(multiSendTx.data.safeTxGas).to.be.eq(666)
     })
-  })
-
-  it('should respect passed safeTxGas option', async () => {
-    const { accounts, contractNetworks, chainId } = await setupTests()
-    const [account1] = accounts
-    const safe = await getSafeWithOwners([account1.address])
-    const ethAdapter = await getEthAdapter(account1.signer)
-    const safeSdk = await Safe.create({
-      ethAdapter,
-      safeAddress: safe.address,
-      contractNetworks
-    })
-    const options: SafeTransactionOptionalProps = {
-      safeTxGas: 666
-    }
-    const safeTransactionData: MetaTransactionData[] = [
-      {
-        to: `0xbeef${'0'.repeat(38)}`,
-        value: '0',
-        data: '0x'
-      }
-    ]
-    const multiSendTx = await safeSdk.createTransaction({ safeTransactionData, options })
-
-    chai.expect(multiSendTx.data.safeTxGas).to.be.eq(options.safeTxGas)
   })
 })


### PR DESCRIPTION
## What it solves
- Resolves #292 
- Updates eslint configuration after prettier plugin 8.0.0 update - more info [here](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21) (it's from early 2021 lol)

## How this PR fixes it
Currently, the SDK doesn't take into account the `safeTxGas` unless you pass the full suite of relay-related params with the most important being `gasPrice`

In my opinion, it's not 100% justified because `safeTxGas` still has some use cases, like ensuring that enough gas is supplied for the transaction. I'm sure there's more that advanced EVM ninjas can share.



