### PR TITLE
Fix fallbackHandlerAbi to optional property

### DIFF
--- a/packages/safe-core-sdk/src/types/index.ts
+++ b/packages/safe-core-sdk/src/types/index.ts
@@ -20,7 +20,7 @@ export interface ContractNetworkConfig {
   /** fallbackHandlerAddress - Address of the Fallback Handler contract deployed on a specific network */
   fallbackHandlerAddress: string
   /** fallbackHandlerAbi - Abi of the Fallback Handler contract deployed on a specific network */
-  fallbackHandlerAbi: AbiItem | AbiItem[]
+  fallbackHandlerAbi?: AbiItem | AbiItem[]
   /** signMessageLibAddress - Address of the SignMessageLib contract deployed on a specific network */
   signMessageLibAddress: string
   /** signMessageLibAbi - Abi of the SignMessageLib contract deployed on a specific network */


### PR DESCRIPTION
## What it solves
It makes the `fallbackHandlerAbi` property in `ContractNetworkConfig` optional
