### PR TITLE
fix: Handle 0 safeTxGas when passed to createTransaction call

### DIFF
--- a/packages/safe-core-sdk/src/utils/transactions/utils.ts
+++ b/packages/safe-core-sdk/src/utils/transactions/utils.ts
@@ -40,7 +40,7 @@ export async function standardizeSafeTransactionData(
   }
   let safeTxGas: number
 
-  if (tx.safeTxGas) {
+  if (typeof tx.safeTxGas !== 'undefined') {
     return {
       ...standardizedTxs,
       safeTxGas: tx.safeTxGas

--- a/packages/safe-core-sdk/tests/createTransaction.test.ts
+++ b/packages/safe-core-sdk/tests/createTransaction.test.ts
@@ -136,7 +136,7 @@ describe('Transactions creation', () => {
     )
 
     itif(safeVersionDeployed < '1.3.0')(
-      'should return a transaction with defined safeTxGas if safeVersion<1.3.0',
+      'should return a transaction with defined safeTxGas of 0 if safeVersion<1.3.0',
       async () => {
         const { accounts, contractNetworks } = await setupTests()
         const [account1, account2] = accounts
@@ -148,6 +148,34 @@ describe('Transactions creation', () => {
           contractNetworks
         })
         const safeTxGas = 0
+        const txDataPartial: SafeTransactionDataPartial = {
+          to: account2.address,
+          value: '0',
+          data: '0x',
+          safeTxGas
+        }
+        const safeTxData = await standardizeSafeTransactionData(
+          safeSdk.getContractManager().safeContract,
+          ethAdapter,
+          txDataPartial
+        )
+        chai.expect(safeTxData.safeTxGas).to.be.eq(safeTxGas)
+      }
+    )
+
+    itif(safeVersionDeployed < '1.3.0')(
+      'should return a transaction with defined safeTxGas if safeVersion<1.3.0',
+      async () => {
+        const { accounts, contractNetworks } = await setupTests()
+        const [account1, account2] = accounts
+        const safe = await getSafeWithOwners([account1.address])
+        const ethAdapter = await getEthAdapter(account1.signer)
+        const safeSdk = await Safe.create({
+          ethAdapter,
+          safeAddress: safe.address,
+          contractNetworks
+        })
+        const safeTxGas = 111
         const txDataPartial: SafeTransactionDataPartial = {
           to: account2.address,
           value: '0',

--- a/packages/safe-core-sdk/tests/createTransaction.test.ts
+++ b/packages/safe-core-sdk/tests/createTransaction.test.ts
@@ -147,7 +147,7 @@ describe('Transactions creation', () => {
           safeAddress: safe.address,
           contractNetworks
         })
-        const safeTxGas = 111
+        const safeTxGas = 0
         const txDataPartial: SafeTransactionDataPartial = {
           to: account2.address,
           value: '0',


### PR DESCRIPTION
## What it solves
Resolves [#1343](https://github.com/safe-global/web-core/issues/1343)

If a transaction is created with 0 safeTxGas in the web-core UI and another owner tries to sign it, the `createTransaction` call from the SDK will return a non 0 safeTxGas which causes issues with the existing txData (such as gasLimit estimation failing).

## How this PR fixes it

Narrow the condition to check for `undefined` so that a `safeTxGas` of 0 is caught by it.