### PR TITLE
fix: allow EthersAdapter to correctly recognize Signer objects from o…

### DIFF
--- a/packages/safe-ethers-lib/src/EthersAdapter.ts
+++ b/packages/safe-ethers-lib/src/EthersAdapter.ts
@@ -48,7 +48,7 @@ class EthersAdapter implements EthAdapter {
       throw new Error('ethers property missing from options')
     }
     this.#ethers = ethers
-    const isSigner = signerOrProvider instanceof Signer
+    const isSigner = signerOrProvider instanceof ethers.Signer
     if (isSigner) {
       const signer = signerOrProvider as Signer
       if (!signer.provider) {


### PR DESCRIPTION
…lder ethers

## What it solves
Resolves #336

## How this PR fixes it
Checking whether `signerOrProvider` is Signer against the provided `ethers`'s Signer from the constructor parameters instead.