### PR TITLE
Update collectibles endpoint to v2

### DIFF
--- a/packages/safe-ethers-adapters/package.json
+++ b/packages/safe-ethers-adapters/package.json
@@ -38,6 +38,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.11.18",
+    "@types/sinon-chai": "^3.2.9",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
     "chai": "^4.3.7",

--- a/packages/safe-service-client/README.md
+++ b/packages/safe-service-client/README.md
@@ -311,19 +311,21 @@ const usdBalances: SafeBalanceUsdResponse[] = await safeService.getUsdBalances(s
 
 ### getCollectibles
 
-Returns the collectives (ERC721 tokens) owned by the given Safe and information about them.
+Returns the collectibles (ERC721 tokens) owned by the given Safe and information about them.
 
 ```js
-const collectibles: SafeCollectibleResponse[] = await safeService.getCollectibles(safeAddress)
+const collectibles: SafeCollectibleListResponse = await safeService.getCollectibles(safeAddress)
 ```
 
 This method can optionally receive the `options` parameter:
 
 ```js
 const options: SafeCollectiblesOptions = {
+  limit // Optional. Default value is 10. This limit is the maximum available value per service limitation.
+  offset // Optional. Default value is 0.
   excludeSpamTokens // Optional. Default value is `true`.
 }
-const collectibles: SafeCollectibleResponse[] = await safeService.getCollectibles(safeAddress, options)
+const collectibles: SafeCollectibleListResponse = await safeService.getCollectibles(safeAddress, options)
 ```
 
 ### getTokenList

--- a/packages/safe-service-client/package.json
+++ b/packages/safe-service-client/package.json
@@ -44,6 +44,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",
+    "@types/sinon-chai": "^3.2.9",
     "@types/yargs": "^16.0.1",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",

--- a/packages/safe-service-client/src/SafeServiceClient.ts
+++ b/packages/safe-service-client/src/SafeServiceClient.ts
@@ -60,7 +60,7 @@ class SafeServiceClient implements SafeTransactionService {
    */
   async getServiceInfo(): Promise<SafeServiceInfoResponse> {
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/about`,
+      url: `${this.#txServiceBaseUrl}/v1/about`,
       method: HttpMethod.Get
     })
   }
@@ -72,7 +72,7 @@ class SafeServiceClient implements SafeTransactionService {
    */
   async getServiceMasterCopiesInfo(): Promise<MasterCopyResponse[]> {
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/about/master-copies`,
+      url: `${this.#txServiceBaseUrl}/v1/about/master-copies`,
       method: HttpMethod.Get
     })
   }
@@ -91,7 +91,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid data')
     }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/data-decoder/`,
+      url: `${this.#txServiceBaseUrl}/v1/data-decoder/`,
       method: HttpMethod.Post,
       body: { data }
     })
@@ -111,7 +111,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(ownerAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/owners/${address}/safes/`,
+      url: `${this.#txServiceBaseUrl}/v1/owners/${address}/safes/`,
       method: HttpMethod.Get
     })
   }
@@ -130,7 +130,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(moduleAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/modules/${address}/safes/`,
+      url: `${this.#txServiceBaseUrl}/v1/modules/${address}/safes/`,
       method: HttpMethod.Get
     })
   }
@@ -148,7 +148,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid safeTxHash')
     }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/multisig-transactions/${safeTxHash}/`,
+      url: `${this.#txServiceBaseUrl}/v1/multisig-transactions/${safeTxHash}/`,
       method: HttpMethod.Get
     })
   }
@@ -167,7 +167,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid safeTxHash')
     }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/multisig-transactions/${safeTxHash}/confirmations/`,
+      url: `${this.#txServiceBaseUrl}/v1/multisig-transactions/${safeTxHash}/confirmations/`,
       method: HttpMethod.Get
     })
   }
@@ -191,7 +191,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid signature')
     }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/multisig-transactions/${safeTxHash}/confirmations/`,
+      url: `${this.#txServiceBaseUrl}/v1/multisig-transactions/${safeTxHash}/confirmations/`,
       method: HttpMethod.Post,
       body: {
         signature
@@ -213,7 +213,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/`,
       method: HttpMethod.Get
     })
   }
@@ -232,7 +232,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/delegates/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/delegates/`,
       method: HttpMethod.Get
     })
   }
@@ -273,7 +273,7 @@ class SafeServiceClient implements SafeTransactionService {
       signature
     }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${safeAddress}/delegates/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${safeAddress}/delegates/`,
       method: HttpMethod.Post,
       body
     })
@@ -299,7 +299,7 @@ class SafeServiceClient implements SafeTransactionService {
     const data = address + totp
     const signature = await signer.signMessage(data)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/delegates/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/delegates/`,
       method: HttpMethod.Delete,
       body: { signature }
     })
@@ -329,7 +329,7 @@ class SafeServiceClient implements SafeTransactionService {
     const data = delegateAddress + totp
     const signature = await signer.signMessage(data)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${safeAddress}/delegates/${delegateAddress}`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${safeAddress}/delegates/${delegateAddress}`,
       method: HttpMethod.Delete,
       body: {
         safe: safeAddress,
@@ -355,7 +355,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/creation/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/creation/`,
       method: HttpMethod.Get
     })
   }
@@ -380,7 +380,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/multisig-transactions/estimations/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/multisig-transactions/estimations/`,
       method: HttpMethod.Post,
       body: safeTransaction
     })
@@ -413,7 +413,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid safeTxHash')
     }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${safe}/multisig-transactions/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${safe}/multisig-transactions/`,
       method: HttpMethod.Post,
       body: {
         ...safeTransactionData,
@@ -439,7 +439,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/incoming-transfers/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/incoming-transfers/`,
       method: HttpMethod.Get
     })
   }
@@ -459,7 +459,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/module-transactions/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/module-transactions/`,
       method: HttpMethod.Get
     })
   }
@@ -478,7 +478,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${address}/multisig-transactions/`,
+      url: `${this.#txServiceBaseUrl}/v1/safes/${address}/multisig-transactions/`,
       method: HttpMethod.Get
     })
   }
@@ -501,11 +501,11 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid Safe address')
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
-    let nonce = currentNonce ? currentNonce : (await this.getSafeInfo(address)).nonce
+    const nonce = currentNonce ? currentNonce : (await this.getSafeInfo(address)).nonce
     return sendRequest({
       url: `${
         this.#txServiceBaseUrl
-      }/safes/${address}/multisig-transactions/?executed=false&nonce__gte=${nonce}`,
+      }/v1/safes/${address}/multisig-transactions/?executed=false&nonce__gte=${nonce}`,
       method: HttpMethod.Get
     })
   }
@@ -526,7 +526,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid Safe address')
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
-    const url = new URL(`${this.#txServiceBaseUrl}/safes/${address}/all-transactions/`)
+    const url = new URL(`${this.#txServiceBaseUrl}/v1/safes/${address}/all-transactions/`)
 
     const trusted = options?.trusted?.toString() || 'true'
     url.searchParams.set('trusted', trusted)
@@ -584,7 +584,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid Safe address')
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
-    let url = new URL(`${this.#txServiceBaseUrl}/safes/${address}/balances/`)
+    const url = new URL(`${this.#txServiceBaseUrl}/v1/safes/${address}/balances/`)
     const excludeSpam = options?.excludeSpamTokens?.toString() || 'true'
     url.searchParams.set('exclude_spam', excludeSpam)
 
@@ -608,7 +608,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid Safe address')
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
-    let url = new URL(`${this.#txServiceBaseUrl}/safes/${address}/balances/usd/`)
+    const url = new URL(`${this.#txServiceBaseUrl}/v1/safes/${address}/balances/usd/`)
     const excludeSpam = options?.excludeSpamTokens?.toString() || 'true'
     url.searchParams.set('exclude_spam', excludeSpam)
 
@@ -632,7 +632,7 @@ class SafeServiceClient implements SafeTransactionService {
       throw new Error('Invalid Safe address')
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
-    let url = new URL(`${this.#txServiceBaseUrl}/safes/${address}/collectibles/`)
+    const url = new URL(`${this.#txServiceBaseUrl}/v1/safes/${address}/collectibles/`)
     const excludeSpam = options?.excludeSpamTokens?.toString() || 'true'
     url.searchParams.set('exclude_spam', excludeSpam)
 
@@ -646,7 +646,7 @@ class SafeServiceClient implements SafeTransactionService {
    */
   async getTokenList(): Promise<TokenInfoListResponse> {
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/tokens/`,
+      url: `${this.#txServiceBaseUrl}/v1/tokens/`,
       method: HttpMethod.Get
     })
   }
@@ -665,7 +665,7 @@ class SafeServiceClient implements SafeTransactionService {
     }
     const { address } = await this.#ethAdapter.getEip3770Address(tokenAddress)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/tokens/${address}/`,
+      url: `${this.#txServiceBaseUrl}/v1/tokens/${address}/`,
       method: HttpMethod.Get
     })
   }

--- a/packages/safe-service-client/src/SafeServiceClient.ts
+++ b/packages/safe-service-client/src/SafeServiceClient.ts
@@ -16,7 +16,7 @@ import {
   SafeBalancesOptions,
   SafeBalancesUsdOptions,
   SafeBalanceUsdResponse,
-  SafeCollectibleResponse,
+  SafeCollectibleListResponse,
   SafeCollectiblesOptions,
   SafeCreationInfoResponse,
   SafeDelegate,
@@ -616,23 +616,33 @@ class SafeServiceClient implements SafeTransactionService {
   }
 
   /**
-   * Returns the collectives (ERC721 tokens) owned by the given Safe and information about them.
+   * Returns the collectibles (ERC721 tokens) owned by the given Safe and information about them.
    *
-   * @param safeAddress - The Safe address
-   * @param options - API params
-   * @returns The collectives owned by the given Safe
+   * @param {string} safeAddress - The Safe address
+   * @param {Object} options - API params
+   * @param {number} options.limit
+   * @param {number} options.offset
+   * @param {boolean} options.excludeSpamTokens
+   * @returns The collectibles owned by the given Safe
    * @throws "Invalid Safe address"
    * @throws "Checksum address validation failed"
    */
   async getCollectibles(
     safeAddress: string,
     options?: SafeCollectiblesOptions
-  ): Promise<SafeCollectibleResponse[]> {
+  ): Promise<SafeCollectibleListResponse> {
     if (safeAddress === '') {
       throw new Error('Invalid Safe address')
     }
     const { address } = await this.#ethAdapter.getEip3770Address(safeAddress)
-    const url = new URL(`${this.#txServiceBaseUrl}/v1/safes/${address}/collectibles/`)
+    const url = new URL(`${this.#txServiceBaseUrl}/v2/safes/${address}/collectibles/`)
+
+    const limit = options?.limit?.toString() || '10'
+    url.searchParams.set('limit', limit)
+
+    const offset = options?.offset?.toString() || '0'
+    url.searchParams.set('offset', offset)
+
     const excludeSpam = options?.excludeSpamTokens?.toString() || 'true'
     url.searchParams.set('exclude_spam', excludeSpam)
 

--- a/packages/safe-service-client/src/SafeTransactionService.ts
+++ b/packages/safe-service-client/src/SafeTransactionService.ts
@@ -11,7 +11,7 @@ import {
   SafeBalancesOptions,
   SafeBalancesUsdOptions,
   SafeBalanceUsdResponse,
-  SafeCollectibleResponse,
+  SafeCollectibleListResponse,
   SafeCollectiblesOptions,
   SafeCreationInfoResponse,
   SafeDelegate,
@@ -85,7 +85,7 @@ interface SafeTransactionService {
   getCollectibles(
     safeAddress: string,
     options?: SafeCollectiblesOptions
-  ): Promise<SafeCollectibleResponse[]>
+  ): Promise<SafeCollectibleListResponse>
 
   // Tokens
   getTokenList(): Promise<TokenInfoListResponse>

--- a/packages/safe-service-client/src/types/safeTransactionServiceTypes.ts
+++ b/packages/safe-service-client/src/types/safeTransactionServiceTypes.ts
@@ -190,6 +190,8 @@ export type SafeBalanceUsdResponse = {
 }
 
 export type SafeCollectiblesOptions = {
+  limit?: number
+  offset?: number
   excludeSpamTokens?: boolean
 }
 
@@ -204,6 +206,13 @@ export type SafeCollectibleResponse = {
   readonly description: string
   readonly imageUri: string
   readonly metadata: any
+}
+
+export type SafeCollectibleListResponse = {
+  readonly count: number
+  readonly next?: string
+  readonly previous?: string
+  readonly results: SafeCollectibleResponse[]
 }
 
 export type TokenInfoResponse = {

--- a/packages/safe-service-client/src/utils/index.ts
+++ b/packages/safe-service-client/src/utils/index.ts
@@ -1,3 +1,3 @@
 export function getTxServiceBaseUrl(txServiceUrl: string): string {
-  return `${txServiceUrl}/api/v1`
+  return `${txServiceUrl}/api`
 }

--- a/packages/safe-service-client/tests/e2e/getCollectibles.test.ts
+++ b/packages/safe-service-client/tests/e2e/getCollectibles.test.ts
@@ -31,9 +31,10 @@ describe('getCollectibles', () => {
 
   it('should return the list of collectibles', async () => {
     const safeAddress = '0x72c346260a4887F0231af41178C1c818Ce34543f'
-    const safeCollectibleResponse = await serviceSdk.getCollectibles(safeAddress)
-    chai.expect(safeCollectibleResponse.length).to.be.equal(1)
-    safeCollectibleResponse.map((safeCollectible) => {
+    const safeCollectibleListResponse = await serviceSdk.getCollectibles(safeAddress)
+    chai.expect(safeCollectibleListResponse.count).to.be.equal(1)
+    chai.expect(safeCollectibleListResponse.results.length).to.be.equal(1)
+    safeCollectibleListResponse.results.map((safeCollectible) => {
       chai.expect(safeCollectible.address).to.be.equal('0x39Ec448b891c476e166b3C3242A90830DB556661')
       chai.expect(safeCollectible.tokenName).to.be.equal("Frank's Art Sale")
     })
@@ -42,9 +43,10 @@ describe('getCollectibles', () => {
   it('should return the list of collectibles EIP-3770', async () => {
     const safeAddress = '0x72c346260a4887F0231af41178C1c818Ce34543f'
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
-    const safeCollectibleResponse = await serviceSdk.getCollectibles(eip3770SafeAddress)
-    chai.expect(safeCollectibleResponse.length).to.be.equal(1)
-    safeCollectibleResponse.map((safeCollectible) => {
+    const safeCollectibleListResponse = await serviceSdk.getCollectibles(eip3770SafeAddress)
+    chai.expect(safeCollectibleListResponse.count).to.be.equal(1)
+    chai.expect(safeCollectibleListResponse.results.length).to.be.equal(1)
+    safeCollectibleListResponse.results.map((safeCollectible) => {
       chai.expect(safeCollectible.address).to.be.equal('0x39Ec448b891c476e166b3C3242A90830DB556661')
       chai.expect(safeCollectible.tokenName).to.be.equal("Frank's Art Sale")
     })

--- a/packages/safe-service-client/tests/endpoint/index.test.ts
+++ b/packages/safe-service-client/tests/endpoint/index.test.ts
@@ -56,7 +56,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getServiceInfo())
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/about`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/about`,
         method: 'get'
       })
     })
@@ -66,7 +66,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getServiceMasterCopiesInfo())
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/about/master-copies`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/about/master-copies`,
         method: 'get'
       })
     })
@@ -77,7 +77,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.decodeData(data))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/data-decoder/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/data-decoder/`,
         method: 'post',
         body: { data }
       })
@@ -88,7 +88,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafesByOwner(randomAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/owners/${randomAddress}/safes/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/owners/${randomAddress}/safes/`,
         method: 'get'
       })
     })
@@ -98,7 +98,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafesByOwner(eip3770RandomAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/owners/${randomAddress}/safes/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/owners/${randomAddress}/safes/`,
         method: 'get'
       })
     })
@@ -108,7 +108,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafesByModule(randomAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/modules/${randomAddress}/safes/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/modules/${randomAddress}/safes/`,
         method: 'get'
       })
     })
@@ -118,7 +118,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafesByModule(eip3770RandomAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/modules/${randomAddress}/safes/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/modules/${randomAddress}/safes/`,
         method: 'get'
       })
     })
@@ -128,7 +128,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getTransaction(safeTxHash))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/multisig-transactions/${safeTxHash}/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/multisig-transactions/${safeTxHash}/`,
         method: 'get'
       })
     })
@@ -140,7 +140,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/multisig-transactions/${safeTxHash}/confirmations/`,
+        )}/v1/multisig-transactions/${safeTxHash}/confirmations/`,
         method: 'get'
       })
     })
@@ -153,7 +153,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/multisig-transactions/${safeTxHash}/confirmations/`,
+        )}/v1/multisig-transactions/${safeTxHash}/confirmations/`,
         method: 'get'
       })
     })
@@ -163,7 +163,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafeInfo(safeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/`,
         method: 'get'
       })
     })
@@ -173,7 +173,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafeInfo(eip3770SafeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/`,
         method: 'get'
       })
     })
@@ -183,7 +183,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafeDelegates(safeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/`,
         method: 'get'
       })
     })
@@ -193,7 +193,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafeDelegates(eip3770SafeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/`,
         method: 'get'
       })
     })
@@ -209,7 +209,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.addSafeDelegate(delegateConfig))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/`,
         method: 'get'
       })
     })
@@ -225,7 +225,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.addSafeDelegate(delegateConfig))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/`,
         method: 'get'
       })
     })
@@ -238,7 +238,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.removeAllSafeDelegates(safeAddress, signer))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/`,
         method: 'delete',
         body: { signature }
       })
@@ -252,7 +252,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.removeAllSafeDelegates(eip3770SafeAddress, signer))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/`,
         method: 'delete',
         body: { signature }
       })
@@ -272,7 +272,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.removeSafeDelegate(delegateConfig))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/${
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/delegates/${
           delegateConfig.delegate
         }`,
         method: 'delete',
@@ -300,7 +300,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/delegates/${delegateAddress}`,
+        )}/v1/safes/${safeAddress}/delegates/${delegateAddress}`,
         method: 'delete',
         body: {
           safe: safeAddress,
@@ -315,7 +315,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafeCreationInfo(safeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/creation/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/creation/`,
         method: 'get'
       })
     })
@@ -325,7 +325,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getSafeCreationInfo(eip3770SafeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/creation/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/creation/`,
         method: 'get'
       })
     })
@@ -343,7 +343,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/multisig-transactions/estimations/`,
+        )}/v1/safes/${safeAddress}/multisig-transactions/estimations/`,
         method: 'post',
         body: safeTransaction
       })
@@ -362,7 +362,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/multisig-transactions/estimations/`,
+        )}/v1/safes/${safeAddress}/multisig-transactions/estimations/`,
         method: 'post',
         body: safeTransaction
       })
@@ -399,7 +399,7 @@ describe('Endpoint tests', () => {
         )
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/multisig-transactions/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/multisig-transactions/`,
         method: 'post',
         body: {
           ...safeTransactionData,
@@ -442,7 +442,7 @@ describe('Endpoint tests', () => {
         )
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/multisig-transactions/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/multisig-transactions/`,
         method: 'post',
         body: {
           ...safeTransactionData,
@@ -459,7 +459,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getIncomingTransactions(safeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/incoming-transfers/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/incoming-transfers/`,
         method: 'get'
       })
     })
@@ -469,7 +469,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getIncomingTransactions(eip3770SafeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/incoming-transfers/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/incoming-transfers/`,
         method: 'get'
       })
     })
@@ -479,7 +479,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getModuleTransactions(safeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/module-transactions/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/module-transactions/`,
         method: 'get'
       })
     })
@@ -489,7 +489,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getModuleTransactions(eip3770SafeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/module-transactions/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/module-transactions/`,
         method: 'get'
       })
     })
@@ -499,7 +499,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getMultisigTransactions(safeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/multisig-transactions/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/multisig-transactions/`,
         method: 'get'
       })
     })
@@ -509,7 +509,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getMultisigTransactions(eip3770SafeAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/multisig-transactions/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/safes/${safeAddress}/multisig-transactions/`,
         method: 'get'
       })
     })
@@ -522,7 +522,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/multisig-transactions/?executed=false&nonce__gte=${currentNonce}`,
+        )}/v1/safes/${safeAddress}/multisig-transactions/?executed=false&nonce__gte=${currentNonce}`,
         method: 'get'
       })
     })
@@ -535,7 +535,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/multisig-transactions/?executed=false&nonce__gte=${currentNonce}`,
+        )}/v1/safes/${safeAddress}/multisig-transactions/?executed=false&nonce__gte=${currentNonce}`,
         method: 'get'
       })
     })
@@ -547,7 +547,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/all-transactions/?trusted=true&queued=true&executed=false`,
+        )}/v1/safes/${safeAddress}/all-transactions/?trusted=true&queued=true&executed=false`,
         method: 'get'
       })
     })
@@ -559,7 +559,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/all-transactions/?trusted=true&queued=true&executed=false`,
+        )}/v1/safes/${safeAddress}/all-transactions/?trusted=true&queued=true&executed=false`,
         method: 'get'
       })
     })
@@ -571,7 +571,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/balances/?exclude_spam=true`,
+        )}/v1/safes/${safeAddress}/balances/?exclude_spam=true`,
         method: 'get'
       })
     })
@@ -583,7 +583,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/balances/?exclude_spam=true`,
+        )}/v1/safes/${safeAddress}/balances/?exclude_spam=true`,
         method: 'get'
       })
     })
@@ -598,7 +598,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/balances/?exclude_spam=false`,
+        )}/v1/safes/${safeAddress}/balances/?exclude_spam=false`,
         method: 'get'
       })
     })
@@ -610,7 +610,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/balances/usd/?exclude_spam=true`,
+        )}/v1/safes/${safeAddress}/balances/usd/?exclude_spam=true`,
         method: 'get'
       })
     })
@@ -622,7 +622,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/balances/usd/?exclude_spam=true`,
+        )}/v1/safes/${safeAddress}/balances/usd/?exclude_spam=true`,
         method: 'get'
       })
     })
@@ -637,7 +637,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/balances/usd/?exclude_spam=false`,
+        )}/v1/safes/${safeAddress}/balances/usd/?exclude_spam=false`,
         method: 'get'
       })
     })
@@ -649,7 +649,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/collectibles/?exclude_spam=true`,
+        )}/v1/safes/${safeAddress}/collectibles/?exclude_spam=true`,
         method: 'get'
       })
     })
@@ -661,7 +661,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/collectibles/?exclude_spam=true`,
+        )}/v1/safes/${safeAddress}/collectibles/?exclude_spam=true`,
         method: 'get'
       })
     })
@@ -676,7 +676,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/safes/${safeAddress}/collectibles/?exclude_spam=false`,
+        )}/v1/safes/${safeAddress}/collectibles/?exclude_spam=false`,
         method: 'get'
       })
     })
@@ -686,7 +686,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getTokenList())
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/tokens/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/tokens/`,
         method: 'get'
       })
     })
@@ -696,7 +696,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getToken(tokenAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/tokens/${tokenAddress}/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/tokens/${tokenAddress}/`,
         method: 'get'
       })
     })
@@ -706,7 +706,7 @@ describe('Endpoint tests', () => {
         .expect(serviceSdk.getToken(eip3770TokenAddress))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
-        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/tokens/${tokenAddress}/`,
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/v1/tokens/${tokenAddress}/`,
         method: 'get'
       })
     })

--- a/packages/safe-service-client/tests/endpoint/index.test.ts
+++ b/packages/safe-service-client/tests/endpoint/index.test.ts
@@ -649,7 +649,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/v1/safes/${safeAddress}/collectibles/?exclude_spam=true`,
+        )}/v2/safes/${safeAddress}/collectibles/?limit=10&offset=0&exclude_spam=true`,
         method: 'get'
       })
     })
@@ -661,13 +661,15 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/v1/safes/${safeAddress}/collectibles/?exclude_spam=true`,
+        )}/v2/safes/${safeAddress}/collectibles/?limit=10&offset=0&exclude_spam=true`,
         method: 'get'
       })
     })
 
     it('getCollectibles (with options)', async () => {
       const options: SafeCollectiblesOptions = {
+        limit: 2,
+        offset: 1,
         excludeSpamTokens: false
       }
       await chai
@@ -676,7 +678,7 @@ describe('Endpoint tests', () => {
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${getTxServiceBaseUrl(
           txServiceBaseUrl
-        )}/v1/safes/${safeAddress}/collectibles/?exclude_spam=false`,
+        )}/v2/safes/${safeAddress}/collectibles/?limit=2&offset=1&exclude_spam=false`,
         method: 'get'
       })
     })

--- a/packages/safe-web3-lib/package.json
+++ b/packages/safe-web3-lib/package.json
@@ -35,6 +35,7 @@
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@typechain/web3-v1": "^6.0.2",
     "@types/node": "^18.11.18",
+    "@types/web3": "1.0.19",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
     "eslint": "^8.32.0",

--- a/packages/safe-web3-lib/src/Web3Adapter.ts
+++ b/packages/safe-web3-lib/src/Web3Adapter.ts
@@ -11,6 +11,9 @@ import Web3 from 'web3'
 import { Transaction } from 'web3-core'
 import { ContractOptions } from 'web3-eth-contract'
 import { AbiItem } from 'web3-utils'
+// TODO remove @types/web3 when migrating to web3@v4
+// Deprecated https://www.npmjs.com/package/@types/web3?activeTab=readme
+// Migration guide https://docs.web3js.org/docs/guides/web3_migration_guide#types
 import type { JsonRPCResponse, Provider } from 'web3/providers'
 import CompatibilityFallbackHandlerWeb3Contract from './contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerWeb3Contract'
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,17 +2340,17 @@
   dependencies:
     bignumber.js "*"
 
+"@types/bn.js@*", "@types/bn.js@^5.1.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.1.tgz#b51e1b55920a4ca26e9285ff79936bbdec910682"
+  integrity sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.5":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/bn.js@^5.1.0":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.1.tgz#b51e1b55920a4ca26e9285ff79936bbdec910682"
-  integrity sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==
   dependencies:
     "@types/node" "*"
 
@@ -2576,6 +2576,19 @@
   dependencies:
     "@types/mime" "*"
     "@types/node" "*"
+
+"@types/underscore@*":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.4.tgz#62e393f8bc4bd8a06154d110c7d042a93751def3"
+  integrity sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==
+
+"@types/web3@1.0.19":
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.19.tgz#46b85d91d398ded9ab7c85a5dd57cb33ac558924"
+  integrity sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==
+  dependencies:
+    "@types/bn.js" "*"
+    "@types/underscore" "*"
 
 "@types/yargs-parser@*":
   version "21.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,6 +2577,26 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/sinon-chai@^3.2.9":
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.9.tgz#71feb938574bbadcb176c68e5ff1a6014c5e69d4"
+  integrity sha512-/19t63pFYU0ikrdbXKBWj9PCdnKyTd0Qkz0X91Ta081cYsq90OxYdcWwK/dwEoDa6dtXgj2HJfmzgq+QZTHdmQ==
+  dependencies:
+    "@types/chai" "*"
+    "@types/sinon" "*"
+
+"@types/sinon@*":
+  version "10.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.13.tgz#60a7a87a70d9372d0b7b38cc03e825f46981fb83"
+  integrity sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
+  integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
+
 "@types/underscore@*":
   version "1.11.4"
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.4.tgz#62e393f8bc4bd8a06154d110c7d042a93751def3"


### PR DESCRIPTION
## What it solves
- [BREAKING CHANGE] Upgrade the `collectibles` endpoint to v2 with pagination support.
- Fix a web3 types issue now that @types/web3 was deprecated with web3@v4 launch.

## How this PR fixes it
- Updated all endpoints to have versioning.
- [BREAKING CHANGE] Use collectibles v2 and add new properties to the endpoint
- Use fixed version of `@types/web3` until web3@v4 migration or can be changed by web3@v1 native types.