### PR TITLE
Check meta transaction array by `isArray` instead of `length` prop

### DIFF
--- a/packages/safe-core-sdk/src/utils/index.ts
+++ b/packages/safe-core-sdk/src/utils/index.ts
@@ -25,7 +25,7 @@ export function isRestrictedAddress(address: string): boolean {
 export function isMetaTransactionArray(
   safeTransactions: SafeTransactionDataPartial | MetaTransactionData[]
 ): safeTransactions is MetaTransactionData[] {
-  return (safeTransactions as MetaTransactionData[])?.length !== undefined
+  return Array.isArray(safeTransactions)
 }
 
 export function isSafeMultisigTransactionResponse(


### PR DESCRIPTION
## What it solves

Use prop `length` can somehow confuse with object and string type


## How this PR fixes it

Use `Array.isArray` to check if a given tx is an array in `isMetaTransactionArray` method


