### PR TITLE
Add account-abstraction-sdk

### DIFF
--- a/packages/account-abstraction-kit/README.md
+++ b/packages/account-abstraction-kit/README.md
@@ -1,0 +1,44 @@
+# Safe Account Abstraction SDK
+
+[![NPM Version](https://badge.fury.io/js/%40safe-global%2Faccount-abstraction.svg)](https://badge.fury.io/js/%40safe-global%2Faccount-abstraction-kit-poc)
+[![GitHub Release](https://img.shields.io/github/release/safe-global/account-abstraction-sdk.svg?style=flat)](https://github.com/safe-global/account-abstraction-sdk/releases)
+[![GitHub](https://img.shields.io/github/license/safe-global/account-abstraction-sdk)](https://github.com/safe-global/account-abstraction-sdk/blob/main/LICENSE.md)
+
+Description TBD
+
+## Table of contents
+
+- [Installation](#installation)
+- [Build](#build)
+- [Initialization](#initialization)
+- [License](#license)
+
+## <a name="installation">Installation</a>
+
+Install the package with yarn or npm:
+
+```bash
+yarn install
+npm install
+```
+
+## <a name="build">Build</a>
+
+Build the package with yarn or npm:
+
+```bash
+yarn build
+npm build
+```
+
+## <a name="initialization">Initialization</a>
+
+Initialization TBD
+
+```js
+
+```
+
+## <a name="license">License</a>
+
+This library is [released under MIT](https://github.com/safe-global/account-abstraction-sdk/blob/main/LICENSE.md).

--- a/packages/account-abstraction-kit/package.json
+++ b/packages/account-abstraction-kit/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@safe-global/account-abstraction-kit-poc",
+  "version": "0.1.0-alpha.1",
+  "description": "Safe Account Abstraction",
+  "main": "dist/src/index.js",
+  "typings": "dist/src/index.d.ts",
+  "scripts": {
+    "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
+    "format": "prettier --write */**/*.{js,json,md,ts}",
+    "unbuild": "rm -rf dist typechain",
+    "build": "rm -rf dist && ts-node ./scripts/typechain && yarn tsc",
+    "test": "echo \"Error: no test specified\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/safe-global/account-abstraction-sdk.git"
+  },
+  "keywords": [
+    "Safe",
+    "Ethereum",
+    "Account Abstraction",
+    "SDK"
+  ],
+  "author": "Safe (https://safe.global)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/safe-global/account-abstraction-sdk/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://github.com/safe-global/account-abstraction-sdk#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@typechain/ethers-v5": "^10.2.0",
+    "typechain": "^8.1.1"
+  },
+  "dependencies": {
+    "@gnosis.pm/safe-contracts": "^1.3.0",
+    "@safe-global/relay-kit": "^0.1.0-alpha.2",
+    "@safe-global/safe-core-sdk": "^3.3.2",
+    "@safe-global/safe-deployments": "^1.20.2",
+    "@safe-global/safe-ethers-lib": "^1.9.2",
+    "ethereumjs-util": "^7.1.5",
+    "ethers": "^5.7.2"
+  }
+}

--- a/packages/account-abstraction-kit/scripts/typechain.ts
+++ b/packages/account-abstraction-kit/scripts/typechain.ts
@@ -1,0 +1,22 @@
+import { glob, runTypeChain } from 'typechain'
+
+const safeContractsRoute = '../../node_modules/@gnosis.pm/safe-contracts/build/artifacts/contracts'
+
+async function main() {
+  const cwd = process.cwd()
+  // find all files matching the glob
+  const allFiles = glob(cwd, [
+    `${safeContractsRoute}/GnosisSafe.sol/GnosisSafe.json`,
+    `${safeContractsRoute}/proxies/GnosisSafeProxyFactory.sol/GnosisSafeProxyFactory.json`,
+    `${safeContractsRoute}/libraries/MultiSendCallOnly.sol/MultiSendCallOnly.json`
+  ])
+  const result = await runTypeChain({
+    cwd,
+    filesToProcess: allFiles,
+    allFiles,
+    outDir: 'typechain',
+    target: 'ethers-v5'
+  })
+}
+
+main().catch(console.error)

--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -1,0 +1,177 @@
+import { RelayAdapter } from '@safe-global/relay-kit'
+import Safe from '@safe-global/safe-core-sdk'
+import EthersAdapter from '@safe-global/safe-ethers-lib'
+import { ethers } from 'ethers'
+import { GnosisSafe__factory } from '../typechain/factories'
+import { GnosisSafe } from '../typechain/GnosisSafe'
+import { MultiSendCallOnly } from '../typechain/libraries'
+import { GnosisSafeProxyFactory } from '../typechain/proxies'
+import {
+  AccountAbstractionConfig,
+  MetaTransactionData,
+  MetaTransactionOptions,
+  OperationType,
+  RelayTransaction
+} from './types'
+import { getMultiSendCallOnlyContract, getSafeContract, getSafeProxyFactoryContract } from './utils'
+import {
+  calculateChainSpecificProxyAddress,
+  encodeCreateProxyWithNonce,
+  encodeExecTransaction,
+  encodeMultiSendData,
+  getSafeInitializer
+} from './utils/contracts'
+
+class AccountAbstraction {
+  #signer: ethers.Signer
+  #chainId?: number
+  #safeContract?: GnosisSafe
+  #safeProxyFactoryContract?: GnosisSafeProxyFactory
+  #multiSendCallOnlyContract?: MultiSendCallOnly
+  #relayAdapter?: RelayAdapter
+
+  constructor(signer: ethers.Signer) {
+    this.#signer = signer
+  }
+
+  async init(options: AccountAbstractionConfig) {
+    if (!this.#signer.provider) {
+      throw new Error('Signer must be connected to a provider')
+    }
+    const { relayAdapter } = options
+    this.setRelayAdapter(relayAdapter)
+
+    this.#chainId = (await this.#signer.provider.getNetwork()).chainId
+    this.#safeProxyFactoryContract = getSafeProxyFactoryContract(this.#chainId, this.#signer)
+    this.#multiSendCallOnlyContract = getMultiSendCallOnlyContract(this.#chainId, this.#signer)
+    const safeAddress = await calculateChainSpecificProxyAddress(
+      this.#safeProxyFactoryContract,
+      this.#signer,
+      this.#chainId
+    )
+    this.#safeContract = GnosisSafe__factory.connect(safeAddress, this.#signer)
+  }
+
+  setRelayAdapter(relayAdapter: RelayAdapter) {
+    this.#relayAdapter = relayAdapter
+  }
+
+  async getSignerAddress(): Promise<string> {
+    const signerAddress = await this.#signer.getAddress()
+    return signerAddress
+  }
+
+  async getNonce(): Promise<number> {
+    if (!this.#safeContract) {
+      throw new Error('SDK not initialized')
+    }
+    return (await this.isSafeDeployed()) ? (await this.#safeContract.nonce()).toNumber() : 0
+  }
+
+  getSafeAddress(): string {
+    if (!this.#safeContract) {
+      throw new Error('SDK not initialized')
+    }
+    return this.#safeContract.address
+  }
+
+  async isSafeDeployed(): Promise<boolean> {
+    if (!this.#signer.provider) {
+      throw new Error('SDK not initialized')
+    }
+    const address = this.getSafeAddress()
+    const codeAtAddress = await this.#signer.provider.getCode(address)
+    const isDeployed = codeAtAddress !== '0x'
+    return isDeployed
+  }
+
+  async relayTransaction(
+    transactions: MetaTransactionData[],
+    options: MetaTransactionOptions
+  ): Promise<string> {
+    if (
+      !this.#relayAdapter ||
+      !this.#chainId ||
+      !this.#safeContract ||
+      !this.#multiSendCallOnlyContract ||
+      !this.#safeProxyFactoryContract
+    ) {
+      throw new Error('SDK not initialized')
+    }
+
+    const safeAddress = this.getSafeAddress()
+
+    const ethAdapter = new EthersAdapter({
+      ethers,
+      signerOrProvider: this.#signer
+    })
+    const safe = await Safe.create({
+      ethAdapter,
+      safeAddress
+    })
+
+    const standardizedSafeTx = await this.#relayAdapter.createRelayedTransaction(
+      safe,
+      transactions,
+      options
+    )
+
+    const signedSafeTx = await safe.signTransaction(standardizedSafeTx)
+
+    const transactionData = encodeExecTransaction(
+      this.#safeContract,
+      signedSafeTx.data,
+      signedSafeTx.encodedSignatures()
+    )
+
+    let relayTransactionTarget = ''
+    let encodedTransaction = ''
+    const isSafeDeployed = await this.isSafeDeployed()
+    if (isSafeDeployed) {
+      relayTransactionTarget = this.#safeContract.address
+      encodedTransaction = transactionData
+    } else {
+      relayTransactionTarget = this.#multiSendCallOnlyContract.address
+      const safeSingletonContract = getSafeContract(this.#chainId, this.#signer)
+      const initializer = await getSafeInitializer(
+        this.#safeContract,
+        await this.getSignerAddress(),
+        this.#chainId
+      )
+
+      const safeDeploymentTransaction: MetaTransactionData = {
+        to: this.#safeProxyFactoryContract.address,
+        value: '0',
+        data: encodeCreateProxyWithNonce(
+          this.#safeProxyFactoryContract,
+          safeSingletonContract.address,
+          initializer
+        ),
+        operation: OperationType.Call
+      }
+      const safeTransaction: MetaTransactionData = {
+        to: this.#safeContract.address,
+        value: '0',
+        data: transactionData,
+        operation: OperationType.Call
+      }
+
+      const multiSendData = encodeMultiSendData([safeDeploymentTransaction, safeTransaction])
+      encodedTransaction = this.#multiSendCallOnlyContract.interface.encodeFunctionData(
+        'multiSend',
+        [multiSendData]
+      )
+    }
+
+    const relayTransaction: RelayTransaction = {
+      target: relayTransactionTarget,
+      encodedTransaction: encodedTransaction,
+      chainId: this.#chainId,
+      options
+    }
+    const response = await this.#relayAdapter.relayTransaction(relayTransaction)
+    return response.taskId
+  }
+}
+
+export default AccountAbstraction

--- a/packages/account-abstraction-kit/src/constants/index.ts
+++ b/packages/account-abstraction-kit/src/constants/index.ts
@@ -1,0 +1,5 @@
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+// keccak256(toUtf8Bytes('Safe Account Abstraction'))
+export const PREDETERMINED_SALT_NONCE =
+  '0xb1073742015cbcf5a3a4d9d1ae33ecf619439710b89475f92e2abd2117e90f90'

--- a/packages/account-abstraction-kit/src/index.ts
+++ b/packages/account-abstraction-kit/src/index.ts
@@ -1,0 +1,4 @@
+import AccountAbstraction from './AccountAbstraction'
+
+export default AccountAbstraction
+export * from './types'

--- a/packages/account-abstraction-kit/src/types/index.ts
+++ b/packages/account-abstraction-kit/src/types/index.ts
@@ -1,0 +1,58 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { RelayAdapter } from '@safe-global/relay-kit'
+
+export enum OperationType {
+  Call,
+  DelegateCall
+}
+
+export interface AccountAbstractionConfig {
+  relayAdapter: RelayAdapter
+}
+
+export interface MetaTransactionData {
+  to: string
+  value: string
+  data: string
+  operation?: OperationType
+}
+
+export interface SafeTransactionData extends MetaTransactionData {
+  operation: OperationType
+  safeTxGas: number
+  baseGas: number
+  gasPrice: number
+  gasToken: string
+  refundReceiver: string
+  nonce: number
+}
+
+// TO-DO: Duplicated. Remove local type and import from "types" package
+// {
+
+export interface MetaTransactionOptions {
+  gasLimit: BigNumber
+  gasToken?: string
+  isSponsored?: boolean
+}
+
+export interface RelayTransaction {
+  target: string
+  encodedTransaction: string
+  chainId: number
+  options: MetaTransactionOptions
+}
+
+// import { RelayResponse } from '@gelatonetwork/relay-sdk'
+export interface RelayResponse {
+  taskId: string
+}
+
+// }
+// TO-DO: Duplicated. Remove local type and import from "types" package
+
+export interface SafeSetupConfig {
+  owners: string[]
+  threshold: number
+  fallbackHandlerAddress: string
+}

--- a/packages/account-abstraction-kit/src/utils/contracts.ts
+++ b/packages/account-abstraction-kit/src/utils/contracts.ts
@@ -1,0 +1,117 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { arrayify, BytesLike } from '@ethersproject/bytes'
+import { pack as solidityPack } from '@ethersproject/solidity'
+import { BigNumberish, ethers, Signer } from 'ethers'
+import { GnosisSafe } from '../../typechain/GnosisSafe'
+import { GnosisSafeProxyFactory } from '../../typechain/proxies/GnosisSafeProxyFactory'
+import { PREDETERMINED_SALT_NONCE, ZERO_ADDRESS } from '../constants'
+import { MetaTransactionData, SafeTransactionData } from '../types'
+import {
+  getCompatibilityFallbackHandlerAddress,
+  getSafeContract,
+  getSafeProxyFactoryContract
+} from './deployments'
+
+export function encodeCreateProxyWithNonce(
+  safeProxyFactoryContract: GnosisSafeProxyFactory,
+  safeSingletonAddress: string,
+  initializer: string
+) {
+  return safeProxyFactoryContract.interface.encodeFunctionData('createProxyWithNonce', [
+    safeSingletonAddress,
+    initializer,
+    PREDETERMINED_SALT_NONCE
+  ])
+}
+
+export function encodeSetupCallData(
+  safeContract: GnosisSafe,
+  owners: string[],
+  chainId: number
+): string {
+  return safeContract.interface.encodeFunctionData('setup', [
+    owners,
+    BigNumber.from(1) as BigNumberish,
+    ZERO_ADDRESS,
+    '0x' as BytesLike,
+    getCompatibilityFallbackHandlerAddress(chainId),
+    ZERO_ADDRESS,
+    BigNumber.from(0) as BigNumberish,
+    ZERO_ADDRESS
+  ])
+}
+
+export function encodeExecTransaction(
+  safeContract: GnosisSafe,
+  transaction: SafeTransactionData,
+  signature: string
+): string {
+  return safeContract.interface.encodeFunctionData('execTransaction', [
+    transaction.to,
+    transaction.value,
+    transaction.data,
+    transaction.operation,
+    transaction.safeTxGas,
+    transaction.baseGas,
+    transaction.gasPrice,
+    transaction.gasToken,
+    transaction.refundReceiver,
+    signature
+  ])
+}
+
+function encodeMetaTransaction(tx: MetaTransactionData): string {
+  const data = arrayify(tx.data)
+  const encoded = solidityPack(
+    ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+    [tx.operation, tx.to, tx.value, data.length, data]
+  )
+  return encoded.slice(2)
+}
+
+export function encodeMultiSendData(txs: MetaTransactionData[]): string {
+  return '0x' + txs.map((tx) => encodeMetaTransaction(tx)).join('')
+}
+
+export async function getSafeInitializer(
+  safeContract: GnosisSafe,
+  signerAddress: string,
+  chainId: number
+): Promise<string> {
+  const initializer = await encodeSetupCallData(safeContract, [signerAddress], chainId)
+  return initializer
+}
+
+export async function calculateChainSpecificProxyAddress(
+  safeProxyFactoryContract: GnosisSafeProxyFactory,
+  signer: Signer,
+  chainId: number
+): Promise<string> {
+  const safeSingletonContract = getSafeContract(chainId, signer)
+  const deployer = safeProxyFactoryContract.address
+  const signerAddress = await signer.getAddress()
+
+  const deploymentCode = ethers.utils.solidityPack(
+    ['bytes', 'uint256'],
+    [
+      await getSafeProxyFactoryContract(chainId, signer).proxyCreationCode(),
+      safeSingletonContract.address
+    ]
+  )
+  const salt = ethers.utils.solidityKeccak256(
+    ['bytes32', 'uint256'],
+    [
+      ethers.utils.solidityKeccak256(
+        ['bytes'],
+        [await getSafeInitializer(safeSingletonContract, signerAddress, chainId)]
+      ),
+      PREDETERMINED_SALT_NONCE
+    ]
+  )
+  const derivedAddress = ethers.utils.getCreate2Address(
+    deployer,
+    salt,
+    ethers.utils.keccak256(deploymentCode)
+  )
+  return derivedAddress
+}

--- a/packages/account-abstraction-kit/src/utils/deployments.ts
+++ b/packages/account-abstraction-kit/src/utils/deployments.ts
@@ -1,0 +1,88 @@
+import {
+  DeploymentFilter,
+  getCompatibilityFallbackHandlerDeployment,
+  getMultiSendCallOnlyDeployment,
+  getProxyFactoryDeployment,
+  getSafeL2SingletonDeployment,
+  getSafeSingletonDeployment
+} from '@safe-global/safe-deployments'
+import { ethers } from 'ethers'
+import { GnosisSafe__factory } from '../../typechain/factories'
+import { MultiSendCallOnly__factory } from '../../typechain/factories/libraries'
+import { GnosisSafeProxyFactory__factory } from '../../typechain/factories/proxies'
+import { GnosisSafe } from '../../typechain/GnosisSafe'
+import { MultiSendCallOnly } from './../../typechain/libraries/MultiSendCallOnly'
+import { GnosisSafeProxyFactory } from './../../typechain/proxies/GnosisSafeProxyFactory'
+
+export const safeDeploymentsL1ChainIds: number[] = [
+  1 // Ethereum Mainnet
+]
+
+export function getSafeContract(
+  chainId: number,
+  signer: ethers.Signer,
+  isL1SafeMasterCopy = false
+): GnosisSafe {
+  const filters: DeploymentFilter = {
+    version: '1.3.0', // Only Safe v1.3.0 supported so far
+    network: chainId.toString(),
+    released: true
+  }
+  const contractDeployment =
+    safeDeploymentsL1ChainIds.includes(chainId) || isL1SafeMasterCopy
+      ? getSafeSingletonDeployment(filters)
+      : getSafeL2SingletonDeployment(filters)
+  const contractAddress = contractDeployment?.networkAddresses[chainId]
+  if (!contractAddress) {
+    throw new Error('Invalid SafeProxy contract address')
+  }
+  const contract = GnosisSafe__factory.connect(contractAddress, signer)
+  return contract
+}
+
+export function getSafeProxyFactoryContract(
+  chainId: number,
+  signer: ethers.Signer
+): GnosisSafeProxyFactory {
+  const contractDeployment = getProxyFactoryDeployment({
+    version: '1.3.0', // Only Safe v1.3.0 supported so far
+    network: chainId.toString(),
+    released: true
+  })
+  const contractAddress = contractDeployment?.networkAddresses[chainId]
+  if (!contractAddress) {
+    throw new Error('Invalid SafeProxyFactory contract address')
+  }
+  const contract = GnosisSafeProxyFactory__factory.connect(contractAddress, signer)
+  return contract
+}
+
+export function getMultiSendCallOnlyContract(
+  chainId: number,
+  signer: ethers.Signer
+): MultiSendCallOnly {
+  const contractDeployment = getMultiSendCallOnlyDeployment({
+    version: '1.3.0', // Only Safe v1.3.0 supported so far
+    network: chainId.toString(),
+    released: true
+  })
+  const contractAddress = contractDeployment?.networkAddresses[chainId]
+  if (!contractAddress) {
+    throw new Error('Invalid MultiSendCallOnly contract address')
+  }
+  const contract = MultiSendCallOnly__factory.connect(contractAddress, signer)
+  return contract
+}
+
+export function getCompatibilityFallbackHandlerAddress(chainId: number): string {
+  const contractDeployment = getCompatibilityFallbackHandlerDeployment({
+    version: '1.3.0', // Only Safe v1.3.0 supported so far
+    network: chainId.toString(),
+    released: true
+  })
+  const contractAddress = contractDeployment?.networkAddresses[chainId]
+  if (!contractAddress) {
+    throw new Error('Invalid CompatibilityFallbackHandler contract address')
+  }
+  return contractAddress
+}

--- a/packages/account-abstraction-kit/src/utils/index.ts
+++ b/packages/account-abstraction-kit/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './contracts'
+export * from './deployments'

--- a/packages/account-abstraction-kit/tsconfig.json
+++ b/packages/account-abstraction-kit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "baseUrl": "src"
+  },
+  "include": ["src", "typechain"]
+}


### PR DESCRIPTION
## What it solves
Adds the package `account-abstraction-sdk` to this monorepo.
The package is refactored in the [next PR](https://github.com/safe-global/safe-core-sdk/pull/364) so it is easier to track the changes