### PR TITLE
Duplicated code cleanup

### DIFF
--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -1,5 +1,6 @@
 import { RelayAdapter } from '@safe-global/relay-kit'
 import Safe, {
+  encodeMultiSendData,
   EthersAdapter,
   getMultiSendCallOnlyContract,
   getProxyFactoryContract,
@@ -21,7 +22,6 @@ import {
 import {
   calculateChainSpecificProxyAddress,
   encodeCreateProxyWithNonce,
-  encodeMultiSendData,
   getSafeInitializer
 } from '@safe-global/account-abstraction-kit-poc/utils/contracts'
 

--- a/packages/account-abstraction-kit/src/utils/contracts.ts
+++ b/packages/account-abstraction-kit/src/utils/contracts.ts
@@ -1,13 +1,10 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { arrayify, BytesLike } from '@ethersproject/bytes'
-import { pack as solidityPack } from '@ethersproject/solidity'
+import { BytesLike } from '@ethersproject/bytes'
 import { getCompatibilityFallbackHandlerContract, getSafeContract } from '@safe-global/protocol-kit'
 import {
   EthAdapter,
   GnosisSafeContract,
   GnosisSafeProxyFactoryContract,
-  MetaTransactionData,
-  SafeTransactionData,
   SafeVersion
 } from '@safe-global/safe-core-sdk-types'
 import { BigNumberish, ethers, Signer } from 'ethers'
@@ -28,7 +25,7 @@ export function encodeCreateProxyWithNonce(
   ])
 }
 
-export async function encodeSetupCallData(
+async function encodeSetupCallData(
   ethAdapter: EthAdapter,
   safeVersion: SafeVersion,
   safeContract: GnosisSafeContract,
@@ -50,38 +47,6 @@ export async function encodeSetupCallData(
     BigNumber.from(0) as BigNumberish,
     ZERO_ADDRESS
   ])
-}
-
-export function encodeExecTransaction(
-  safeContract: GnosisSafeContract,
-  transaction: SafeTransactionData,
-  signature: string
-): string {
-  return safeContract.encode('execTransaction', [
-    transaction.to,
-    transaction.value,
-    transaction.data,
-    transaction.operation,
-    transaction.safeTxGas,
-    transaction.baseGas,
-    transaction.gasPrice,
-    transaction.gasToken,
-    transaction.refundReceiver,
-    signature
-  ])
-}
-
-function encodeMetaTransaction(tx: MetaTransactionData): string {
-  const data = arrayify(tx.data)
-  const encoded = solidityPack(
-    ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
-    [tx.operation, tx.to, tx.value, data.length, data]
-  )
-  return encoded.slice(2)
-}
-
-export function encodeMultiSendData(txs: MetaTransactionData[]): string {
-  return '0x' + txs.map((tx) => encodeMetaTransaction(tx)).join('')
 }
 
 export async function getSafeInitializer(

--- a/packages/protocol-kit/src/index.ts
+++ b/packages/protocol-kit/src/index.ts
@@ -52,7 +52,7 @@ import {
 
 import { ContractNetworksConfig } from './types'
 import { SafeTransactionOptionalProps } from './utils/transactions/types'
-import { standardizeSafeTransactionData } from './utils/transactions/utils'
+import { encodeMultiSendData, standardizeSafeTransactionData } from './utils/transactions/utils'
 
 export {
   ContractManager,
@@ -70,6 +70,7 @@ export {
   AddOwnerTxParams,
   RemoveOwnerTxParams,
   SwapOwnerTxParams,
+  encodeMultiSendData,
   standardizeSafeTransactionData,
   EthersAdapter,
   EthersAdapterConfig,

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayAdapter.test.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayAdapter.test.ts
@@ -96,7 +96,7 @@ describe('GelatoRelayAdapter', () => {
   })
 
   it('should allow to make a sponsored transaction', async () => {
-    const response = await gelatoRelayAdapter.sponsorTransaction(SAFE_ADDRESS, '0x', CHAIN_ID)
+    const response = await gelatoRelayAdapter.sendSponsorTransaction(SAFE_ADDRESS, '0x', CHAIN_ID)
 
     expect(response).toBe(RELAY_RESPONSE)
     expect(mockSponsoredCall).toHaveBeenCalledWith(
@@ -112,7 +112,7 @@ describe('GelatoRelayAdapter', () => {
   it('should throw an error when trying to do a sponsored transaction without an api key', async () => {
     const relayAdapter = new GelatoRelayAdapter()
     await expect(
-      relayAdapter.sponsorTransaction(SAFE_ADDRESS, '0x', CHAIN_ID)
+      relayAdapter.sendSponsorTransaction(SAFE_ADDRESS, '0x', CHAIN_ID)
     ).rejects.toThrowError('API key not defined')
   })
 
@@ -187,7 +187,7 @@ describe('GelatoRelayAdapter', () => {
   })
 
   it('should allow to make a paid transaction', async () => {
-    const response = await gelatoRelayAdapter.payTransaction(SAFE_ADDRESS, '0x', CHAIN_ID, {
+    const response = await gelatoRelayAdapter.sendSyncTransaction(SAFE_ADDRESS, '0x', CHAIN_ID, {
       gasLimit: BigNumber.from(100000)
     })
 


### PR DESCRIPTION
## What it solves
Some duplicated code still existed on the account-abstraction-kit. Also we were doing additional checks when using Gelato 1Balance that are not needed

## How this PR fixes it
Remove duplicated code and use from protocol-kit exported functions
Code cleanup to select when transaction is sponsored or using sync balance and prevent aditional calculations not needed for 1Balance