### PR TITLE
chore: add tsconfig for the build

### DIFF
--- a/packages/api-kit/package.json
+++ b/packages/api-kit/package.json
@@ -11,8 +11,6 @@
     "API"
   ],
   "scripts": {
-    "unbuild": "rimraf dist",
-    "build": "yarn rimraf dist .nyc_output cache && tsc",
     "test:web3": "export TESTS_PATH=tests/endpoint && export ETH_LIB=web3 && nyc hardhat test",
     "test:ethers": "export TESTS_PATH=tests/endpoint && export ETH_LIB=ethers && nyc hardhat test",
     "test": "yarn test:ethers",
@@ -20,7 +18,9 @@
     "test:ci:ethers": "export TESTS_PATH=tests/e2e && export ETH_LIB=ethers && nyc hardhat test",
     "test:ci": "yarn test:ci:ethers",
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
-    "format": "prettier --write \"*/**/*.{js,json,md,ts}\""
+    "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
+    "unbuild": "rimraf dist .nyc_output cache",
+    "build": "yarn unbuild && tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/api-kit/tsconfig.build.json
+++ b/packages/api-kit/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -5,11 +5,11 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "test": "jest src --coverage",
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
     "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
     "unbuild": "rm -rf dist",
-    "build": "rm -rf dist && yarn tsc",
-    "test": "jest src --coverage"
+    "build": "yarn unbuild && yarn tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/auth-kit/tsconfig.build.json
+++ b/packages/auth-kit/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/onramp-kit/package.json
+++ b/packages/onramp-kit/package.json
@@ -5,11 +5,11 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "test": "jest src --coverage",
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
     "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
     "unbuild": "rm -rf dist",
-    "build": "rm -rf dist && yarn tsc",
-    "test": "jest src --coverage"
+    "build": "yarn unbuild && yarn tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/onramp-kit/tsconfig.build.json
+++ b/packages/onramp-kit/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -10,10 +10,8 @@
     "SDK"
   ],
   "scripts": {
-    "typechain": "ts-node ./scripts/generateTypechainFiles.ts",
     "safe-deployments": "ts-node scripts/checkSafeDeployments.ts",
-    "unbuild": "rimraf dist artifacts deployments cache .nyc_output typechain *.tsbuildinfo",
-    "build": "hardhat compile && yarn typechain && yarn safe-deployments && tsc",
+    "typechain": "ts-node ./scripts/generateTypechainFiles.ts",
     "test:ganache:web3:v1.0.0": "export TEST_NETWORK=ganache && export ETH_LIB=web3 && export SAFE_VERSION=1.0.0 && hardhat --network localhost deploy && nyc hardhat --network localhost test",
     "test:ganache:web3:v1.1.1": "export TEST_NETWORK=ganache && export ETH_LIB=web3 && export SAFE_VERSION=1.1.1 && hardhat --network localhost deploy && nyc hardhat --network localhost test",
     "test:ganache:web3:v1.2.0": "export TEST_NETWORK=ganache && export ETH_LIB=web3 && export SAFE_VERSION=1.2.0 && hardhat --network localhost deploy && nyc hardhat --network localhost test",
@@ -32,7 +30,9 @@
     "test:hardhat:ethers:v1.3.0": "export TEST_NETWORK=hardhat && export ETH_LIB=ethers && export SAFE_VERSION=1.3.0 && hardhat deploy && nyc hardhat test",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
-    "format": "prettier --write \"*/**/*.{js,json,md,ts}\""
+    "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
+    "unbuild": "rimraf dist artifacts deployments cache .nyc_output typechain *.tsbuildinfo",
+    "build": "yarn unbuild && hardhat compile && yarn typechain && yarn safe-deployments && tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/protocol-kit/tsconfig.build.json
+++ b/packages/protocol-kit/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "typechain/**/*"]
+}

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -12,11 +12,11 @@
     "Relay"
   ],
   "scripts": {
-    "unbuild": "rimraf dist dist .nyc_output cache",
-    "build": "yarn unbuild && tsc",
+    "test": "jest src",
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
     "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
-    "test": "jest src"
+    "unbuild": "rimraf dist .nyc_output cache",
+    "build": "yarn unbuild && tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/relay-kit/tsconfig.build.json
+++ b/packages/relay-kit/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -10,10 +10,10 @@
     "SDK"
   ],
   "scripts": {
-    "unbuild": "rimraf dist *.tsbuildinfo",
-    "build": "rimraf dist && tsc",
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
-    "format": "prettier --write \"*/**/*.{js,json,md,ts}\""
+    "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
+    "unbuild": "rimraf dist *.tsbuildinfo",
+    "build": "yarn unbuild && tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/safe-core-sdk-types/tsconfig.build.json
+++ b/packages/safe-core-sdk-types/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## What it solves
- Adds the new `tsconfig.build.json` file for each package to avoid adding unnecessary folders to the builds
- Reorganizes the scripts