### PR TITLE
chore: remove chainId from contracts getters

### DIFF
--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -1,20 +1,3 @@
-import { RelayAdapter } from '@safe-global/relay-kit'
-import Safe, {
-  encodeMultiSendData,
-  EthersAdapter,
-  getMultiSendCallOnlyContract,
-  getProxyFactoryContract,
-  getSafeContract
-} from '@safe-global/protocol-kit'
-import {
-  GnosisSafeContract,
-  GnosisSafeProxyFactoryContract,
-  MetaTransactionData,
-  MetaTransactionOptions,
-  RelayTransaction,
-  SafeVersion
-} from '@safe-global/safe-core-sdk-types'
-import { ethers } from 'ethers'
 import {
   AccountAbstractionConfig,
   OperationType
@@ -24,6 +7,23 @@ import {
   encodeCreateProxyWithNonce,
   getSafeInitializer
 } from '@safe-global/account-abstraction-kit-poc/utils/contracts'
+import Safe, {
+  encodeMultiSendData,
+  EthersAdapter,
+  getMultiSendCallOnlyContract,
+  getProxyFactoryContract,
+  getSafeContract
+} from '@safe-global/protocol-kit'
+import { RelayAdapter } from '@safe-global/relay-kit'
+import {
+  GnosisSafeContract,
+  GnosisSafeProxyFactoryContract,
+  MetaTransactionData,
+  MetaTransactionOptions,
+  RelayTransaction,
+  SafeVersion
+} from '@safe-global/safe-core-sdk-types'
+import { ethers } from 'ethers'
 
 const safeVersion: SafeVersion = '1.3.0'
 
@@ -49,11 +49,9 @@ class AccountAbstraction {
     const { relayAdapter } = options
     this.setRelayAdapter(relayAdapter)
 
-    const chainId = await this.#ethAdapter.getChainId()
     this.#safeProxyFactoryContract = await getProxyFactoryContract({
       ethAdapter: this.#ethAdapter,
-      safeVersion,
-      chainId
+      safeVersion
     })
     const safeAddress = await calculateChainSpecificProxyAddress(
       this.#ethAdapter,
@@ -64,8 +62,7 @@ class AccountAbstraction {
     this.#safeContract = await getSafeContract({
       ethAdapter: this.#ethAdapter,
       safeVersion,
-      customSafeAddress: safeAddress,
-      chainId
+      customSafeAddress: safeAddress
     })
   }
 
@@ -110,9 +107,7 @@ class AccountAbstraction {
       throw new Error('SDK not initialized')
     }
 
-    const chainId = await this.#ethAdapter.getChainId()
     const safeAddress = this.getSafeAddress()
-
     const safe = await Safe.create({
       ethAdapter: this.#ethAdapter,
       safeAddress
@@ -140,20 +135,17 @@ class AccountAbstraction {
     } else {
       const multiSendCallOnlyContract = await getMultiSendCallOnlyContract({
         ethAdapter: this.#ethAdapter,
-        safeVersion,
-        chainId
+        safeVersion
       })
       relayTransactionTarget = multiSendCallOnlyContract.getAddress()
       const safeSingletonContract = await getSafeContract({
         ethAdapter: this.#ethAdapter,
-        safeVersion,
-        chainId
+        safeVersion
       })
       const initializer = await getSafeInitializer(
         this.#ethAdapter,
         this.#safeContract,
-        await this.getSignerAddress(),
-        chainId
+        await this.getSignerAddress()
       )
 
       const safeDeploymentTransaction: MetaTransactionData = {
@@ -177,6 +169,7 @@ class AccountAbstraction {
       encodedTransaction = multiSendCallOnlyContract.encode('multiSend', [multiSendData])
     }
 
+    const chainId = await this.#ethAdapter.getChainId()
     const relayTransaction: RelayTransaction = {
       target: relayTransactionTarget,
       encodedTransaction: encodedTransaction,

--- a/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
+++ b/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
@@ -2,6 +2,7 @@ import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Provider } from '@ethersproject/providers'
+import { generateTypedData, validateEip3770Address } from '@safe-global/protocol-kit/utils'
 import {
   Eip3770Address,
   EthAdapter,
@@ -9,7 +10,6 @@ import {
   GetContractProps,
   SafeTransactionEIP712Args
 } from '@safe-global/safe-core-sdk-types'
-import { generateTypedData, validateEip3770Address } from '@safe-global/protocol-kit/utils'
 import { ethers } from 'ethers'
 import CompatibilityFallbackHandlerContractEthers from './contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerEthersContract'
 import {
@@ -94,12 +94,12 @@ class EthersAdapter implements EthAdapter {
     return this.#ethers.utils.getAddress(address)
   }
 
-  getSafeContract({
+  async getSafeContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): GnosisSafeContractEthers {
+  }: GetContractProps): Promise<GnosisSafeContractEthers> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
@@ -110,12 +110,12 @@ class EthersAdapter implements EthAdapter {
     return getSafeContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
-  getSafeProxyFactoryContract({
+  async getSafeProxyFactoryContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): GnosisSafeProxyFactoryEthersContract {
+  }: GetContractProps): Promise<GnosisSafeProxyFactoryEthersContract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
@@ -126,12 +126,12 @@ class EthersAdapter implements EthAdapter {
     return getSafeProxyFactoryContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
-  getMultiSendContract({
+  async getMultiSendContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): MultiSendEthersContract {
+  }: GetContractProps): Promise<MultiSendEthersContract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
@@ -142,12 +142,12 @@ class EthersAdapter implements EthAdapter {
     return getMultiSendContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
-  getMultiSendCallOnlyContract({
+  async getMultiSendCallOnlyContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): MultiSendCallOnlyEthersContract {
+  }: GetContractProps): Promise<MultiSendCallOnlyEthersContract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
@@ -158,12 +158,12 @@ class EthersAdapter implements EthAdapter {
     return getMultiSendCallOnlyContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
-  getCompatibilityFallbackHandlerContract({
+  async getCompatibilityFallbackHandlerContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): CompatibilityFallbackHandlerContractEthers {
+  }: GetContractProps): Promise<CompatibilityFallbackHandlerContractEthers> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
@@ -178,12 +178,12 @@ class EthersAdapter implements EthAdapter {
     )
   }
 
-  getSignMessageLibContract({
+  async getSignMessageLibContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): SignMessageLibEthersContract {
+  }: GetContractProps): Promise<SignMessageLibEthersContract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]
@@ -194,12 +194,12 @@ class EthersAdapter implements EthAdapter {
     return getSignMessageLibContractInstance(safeVersion, contractAddress, signerOrProvider)
   }
 
-  getCreateCallContract({
+  async getCreateCallContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress
-  }: GetContractProps): CreateCallEthersContract {
+  }: GetContractProps): Promise<CreateCallEthersContract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress
       ? customContractAddress
       : singletonDeployment?.networkAddresses[chainId]

--- a/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
+++ b/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
@@ -100,9 +100,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<GnosisSafeContractEthers> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid SafeProxy contract address')
     }
@@ -116,9 +114,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<GnosisSafeProxyFactoryEthersContract> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid SafeProxyFactory contract address')
     }
@@ -132,9 +128,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<MultiSendEthersContract> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid MultiSend contract address')
     }
@@ -148,9 +142,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<MultiSendCallOnlyEthersContract> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid MultiSendCallOnly contract address')
     }
@@ -164,9 +156,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<CompatibilityFallbackHandlerContractEthers> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid CompatibilityFallbackHandler contract address')
     }
@@ -184,9 +174,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<SignMessageLibEthersContract> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid SignMessageLib contract address')
     }
@@ -200,9 +188,7 @@ class EthersAdapter implements EthAdapter {
     customContractAddress
   }: GetContractProps): Promise<CreateCallEthersContract> {
     const chainId = await this.getChainId()
-    const contractAddress = customContractAddress
-      ? customContractAddress
-      : singletonDeployment?.networkAddresses[chainId]
+    const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid CreateCall contract address')
     }

--- a/packages/protocol-kit/src/adapters/web3/Web3Adapter.ts
+++ b/packages/protocol-kit/src/adapters/web3/Web3Adapter.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { generateTypedData, validateEip3770Address } from '@safe-global/protocol-kit/utils'
 import {
   Eip3770Address,
   EthAdapter,
@@ -6,7 +7,6 @@ import {
   GetContractProps,
   SafeTransactionEIP712Args
 } from '@safe-global/safe-core-sdk-types'
-import { generateTypedData, validateEip3770Address } from '@safe-global/protocol-kit/utils'
 import Web3 from 'web3'
 import { Transaction } from 'web3-core'
 import { ContractOptions } from 'web3-eth-contract'
@@ -82,13 +82,13 @@ class Web3Adapter implements EthAdapter {
     return this.#web3.utils.toChecksumAddress(address)
   }
 
-  getSafeContract({
+  async getSafeContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): GnosisSafeContractWeb3 {
+  }: GetContractProps): Promise<GnosisSafeContractWeb3> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid SafeProxy contract address')
@@ -100,13 +100,13 @@ class Web3Adapter implements EthAdapter {
     return getSafeContractInstance(safeVersion, safeContract)
   }
 
-  getSafeProxyFactoryContract({
+  async getSafeProxyFactoryContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): GnosisSafeProxyFactoryWeb3Contract {
+  }: GetContractProps): Promise<GnosisSafeProxyFactoryWeb3Contract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid SafeProxyFactory contract address')
@@ -118,13 +118,13 @@ class Web3Adapter implements EthAdapter {
     return getGnosisSafeProxyFactoryContractInstance(safeVersion, proxyFactoryContract)
   }
 
-  getMultiSendContract({
+  async getMultiSendContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): MultiSendWeb3Contract {
+  }: GetContractProps): Promise<MultiSendWeb3Contract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid MultiSend contract address')
@@ -136,13 +136,13 @@ class Web3Adapter implements EthAdapter {
     return getMultiSendContractInstance(safeVersion, multiSendContract)
   }
 
-  getMultiSendCallOnlyContract({
+  async getMultiSendCallOnlyContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): MultiSendCallOnlyWeb3Contract {
+  }: GetContractProps): Promise<MultiSendCallOnlyWeb3Contract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid MultiSendCallOnly contract address')
@@ -154,13 +154,13 @@ class Web3Adapter implements EthAdapter {
     return getMultiSendCallOnlyContractInstance(safeVersion, multiSendContract)
   }
 
-  getCompatibilityFallbackHandlerContract({
+  async getCompatibilityFallbackHandlerContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): CompatibilityFallbackHandlerWeb3Contract {
+  }: GetContractProps): Promise<CompatibilityFallbackHandlerWeb3Contract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid Compatibility Fallback Handler contract address')
@@ -172,13 +172,13 @@ class Web3Adapter implements EthAdapter {
     return getCompatibilityFallbackHandlerContractInstance(safeVersion, multiSendContract)
   }
 
-  getSignMessageLibContract({
+  async getSignMessageLibContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): SignMessageLibWeb3Contract {
+  }: GetContractProps): Promise<SignMessageLibWeb3Contract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid SignMessageLib contract address')
@@ -190,13 +190,13 @@ class Web3Adapter implements EthAdapter {
     return getSignMessageLibContractInstance(safeVersion, signMessageLibContract)
   }
 
-  getCreateCallContract({
+  async getCreateCallContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): CreateCallWeb3Contract {
+  }: GetContractProps): Promise<CreateCallWeb3Contract> {
+    const chainId = await this.getChainId()
     const contractAddress = customContractAddress ?? singletonDeployment?.networkAddresses[chainId]
     if (!contractAddress) {
       throw new Error('Invalid CreateCall contract address')

--- a/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
+++ b/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
@@ -1,3 +1,4 @@
+import { ContractNetworkConfig } from '@safe-global/protocol-kit/types'
 import {
   CompatibilityFallbackHandlerContract,
   CreateCallContract,
@@ -21,13 +22,11 @@ import {
   getSignMessageLibDeployment,
   SingletonDeployment
 } from '@safe-global/safe-deployments'
-import { ContractNetworkConfig } from '@safe-global/protocol-kit/types'
 import { safeDeploymentsL1ChainIds, safeDeploymentsVersions } from './config'
 
 interface GetContractInstanceProps {
   ethAdapter: EthAdapter
   safeVersion: SafeVersion
-  chainId: number
   customContracts?: ContractNetworkConfig
 }
 
@@ -104,15 +103,14 @@ export function getCreateCallContractDeployment(
 export async function getSafeContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customSafeAddress,
   isL1SafeMasterCopy,
   customContracts
 }: GetSafeContractInstanceProps): Promise<GnosisSafeContract> {
+  const chainId = await ethAdapter.getChainId()
   const singletonDeployment = getSafeContractDeployment(safeVersion, chainId, isL1SafeMasterCopy)
-  const gnosisSafeContract = ethAdapter.getSafeContract({
+  const gnosisSafeContract = await ethAdapter.getSafeContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress: customSafeAddress ?? customContracts?.safeMasterCopyAddress,
     customContractAbi: customContracts?.safeMasterCopyAbi
@@ -127,13 +125,12 @@ export async function getSafeContract({
 export async function getProxyFactoryContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customContracts
 }: GetContractInstanceProps): Promise<GnosisSafeProxyFactoryContract> {
+  const chainId = await ethAdapter.getChainId()
   const proxyFactoryDeployment = getSafeProxyFactoryContractDeployment(safeVersion, chainId)
   const safeProxyFactoryContract = await ethAdapter.getSafeProxyFactoryContract({
     safeVersion,
-    chainId,
     singletonDeployment: proxyFactoryDeployment,
     customContractAddress: customContracts?.safeProxyFactoryAddress,
     customContractAbi: customContracts?.safeProxyFactoryAbi
@@ -150,16 +147,15 @@ export async function getProxyFactoryContract({
 export async function getCompatibilityFallbackHandlerContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customContracts
 }: GetContractInstanceProps): Promise<CompatibilityFallbackHandlerContract> {
+  const chainId = await ethAdapter.getChainId()
   const fallbackHandlerDeployment = getCompatibilityFallbackHandlerContractDeployment(
     safeVersion,
     chainId
   )
   const fallbackHandlerContract = await ethAdapter.getCompatibilityFallbackHandlerContract({
     safeVersion,
-    chainId,
     singletonDeployment: fallbackHandlerDeployment,
     customContractAddress: customContracts?.fallbackHandlerAddress,
     customContractAbi: customContracts?.fallbackHandlerAbi
@@ -176,13 +172,12 @@ export async function getCompatibilityFallbackHandlerContract({
 export async function getMultiSendContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customContracts
 }: GetContractInstanceProps): Promise<MultiSendContract> {
+  const chainId = await ethAdapter.getChainId()
   const multiSendDeployment = getMultiSendContractDeployment(safeVersion, chainId)
   const multiSendContract = await ethAdapter.getMultiSendContract({
     safeVersion,
-    chainId,
     singletonDeployment: multiSendDeployment,
     customContractAddress: customContracts?.multiSendAddress,
     customContractAbi: customContracts?.multiSendAbi
@@ -197,13 +192,12 @@ export async function getMultiSendContract({
 export async function getMultiSendCallOnlyContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customContracts
 }: GetContractInstanceProps): Promise<MultiSendCallOnlyContract> {
+  const chainId = await ethAdapter.getChainId()
   const multiSendCallOnlyDeployment = getMultiSendCallOnlyContractDeployment(safeVersion, chainId)
   const multiSendCallOnlyContract = await ethAdapter.getMultiSendCallOnlyContract({
     safeVersion,
-    chainId,
     singletonDeployment: multiSendCallOnlyDeployment,
     customContractAddress: customContracts?.multiSendCallOnlyAddress,
     customContractAbi: customContracts?.multiSendCallOnlyAbi
@@ -220,13 +214,12 @@ export async function getMultiSendCallOnlyContract({
 export async function getSignMessageLibContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customContracts
 }: GetContractInstanceProps): Promise<SignMessageLibContract> {
+  const chainId = await ethAdapter.getChainId()
   const signMessageLibDeployment = getSignMessageLibContractDeployment(safeVersion, chainId)
   const signMessageLibContract = await ethAdapter.getSignMessageLibContract({
     safeVersion,
-    chainId,
     singletonDeployment: signMessageLibDeployment,
     customContractAddress: customContracts?.signMessageLibAddress,
     customContractAbi: customContracts?.signMessageLibAbi
@@ -243,13 +236,12 @@ export async function getSignMessageLibContract({
 export async function getCreateCallContract({
   ethAdapter,
   safeVersion,
-  chainId,
   customContracts
 }: GetContractInstanceProps): Promise<CreateCallContract> {
+  const chainId = await ethAdapter.getChainId()
   const createCallDeployment = getCreateCallContractDeployment(safeVersion, chainId)
   const createCallContract = await ethAdapter.getCreateCallContract({
     safeVersion,
-    chainId,
     singletonDeployment: createCallDeployment,
     customContractAddress: customContracts?.createCallAddress,
     customContractAbi: customContracts?.createCallAbi

--- a/packages/protocol-kit/src/managers/contractManager.ts
+++ b/packages/protocol-kit/src/managers/contractManager.ts
@@ -1,8 +1,3 @@
-import {
-  GnosisSafeContract,
-  MultiSendCallOnlyContract,
-  MultiSendContract
-} from '@safe-global/safe-core-sdk-types'
 import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import {
   getMultiSendCallOnlyContract,
@@ -11,6 +6,11 @@ import {
 } from '@safe-global/protocol-kit/contracts/safeDeploymentContracts'
 import { SafeConfig } from '@safe-global/protocol-kit/Safe'
 import { ContractNetworksConfig } from '@safe-global/protocol-kit/types'
+import {
+  GnosisSafeContract,
+  MultiSendCallOnlyContract,
+  MultiSendContract
+} from '@safe-global/safe-core-sdk-types'
 
 class ContractManager {
   #contractNetworks?: ContractNetworksConfig
@@ -44,7 +44,6 @@ class ContractManager {
     const temporarySafeContract = await getSafeContract({
       ethAdapter,
       safeVersion: SAFE_LAST_VERSION,
-      chainId,
       isL1SafeMasterCopy,
       customSafeAddress: safeAddress,
       customContracts
@@ -53,7 +52,6 @@ class ContractManager {
     this.#safeContract = await getSafeContract({
       ethAdapter,
       safeVersion,
-      chainId,
       isL1SafeMasterCopy,
       customSafeAddress: safeAddress,
       customContracts
@@ -61,13 +59,11 @@ class ContractManager {
     this.#multiSendContract = await getMultiSendContract({
       ethAdapter,
       safeVersion,
-      chainId,
       customContracts
     })
     this.#multiSendCallOnlyContract = await getMultiSendCallOnlyContract({
       ethAdapter,
       safeVersion,
-      chainId,
       customContracts
     })
   }

--- a/packages/protocol-kit/src/safeFactory/index.ts
+++ b/packages/protocol-kit/src/safeFactory/index.ts
@@ -1,12 +1,3 @@
-import {
-  EthAdapter,
-  GnosisSafeContract,
-  GnosisSafeProxyFactoryContract,
-  SafeVersion,
-  TransactionOptions
-} from '@safe-global/safe-core-sdk-types'
-import { generateAddress2, keccak256, toBuffer } from 'ethereumjs-util'
-import semverSatisfies from 'semver/functions/satisfies'
 import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import {
   getCompatibilityFallbackHandlerContract,
@@ -16,6 +7,15 @@ import {
 import Safe from '@safe-global/protocol-kit/Safe'
 import { ContractNetworksConfig } from '@safe-global/protocol-kit/types'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
+import {
+  EthAdapter,
+  GnosisSafeContract,
+  GnosisSafeProxyFactoryContract,
+  SafeVersion,
+  TransactionOptions
+} from '@safe-global/safe-core-sdk-types'
+import { generateAddress2, keccak256, toBuffer } from 'ethereumjs-util'
+import semverSatisfies from 'semver/functions/satisfies'
 import { validateSafeAccountConfig, validateSafeDeploymentConfig } from './utils'
 
 export interface SafeAccountConfig {
@@ -101,13 +101,11 @@ class SafeFactory {
     this.#safeProxyFactoryContract = await getProxyFactoryContract({
       ethAdapter,
       safeVersion,
-      chainId,
       customContracts
     })
     this.#gnosisSafeContract = await getSafeContract({
       ethAdapter,
       safeVersion,
-      chainId,
       isL1SafeMasterCopy,
       customContracts
     })
@@ -159,7 +157,6 @@ class SafeFactory {
       const fallbackHandlerContract = await getCompatibilityFallbackHandlerContract({
         ethAdapter: this.#ethAdapter,
         safeVersion: this.#safeVersion,
-        chainId,
         customContracts
       })
       fallbackHandlerAddress = fallbackHandlerContract.getAddress()

--- a/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
+++ b/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
@@ -1,7 +1,3 @@
-import { SafeVersion } from '@safe-global/safe-core-sdk-types'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-import { deployments, waffle } from 'hardhat'
 import {
   getCompatibilityFallbackHandlerContractDeployment,
   getCreateCallContractDeployment,
@@ -11,6 +7,10 @@ import {
   getSafeProxyFactoryContractDeployment,
   getSignMessageLibContractDeployment
 } from '@safe-global/protocol-kit/contracts/safeDeploymentContracts'
+import { SafeVersion } from '@safe-global/safe-core-sdk-types'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { deployments, waffle } from 'hardhat'
 import { getContractNetworks } from './utils/setupContractNetworks'
 import {
   getCompatibilityFallbackHandler,
@@ -22,11 +22,11 @@ import {
   getSignMessageLib
 } from './utils/setupContracts'
 import { getEthAdapter } from './utils/setupEthAdapter'
-import { getAccounts } from './utils/setupTestNetwork'
+import { getAccounts, getNetworkProvider } from './utils/setupTestNetwork'
 
 chai.use(chaiAsPromised)
 
-describe('Safe contracts', () => {
+describe.only('Safe contracts', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     await deployments.fixture()
     const accounts = await getAccounts()
@@ -41,15 +41,12 @@ describe('Safe contracts', () => {
 
   describe('getSafeContract', async () => {
     it('should return an L1 Safe contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getSafeContractDeployment(safeVersion, chainId)
       const safeContract = await ethAdapter.getSafeContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -58,15 +55,12 @@ describe('Safe contracts', () => {
     })
 
     it('should return an L2 Safe contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('gnosis'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 100
       const singletonDeployment = getSafeContractDeployment(safeVersion, chainId)
       const safeContract = await ethAdapter.getSafeContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -75,9 +69,7 @@ describe('Safe contracts', () => {
     })
 
     it('should return an L1 Safe contract from safe-deployments using the L1 flag', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('gnosis'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 100
       const isL1SafeMasterCopy = true
@@ -88,7 +80,6 @@ describe('Safe contracts', () => {
       )
       const safeContract = await ethAdapter.getSafeContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -104,7 +95,6 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const safeContract = await ethAdapter.getSafeContract({
         safeVersion,
-        chainId,
         customContractAddress: customContract?.safeMasterCopyAddress,
         customContractAbi: customContract?.safeMasterCopyAbi
       })
@@ -116,15 +106,12 @@ describe('Safe contracts', () => {
 
   describe('getMultiSendContract', async () => {
     it('should return a MultiSend contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getMultiSendContractDeployment(safeVersion, chainId)
       const multiSendContract = await ethAdapter.getMultiSendContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -140,7 +127,6 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const multiSendContract = await ethAdapter.getMultiSendContract({
         safeVersion,
-        chainId,
         customContractAddress: customContract.multiSendAddress,
         customContractAbi: customContract.multiSendAbi
       })
@@ -152,15 +138,12 @@ describe('Safe contracts', () => {
 
   describe('getMultiSendCallOnlyContract', async () => {
     it('should return a MultiSendCallOnly contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getMultiSendCallOnlyContractDeployment(safeVersion, chainId)
       const multiSendCallOnlyContract = await ethAdapter.getMultiSendCallOnlyContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -176,7 +159,6 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const multiSendCallOnlyContract = await ethAdapter.getMultiSendCallOnlyContract({
         safeVersion,
-        chainId,
         customContractAddress: customContract.multiSendCallOnlyAddress,
         customContractAbi: customContract.multiSendCallOnlyAbi
       })
@@ -188,9 +170,7 @@ describe('Safe contracts', () => {
 
   describe('getCompatibilityFallbackHandlerContract', async () => {
     it('should return a CompatibilityFallbackHandler contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getCompatibilityFallbackHandlerContractDeployment(
@@ -200,7 +180,6 @@ describe('Safe contracts', () => {
       const compatibilityFallbackHandlerContract =
         await ethAdapter.getCompatibilityFallbackHandlerContract({
           safeVersion,
-          chainId,
           singletonDeployment
         })
       chai
@@ -217,7 +196,6 @@ describe('Safe contracts', () => {
       const compatibilityFallbackHandlerContract =
         await ethAdapter.getCompatibilityFallbackHandlerContract({
           safeVersion,
-          chainId,
           customContractAddress: customContract.fallbackHandlerAddress,
           customContractAbi: customContract.fallbackHandlerAbi
         })
@@ -229,15 +207,12 @@ describe('Safe contracts', () => {
 
   describe('getSafeProxyFactoryContract', async () => {
     it('should return a SafeProxyFactory contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getSafeProxyFactoryContractDeployment(safeVersion, chainId)
       const factoryContract = await ethAdapter.getSafeProxyFactoryContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -253,7 +228,6 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const factoryContract = await ethAdapter.getSafeProxyFactoryContract({
         safeVersion,
-        chainId,
         customContractAddress: customContract.safeProxyFactoryAddress,
         customContractAbi: customContract.safeProxyFactoryAbi
       })
@@ -265,15 +239,12 @@ describe('Safe contracts', () => {
 
   describe('getSignMessageLibContract', async () => {
     it('should return a SignMessageLib contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getSignMessageLibContractDeployment(safeVersion, chainId)
       const signMessageLibContract = await ethAdapter.getSignMessageLibContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -289,7 +260,6 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const signMessageLibContract = await ethAdapter.getSignMessageLibContract({
         safeVersion,
-        chainId,
         customContractAddress: customContract.signMessageLibAddress,
         customContractAbi: customContract.signMessageLibAbi
       })
@@ -301,15 +271,12 @@ describe('Safe contracts', () => {
 
   describe('getCreateCallContract', async () => {
     it('should return a CreateCall contract from safe-deployments', async () => {
-      const { accounts } = await setupTests()
-      const [account1] = accounts
-      const ethAdapter = await getEthAdapter(account1.signer)
+      const ethAdapter = await getEthAdapter(getNetworkProvider('mainnet'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 1
       const singletonDeployment = getCreateCallContractDeployment(safeVersion, chainId)
       const createCallContract = await ethAdapter.getCreateCallContract({
         safeVersion,
-        chainId,
         singletonDeployment
       })
       chai
@@ -325,7 +292,6 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const createCallContract = await ethAdapter.getCreateCallContract({
         safeVersion,
-        chainId,
         customContractAddress: customContract.createCallAddress,
         customContractAbi: customContract.createCallAbi
       })

--- a/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
+++ b/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
@@ -26,7 +26,7 @@ import { getAccounts, getNetworkProvider } from './utils/setupTestNetwork'
 
 chai.use(chaiAsPromised)
 
-describe.only('Safe contracts', () => {
+describe('Safe contracts', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     await deployments.fixture()
     const accounts = await getAccounts()

--- a/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
+++ b/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
@@ -21,8 +21,8 @@ import {
   getSafeSingleton,
   getSignMessageLib
 } from './utils/setupContracts'
-import { getEthAdapter } from './utils/setupEthAdapter'
-import { getAccounts, getNetworkProvider } from './utils/setupTestNetwork'
+import { getEthAdapter, getNetworkProvider } from './utils/setupEthAdapter'
+import { getAccounts } from './utils/setupTestNetwork'
 
 chai.use(chaiAsPromised)
 

--- a/packages/protocol-kit/tests/e2e/utils/setupEthAdapter.ts
+++ b/packages/protocol-kit/tests/e2e/utils/setupEthAdapter.ts
@@ -1,12 +1,12 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { Provider } from '@ethersproject/providers'
-import { EthAdapter } from '@safe-global/safe-core-sdk-types'
 import {
   EthersAdapter,
   EthersAdapterConfig,
   Web3Adapter,
   Web3AdapterConfig
 } from '@safe-global/protocol-kit/index'
+import { EthAdapter } from '@safe-global/safe-core-sdk-types'
 import { ethers, web3 } from 'hardhat'
 
 export async function getEthAdapter(signerOrProvider: Signer | Provider): Promise<EthAdapter> {

--- a/packages/protocol-kit/tests/e2e/utils/setupEthAdapter.ts
+++ b/packages/protocol-kit/tests/e2e/utils/setupEthAdapter.ts
@@ -7,23 +7,62 @@ import {
   Web3AdapterConfig
 } from '@safe-global/protocol-kit/index'
 import { EthAdapter } from '@safe-global/safe-core-sdk-types'
+import dotenv from 'dotenv'
 import { ethers, web3 } from 'hardhat'
+import Web3 from 'web3'
 
-export async function getEthAdapter(signerOrProvider: Signer | Provider): Promise<EthAdapter> {
+dotenv.config()
+
+type Network = 'mainnet' | 'goerli' | 'gnosis'
+
+export async function getEthAdapter(
+  signerOrProvider: Signer | Provider | Web3
+): Promise<EthAdapter> {
   let ethAdapter: EthAdapter
   switch (process.env.ETH_LIB) {
     case 'web3':
       const signerAddress =
         signerOrProvider instanceof Signer ? await signerOrProvider.getAddress() : undefined
-      const web3AdapterConfig: Web3AdapterConfig = { web3: web3 as any, signerAddress }
+      const web3Instance = signerOrProvider instanceof Web3 ? signerOrProvider : (web3 as any)
+      const web3AdapterConfig: Web3AdapterConfig = { web3: web3Instance, signerAddress }
       ethAdapter = new Web3Adapter(web3AdapterConfig)
       break
     case 'ethers':
-      const ethersAdapterConfig: EthersAdapterConfig = { ethers, signerOrProvider }
+      const ethersAdapterConfig: EthersAdapterConfig = {
+        ethers,
+        signerOrProvider: signerOrProvider as Provider
+      }
       ethAdapter = new EthersAdapter(ethersAdapterConfig)
       break
     default:
       throw new Error('Ethereum library not supported')
   }
+
   return ethAdapter
+}
+
+export function getNetworkProvider(network: Network): Provider | Web3 {
+  let rpcUrl: string
+  switch (network) {
+    case 'gnosis':
+      rpcUrl = 'https://rpc.gnosischain.com'
+      break
+    default:
+      rpcUrl = `https://${network}.infura.io/v3/${process.env.INFURA_KEY}`
+      break
+  }
+
+  let provider
+  switch (process.env.ETH_LIB) {
+    case 'web3':
+      provider = new Web3(rpcUrl)
+      break
+    case 'ethers':
+      provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+      break
+    default:
+      throw new Error('Ethereum library not supported')
+  }
+
+  return provider
 }

--- a/packages/protocol-kit/tests/e2e/utils/setupTestNetwork.ts
+++ b/packages/protocol-kit/tests/e2e/utils/setupTestNetwork.ts
@@ -1,13 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer'
-import { Provider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
-import dotenv from 'dotenv'
 import { ethers, waffle, Web3 } from 'hardhat'
-
-dotenv.config()
-
-type Network = 'mainnet' | 'goerli' | 'gnosis'
-
 interface Account {
   signer: Signer
   address: string
@@ -40,19 +33,4 @@ export async function getAccounts(): Promise<Account[]> {
   const accounts =
     process.env.TEST_NETWORK === 'ganache' ? await getGanacheAccounts() : getHardhatAccounts()
   return accounts
-}
-
-export function getNetworkProvider(network: Network): Provider {
-  let rpcUrl: string
-  switch (network) {
-    case 'gnosis':
-      rpcUrl = 'https://rpc.gnosischain.com'
-      break
-    default:
-      rpcUrl = `https://${network}.infura.io/v3/${process.env.INFURA_KEY}`
-      break
-  }
-
-  const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
-  return provider
 }

--- a/packages/protocol-kit/tests/e2e/utils/setupTestNetwork.ts
+++ b/packages/protocol-kit/tests/e2e/utils/setupTestNetwork.ts
@@ -1,6 +1,12 @@
 import { Signer } from '@ethersproject/abstract-signer'
+import { Provider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
+import dotenv from 'dotenv'
 import { ethers, waffle, Web3 } from 'hardhat'
+
+dotenv.config()
+
+type Network = 'mainnet' | 'goerli' | 'gnosis'
 
 interface Account {
   signer: Signer
@@ -34,4 +40,19 @@ export async function getAccounts(): Promise<Account[]> {
   const accounts =
     process.env.TEST_NETWORK === 'ganache' ? await getGanacheAccounts() : getHardhatAccounts()
   return accounts
+}
+
+export function getNetworkProvider(network: Network): Provider {
+  let rpcUrl: string
+  switch (network) {
+    case 'gnosis':
+      rpcUrl = 'https://rpc.gnosischain.com'
+      break
+    default:
+      rpcUrl = `https://${network}.infura.io/v3/${process.env.INFURA_KEY}`
+      break
+  }
+
+  const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+  return provider
 }

--- a/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
+++ b/packages/safe-core-sdk-types/src/ethereumLibs/EthAdapter.ts
@@ -1,6 +1,4 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { SingletonDeployment } from '@safe-global/safe-deployments'
-import { AbiItem } from 'web3-utils'
 import { CompatibilityFallbackHandlerContract } from '@safe-global/safe-core-sdk-types/contracts/CompatibilityFallbackHandlerContract'
 import { CreateCallContract } from '@safe-global/safe-core-sdk-types/contracts/CreateCallContract'
 import { GnosisSafeContract } from '@safe-global/safe-core-sdk-types/contracts/GnosisSafeContract'
@@ -13,6 +11,8 @@ import {
   SafeTransactionEIP712Args,
   SafeVersion
 } from '@safe-global/safe-core-sdk-types/types'
+import { SingletonDeployment } from '@safe-global/safe-deployments'
+import { AbiItem } from 'web3-utils'
 
 export interface EthAdapterTransaction {
   to: string
@@ -27,7 +27,6 @@ export interface EthAdapterTransaction {
 
 export interface GetContractProps {
   safeVersion: SafeVersion
-  chainId: number
   singletonDeployment?: SingletonDeployment
   customContractAddress?: string
   customContractAbi?: AbiItem | AbiItem[]
@@ -42,53 +41,46 @@ export interface EthAdapter {
   getChecksummedAddress(address: string): string
   getSafeContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): GnosisSafeContract
+  }: GetContractProps): Promise<GnosisSafeContract>
   getMultiSendContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): MultiSendContract
+  }: GetContractProps): Promise<MultiSendContract>
   getMultiSendCallOnlyContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): MultiSendCallOnlyContract
+  }: GetContractProps): Promise<MultiSendCallOnlyContract>
   getCompatibilityFallbackHandlerContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): CompatibilityFallbackHandlerContract
+  }: GetContractProps): Promise<CompatibilityFallbackHandlerContract>
   getSafeProxyFactoryContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): GnosisSafeProxyFactoryContract
+  }: GetContractProps): Promise<GnosisSafeProxyFactoryContract>
   getSignMessageLibContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): SignMessageLibContract
+  }: GetContractProps): Promise<SignMessageLibContract>
   getCreateCallContract({
     safeVersion,
-    chainId,
     singletonDeployment,
     customContractAddress,
     customContractAbi
-  }: GetContractProps): CreateCallContract
+  }: GetContractProps): Promise<CreateCallContract>
   getContractCode(address: string, defaultBlock?: string | number): Promise<string>
   isContractDeployed(address: string, defaultBlock?: string | number): Promise<boolean>
   getStorageAt(address: string, position: string): Promise<string>


### PR DESCRIPTION
## What it solves
- Removes unnecessary `chainId` param from the methods that get the contract instances
- Updates the tests