### PR TITLE
docs: Add some help for starting the examples

### DIFF
--- a/packages/auth-kit/example/.env.sample
+++ b/packages/auth-kit/example/.env.sample
@@ -1,2 +1,6 @@
+# Get the web3auth client id from https://web3auth.io
 VITE_WEB3AUTH_CLIENT_ID=
+
+# You can use any RPC but if you want to use infura with 
+# this example get your key from https://www.infura.io
 VITE_INFURA_KEY=

--- a/packages/auth-kit/example/README.md
+++ b/packages/auth-kit/example/README.md
@@ -12,3 +12,16 @@ This example can be used as a playground to test the package as it is relatively
 ```typescript
 import { SafeAuthKit, SafeAuthProviderType, SafeAuthSignInData } from '../../src/index'
 ```
+
+To use the example properly in your local machine follow these steps:
+
+**In the project root**
+
+1. `yarn install`
+2. `yarn build`
+
+**In the auth-kit example root**
+
+3. `yarn install`
+4. Configure `.env` following `.env.sample`
+5. `yarn start`

--- a/packages/onramp-kit/example/client/.env.sample
+++ b/packages/onramp-kit/example/client/.env.sample
@@ -1,3 +1,5 @@
+# Get your Stripe public key from https://stripe.com/docs/crypto/overview
 VITE_STRIPE_PUBLIC_KEY=
+
+# Configure the Stripe backend URL
 VITE_SAFE_STRIPE_BACKEND_BASE_URL=
-VITE_SESSION_ADDRESS=

--- a/packages/onramp-kit/example/client/README.md
+++ b/packages/onramp-kit/example/client/README.md
@@ -12,3 +12,16 @@ This example can be used as a playground to test the package as it is relatively
 ```typescript
 import { SafeOnRampKit, SafeOnRampProviderType } from '../../src/index'
 ```
+
+To use the example properly in your local machine follow these steps:
+
+**In the project root**
+
+1. `yarn install`
+2. `yarn build`
+
+**In the onramp-kit client example root**
+
+3. `yarn install`
+4. Configure `.env` following `.env.sample`
+5. `yarn start`

--- a/packages/onramp-kit/example/server/.env.sample
+++ b/packages/onramp-kit/example/server/.env.sample
@@ -1,0 +1,9 @@
+
+# Frontend origin (CORS)
+FRONTEND_ORIGIN=http://localhost:3000,http://127.0.0.1:5173
+
+# Server port
+SERVER_PORT=3001
+
+# Stripe merchant Id see: https://stripe.com/docs/crypto/using-the-api
+STRIPE_SERVER_SECRET_KEY=

--- a/packages/onramp-kit/example/server/README.md
+++ b/packages/onramp-kit/example/server/README.md
@@ -3,7 +3,7 @@
 ### create a .env file
 
 ```
-FRONTEND_ORGIN=http://localhost:3000,http://127.0.0.1:5173
+FRONTEND_ORIGIN=http://localhost:3000,http://127.0.0.1:5173
 SERVER_PORT=3001
 STRIPE_SERVER_SECRET_KEY=
 ```

--- a/packages/onramp-kit/example/server/example.env
+++ b/packages/onramp-kit/example/server/example.env
@@ -1,9 +1,0 @@
-
-# Frontend origin (CORS)
-FRONTEND_ORGIN=http://localhost:3000,http://127.0.0.1:5173
-
-# Server port
-SERVER_PORT=3001
-
-# Stripe merchant Id see: https://paper.dropbox.com/doc/Public-Crypto-Onramp-Pilot-API-Testing-Guide-csKFlmSELSKNvuc1xenRd
-STRIPE_SERVER_SECRET_KEY=

--- a/packages/onramp-kit/example/server/index.ts
+++ b/packages/onramp-kit/example/server/index.ts
@@ -5,9 +5,9 @@ import routes from './src/router/router'
 
 dotenv.config()
 
-const { SERVER_PORT, FRONTEND_ORGIN } = process.env
+const { SERVER_PORT, FRONTEND_ORIGIN } = process.env
 
-const allowedOrigins = FRONTEND_ORGIN?.split(',')
+const allowedOrigins = FRONTEND_ORIGIN?.split(',')
 
 const DEFAULT_SERVER_PORT = '3001'
 


### PR DESCRIPTION
This PR add some information in the README's about how to start the example projects in the auth-kit and onramp-kit
