### PR TITLE
fix: TokenInfoListResponse results type

### DIFF
--- a/packages/api-kit/src/types/safeTransactionServiceTypes.ts
+++ b/packages/api-kit/src/types/safeTransactionServiceTypes.ts
@@ -190,7 +190,7 @@ export type TokenInfoListResponse = {
   readonly count: number
   readonly next?: string
   readonly previous?: string
-  readonly results: TokenInfoListResponse[]
+  readonly results: TokenInfoResponse[]
 }
 
 export type TransferWithTokenInfoResponse = TransferResponse & {


### PR DESCRIPTION
TokenInfoListResponse results is a circular reference. As per the API docs, it should be TokenInfoResponse.

## What it solves
Resolves an incorrect type in `api-kit`

## How this PR fixes it
Properly define TokenInfoListResponse type