### PR TITLE
fix(auth-kit): Remove log causing wallet connection error

### DIFF
--- a/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
+++ b/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
@@ -60,12 +60,6 @@ export class Web3AuthAdapter implements SafeAuthAdapter<Web3AuthAdapter> {
     if (!this.web3authInstance) return
 
     this.provider = await this.web3authInstance.connect()
-    console.log(
-      'KEY:',
-      await this.provider?.request?.({
-        method: 'eth_private_key'
-      })
-    )
   }
 
   /**


### PR DESCRIPTION
## What it solves
Metamask does not allow to get the private key so if user try to connect using a regular Wallet an exception is thrown
