### PR TITLE
feat(auth-kit): Expose the getUserInfo() method from web3auth

### DIFF
--- a/packages/auth-kit/example/src/App.tsx
+++ b/packages/auth-kit/example/src/App.tsx
@@ -14,6 +14,7 @@ import AppBar from './AppBar'
 import {
   SafeAuthKit,
   SafeAuthSignInData,
+  SafeGetUserInfoResponse,
   Web3AuthAdapter,
   Web3AuthEventListener
 } from '../../src/index'
@@ -22,10 +23,11 @@ const connectedHandler: Web3AuthEventListener = (data) => console.log('CONNECTED
 const disconnectedHandler: Web3AuthEventListener = (data) => console.log('DISCONNECTED', data)
 
 function App() {
+  const [safeAuth, setSafeAuth] = useState<SafeAuthKit<Web3AuthAdapter>>()
   const [safeAuthSignInResponse, setSafeAuthSignInResponse] = useState<SafeAuthSignInData | null>(
     null
   )
-  const [safeAuth, setSafeAuth] = useState<SafeAuthKit<Web3AuthAdapter>>()
+  const [userInfo, setUserInfo] = useState<SafeGetUserInfoResponse<Web3AuthAdapter>>()
   const [provider, setProvider] = useState<SafeEventEmitterProvider | null>(null)
 
   useEffect(() => {
@@ -90,10 +92,14 @@ function App() {
   const login = async () => {
     if (!safeAuth) return
 
-    const response = await safeAuth.signIn()
-    console.log('SIGN IN RESPONSE: ', response)
+    const signInInfo = await safeAuth.signIn()
+    console.log('SIGN IN RESPONSE: ', signInInfo)
 
-    setSafeAuthSignInResponse(response)
+    const userInfo = await safeAuth.getUserInfo()
+    console.log('USER INFO: ', userInfo)
+
+    setSafeAuthSignInResponse(signInInfo)
+    setUserInfo(userInfo || undefined)
     setProvider(safeAuth.getProvider() as SafeEventEmitterProvider)
   }
 
@@ -108,7 +114,7 @@ function App() {
 
   return (
     <>
-      <AppBar onLogin={login} onLogout={logout} isLoggedIn={!!provider} />
+      <AppBar onLogin={login} onLogout={logout} userInfo={userInfo} isLoggedIn={!!provider} />
       {safeAuthSignInResponse?.eoa && (
         <Grid container>
           <Grid item md={4} p={4}>

--- a/packages/auth-kit/example/src/AppBar.tsx
+++ b/packages/auth-kit/example/src/AppBar.tsx
@@ -1,12 +1,14 @@
 import { AppBar as MuiAppBar, Typography, styled, Box, Button } from '@mui/material'
+import { SafeGetUserInfoResponse, Web3AuthAdapter } from '../../src'
 
 type AppBarProps = {
   isLoggedIn: boolean
   onLogin: () => void
   onLogout: () => void
+  userInfo?: SafeGetUserInfoResponse<Web3AuthAdapter>
 }
 
-const AppBar = ({ isLoggedIn, onLogin, onLogout }: AppBarProps) => {
+const AppBar = ({ isLoggedIn, onLogin, onLogout, userInfo }: AppBarProps) => {
   return (
     <StyledAppBar position="static" color="default">
       <Typography variant="h3" pl={4} fontWeight={700}>
@@ -15,9 +17,16 @@ const AppBar = ({ isLoggedIn, onLogin, onLogout }: AppBarProps) => {
 
       <Box mr={5}>
         {isLoggedIn ? (
-          <Button variant="contained" onClick={onLogout}>
-            Log Out
-          </Button>
+          <Box display="flex" alignItems="center">
+            {userInfo && (
+              <Typography variant="body1" fontWeight={700}>
+                Hello {userInfo.name || userInfo.email} !!
+              </Typography>
+            )}
+            <Button variant="contained" onClick={onLogout} sx={{ ml: 2 }}>
+              Log Out
+            </Button>
+          </Box>
         ) : (
           <Button variant="contained" onClick={onLogin}>
             Login

--- a/packages/auth-kit/src/SafeAuthKit.ts
+++ b/packages/auth-kit/src/SafeAuthKit.ts
@@ -110,6 +110,15 @@ export class SafeAuthKit<TAdapter extends SafeAuthAdapter<TAdapter>>
   }
 
   /**
+   * Retrieve the user info
+   */
+  async getUserInfo() {
+    if (!this.#adapter) return null
+
+    return this.#adapter?.getUserInfo()
+  }
+
+  /**
    * Subscribe to an event
    * @param eventName The event name to subscribe to. Choose from SafeAuthEvents type
    * @param listener The callback function to be called when the event is emitted

--- a/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
+++ b/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
@@ -44,9 +44,9 @@ export class Web3AuthAdapter implements SafeAuthAdapter<Web3AuthAdapter> {
 
       this.#adapters?.forEach((adapter) => this.web3authInstance?.configureAdapter(adapter))
 
-      this.provider = this.web3authInstance.provider
-
       await this.web3authInstance.initModal({ modalConfig: this.#modalConfig })
+
+      this.provider = this.web3authInstance.provider
     } catch (e) {
       throw new Error(getErrorMessage(e))
     }

--- a/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
+++ b/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
@@ -85,7 +85,7 @@ export class Web3AuthAdapter implements SafeAuthAdapter<Web3AuthAdapter> {
       throw new Error('Web3AuthAdapter is not initialized')
     }
 
-    const userInfo = await this.web3authInstance?.getUserInfo()
+    const userInfo = await this.web3authInstance.getUserInfo()
 
     return userInfo
   }

--- a/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
+++ b/packages/auth-kit/src/packs/web3auth/Web3AuthAdapter.ts
@@ -1,4 +1,4 @@
-import { IAdapter } from '@web3auth/base'
+import { IAdapter, UserInfo } from '@web3auth/base'
 import { ModalConfig, Web3Auth, Web3AuthOptions } from '@web3auth/modal'
 import { ExternalProvider } from '@ethersproject/providers'
 
@@ -56,8 +56,10 @@ export class Web3AuthAdapter implements SafeAuthAdapter<Web3AuthAdapter> {
    * Connect to the Web3Auth service provider
    * @returns
    */
-  async signIn(): Promise<void> {
-    if (!this.web3authInstance) return
+  async signIn() {
+    if (!this.web3authInstance) {
+      throw new Error('Web3AuthAdapter is not initialized')
+    }
 
     this.provider = await this.web3authInstance.connect()
   }
@@ -65,11 +67,27 @@ export class Web3AuthAdapter implements SafeAuthAdapter<Web3AuthAdapter> {
   /**
    * Disconnect from the Web3Auth service provider
    */
-  async signOut(): Promise<void> {
-    if (!this.web3authInstance) return
+  async signOut() {
+    if (!this.web3authInstance) {
+      throw new Error('Web3AuthAdapter is not initialized')
+    }
 
     this.provider = null
     await this.web3authInstance.logout()
+  }
+
+  /**
+   * Get authenticated user information
+   * @returns The user info
+   */
+  async getUserInfo(): Promise<Partial<UserInfo>> {
+    if (!this.web3authInstance) {
+      throw new Error('Web3AuthAdapter is not initialized')
+    }
+
+    const userInfo = await this.web3authInstance?.getUserInfo()
+
+    return userInfo
   }
 
   /**

--- a/packages/auth-kit/src/types.ts
+++ b/packages/auth-kit/src/types.ts
@@ -1,4 +1,5 @@
 import { ExternalProvider } from '@ethersproject/providers'
+import { UserInfo } from '@web3auth/base'
 
 import { Web3AuthEvent, Web3AuthEventListener } from './packs/web3auth/types'
 import { Web3AuthAdapter } from './packs/web3auth/Web3AuthAdapter'
@@ -13,6 +14,7 @@ export interface SafeAuthAdapter<TAdapter> {
   init(): Promise<void>
   signIn(): Promise<SafeSignInResponse<TAdapter>>
   signOut(): Promise<void>
+  getUserInfo(): Promise<SafeGetUserInfoResponse<TAdapter>>
   subscribe(event: SafeAuthEvent<TAdapter>, handler: SafeAuthEventListener<TAdapter>): void
   unsubscribe(event: SafeAuthEvent<TAdapter>, handler: SafeAuthEventListener<TAdapter>): void
 }
@@ -28,6 +30,7 @@ export interface ISafeAuthKit<TAdapter> {
 export type SafeAuthEvent<T> = T extends Web3AuthAdapter ? Web3AuthEvent : never
 export type SafeAuthEventListener<T> = T extends Web3AuthAdapter ? Web3AuthEventListener : never
 export type SafeSignInResponse<T> = T extends Web3AuthAdapter ? void : never
+export type SafeGetUserInfoResponse<T> = T extends Web3AuthAdapter ? Partial<UserInfo> : never
 
 export interface SafeAuthConfig {
   txServiceUrl?: string


### PR DESCRIPTION
## What it solves
It allow users to use the [`getUserInfo()`](https://web3auth.io/docs/pnp/features/server-side-verification/social-login-users#getuserinfo) method from web3 auth

It expose it through the common interface as new providers can expose this information as well with their own methods


NOTE: It fix a bug where the provider was not initialised if i try to make a page refresh
