### PR TITLE
chore: update version numbers

### DIFF
--- a/packages/account-abstraction-kit/package.json
+++ b/packages/account-abstraction-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/account-abstraction-kit-poc",
-  "version": "0.1.0-alpha.1",
+  "version": "1.0.0",
   "description": "Safe Account Abstraction Kit PoC",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -34,9 +34,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@safe-global/protocol-kit": "^0.1.1",
-    "@safe-global/relay-kit": "^0.1.1",
-    "@safe-global/safe-core-sdk-types": "^1.10.1",
+    "@safe-global/protocol-kit": "^1.0.0",
+    "@safe-global/relay-kit": "^1.0.0",
+    "@safe-global/safe-core-sdk-types": "^2.0.0",
     "ethereumjs-util": "^7.1.5",
     "ethers": "^5.7.2"
   }

--- a/packages/api-kit/package.json
+++ b/packages/api-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/api-kit",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Safe API Kit",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.2",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@safe-global/protocol-kit": "^0.1.1",
+    "@safe-global/protocol-kit": "^1.0.0",
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.7.0",
-    "@safe-global/safe-core-sdk-types": "^1.10.1",
+    "@safe-global/safe-core-sdk-types": "^2.0.0",
     "node-fetch": "^2.6.6"
   }
 }

--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/auth-kit",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Authentication library for web2 logins",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -43,8 +43,8 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@safe-global/api-kit": "^1.0.1",
-    "@safe-global/protocol-kit": "^0.1.1",
+    "@safe-global/api-kit": "^1.1.0",
+    "@safe-global/protocol-kit": "^1.0.0",
     "@walletconnect/client": "^1.8.0",
     "ethers": "^5.7.2"
   },

--- a/packages/onramp-kit/package.json
+++ b/packages/onramp-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/onramp-kit",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Onramp library",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/protocol-kit",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "SDK to interact with Safe smart contracts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -53,7 +53,7 @@
     "@nomiclabs/hardhat-ethers": "^2.2.2",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@safe-global/safe-core-sdk-types": "^1.10.1",
+    "@safe-global/safe-core-sdk-types": "^2.0.0",
     "@typechain/ethers-v5": "^10.2.0",
     "@typechain/web3-v1": "^6.0.2",
     "@types/chai": "^4.3.4",

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/relay-kit",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Safe Relay Kit",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -36,8 +36,8 @@
   },
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^3.1.0",
-    "@safe-global/protocol-kit": "^0.1.1",
-    "@safe-global/safe-core-sdk-types": "^1.10.1",
+    "@safe-global/protocol-kit": "^1.0.0",
+    "@safe-global/safe-core-sdk-types": "^2.0.0",
     "ethers": "^5.7.2"
   }
 }

--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-core-sdk-types",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "description": "Safe Core SDK types",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/safe-ethers-adapters/package.json
+++ b/packages/safe-ethers-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-ethers-adapters",
-  "version": "0.1.0-alpha.16",
+  "version": "0.2.0-alpha.0",
   "description": "Safe Ethers Adapters",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -56,8 +56,8 @@
     "@ethersproject/properties": "^5.7.0"
   },
   "dependencies": {
-    "@safe-global/protocol-kit": "^0.1.1",
-    "@safe-global/safe-core-sdk-types": "^1.10.1",
+    "@safe-global/protocol-kit": "^1.0.0",
+    "@safe-global/safe-core-sdk-types": "^2.0.0",
     "@safe-global/safe-deployments": "^1.22.0",
     "axios": "^0.27.2"
   }


### PR DESCRIPTION
## Updates:

- `@safe-global/account-abstraction-kit-poc`: `v1.0.0`
- `@safe-global/api-kit`: `v1.1.0`
- `@safe-global/auth-kit`: `v1.0.0`
- `@safe-global/onramp-kit`: `v1.0.0`
- `@safe-global/protocol-kit`: `v1.0.0`
- `@safe-global/relay-kit`: `v1.0.0`
- `@safe-global/safe-core-sdk-types`: `v2.0.0`
- `@safe-global/safe-ethers-adapters`: `v0.2.0-alpha.0`



