### PR TITLE
fix(protocol-kit): enable owner resolution for predicted safe

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -259,6 +259,10 @@ class Safe {
    * @returns The list of owners
    */
   async getOwners(): Promise<string[]> {
+    if (this.#predictedSafe?.safeAccountConfig.owners) {
+      return Promise.resolve(this.#predictedSafe.safeAccountConfig.owners)
+    }
+
     return this.#ownerManager.getOwners()
   }
 
@@ -271,6 +275,7 @@ class Safe {
     if (!this.#contractManager.safeContract) {
       return Promise.resolve(0)
     }
+
     return this.#contractManager.safeContract.getNonce()
   }
 
@@ -280,6 +285,10 @@ class Safe {
    * @returns The Safe threshold
    */
   async getThreshold(): Promise<number> {
+    if (this.#predictedSafe?.safeAccountConfig.threshold) {
+      return Promise.resolve(this.#predictedSafe.safeAccountConfig.threshold)
+    }
+
     return this.#ownerManager.getThreshold()
   }
 
@@ -346,6 +355,14 @@ class Safe {
    * @returns TRUE if the account is an owner
    */
   async isOwner(ownerAddress: string): Promise<boolean> {
+    if (this.#predictedSafe?.safeAccountConfig.owners) {
+      return Promise.resolve(
+        this.#predictedSafe?.safeAccountConfig.owners.some((owner: string) =>
+          sameString(owner, ownerAddress)
+        )
+      )
+    }
+
     return this.#ownerManager.isOwner(ownerAddress)
   }
 
@@ -521,7 +538,7 @@ class Safe {
     if (!signerAddress) {
       throw new Error('EthAdapter must be initialized with a signer to use this method')
     }
-    const addressIsOwner = owners.find(
+    const addressIsOwner = owners.some(
       (owner: string) => signerAddress && sameString(owner, signerAddress)
     )
     if (!addressIsOwner) {
@@ -576,7 +593,7 @@ class Safe {
     if (!signerAddress) {
       throw new Error('EthAdapter must be initialized with a signer to use this method')
     }
-    const addressIsOwner = owners.find(
+    const addressIsOwner = owners.some(
       (owner: string) => signerAddress && sameString(owner, signerAddress)
     )
     if (!addressIsOwner) {

--- a/packages/protocol-kit/tests/e2e/createTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransaction.test.ts
@@ -437,5 +437,30 @@ describe('Transactions creation', () => {
       chai.expect(multiSendTx.data.nonce).to.be.eq(BASE_OPTIONS.nonce)
       chai.expect(multiSendTx.data.safeTxGas).to.be.eq(BASE_OPTIONS.safeTxGas)
     })
+
+    itif(safeVersionDeployed < '1.3.0')(
+      'should fail to create a transaction if the Safe with version <v1.3.0 is using predicted config',
+      async () => {
+        const { safe, predictedSafe, accounts, contractNetworks } = await setupTests()
+        const account = accounts[0]
+        const ethAdapter = await getEthAdapter(account.signer)
+        const safeSdk = await Safe.create({
+          ethAdapter,
+          predictedSafe,
+          contractNetworks
+        })
+        const safeTransactionData: SafeTransactionDataPartial = {
+          to: safe.address,
+          value: '0',
+          data: '0x'
+        }
+        const tx = safeSdk.createTransaction({ safeTransactionData })
+        await chai
+          .expect(tx)
+          .to.be.rejectedWith(
+            'Account Abstraction functionality is not available for Safes with version lower than v1.3.0'
+          )
+      }
+    )
   })
 })

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -97,10 +97,12 @@ describe('Off-chain signatures', () => {
           data: '0x'
         }
         const tx = await safeSdkExistingSafe.createTransaction({ safeTransactionData })
-        chai.expect(tx.signatures.size).to.be.eq(0)
-        const signedTx = await safeSdk.signTransaction(tx)
-        chai.expect(tx.signatures.size).to.be.eq(0)
-        chai.expect(signedTx.signatures.size).to.be.eq(1)
+        const signedTx = safeSdk.signTransaction(tx)
+        await chai
+          .expect(signedTx)
+          .to.be.rejectedWith(
+            'Account Abstraction functionality is not available for Safes with version lower than v1.3.0'
+          )
       }
     )
 

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -76,54 +76,50 @@ describe('Off-chain signatures', () => {
 
   describe('signTransaction', async () => {
     itif(safeVersionDeployed < '1.3.0')(
-      'should fail if the Safe with version <v1.3.0 is not deployed',
+      'should sign a transaction with the current signer if the Safe with version <v1.3.0 is using predicted config',
       async () => {
         const { safe, predictedSafe, accounts, contractNetworks } = await setupTests()
-        const account3 = accounts[2]
-        const ethAdapter = await getEthAdapter(account3.signer)
+        const account = accounts[0]
+        const ethAdapter = await getEthAdapter(account.signer)
         const safeSdk = await Safe.create({
           ethAdapter,
           predictedSafe,
           contractNetworks
         })
-        const safeSdkExistingSafe = await Safe.create({
-          ethAdapter,
-          safeAddress: safe.address,
-          contractNetworks
-        })
         const safeTransactionData: SafeTransactionDataPartial = {
-          to: await safeSdkExistingSafe.getAddress(),
+          to: safe.address,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdkExistingSafe.createTransaction({ safeTransactionData })
-        await chai.expect(safeSdk.signTransaction(tx)).to.be.rejectedWith('Safe is not deployed')
+        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        chai.expect(tx.signatures.size).to.be.eq(0)
+        const signedTx = await safeSdk.signTransaction(tx)
+        chai.expect(tx.signatures.size).to.be.eq(0)
+        chai.expect(signedTx.signatures.size).to.be.eq(1)
       }
     )
 
     itif(safeVersionDeployed >= '1.3.0')(
-      'should fail if the Safe with version >=v1.3.0 is not deployed',
+      'should sign a transaction with the current signer if the Safe with version >=v1.3.0 is using predicted config',
       async () => {
         const { safe, predictedSafe, accounts, contractNetworks } = await setupTests()
-        const account3 = accounts[2]
-        const ethAdapter = await getEthAdapter(account3.signer)
+        const account = accounts[0]
+        const ethAdapter = await getEthAdapter(account.signer)
         const safeSdk = await Safe.create({
           ethAdapter,
           predictedSafe,
           contractNetworks
         })
-        const safeSdkExistingSafe = await Safe.create({
-          ethAdapter,
-          safeAddress: safe.address,
-          contractNetworks
-        })
         const safeTransactionData: SafeTransactionDataPartial = {
-          to: await safeSdkExistingSafe.getAddress(),
+          to: safe.address,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdkExistingSafe.createTransaction({ safeTransactionData })
-        await chai.expect(safeSdk.signTransaction(tx)).to.be.rejectedWith('Safe is not deployed')
+        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        chai.expect(tx.signatures.size).to.be.eq(0)
+        const signedTx = await safeSdk.signTransaction(tx)
+        chai.expect(tx.signatures.size).to.be.eq(0)
+        chai.expect(signedTx.signatures.size).to.be.eq(1)
       }
     )
 

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -86,12 +86,17 @@ describe('Off-chain signatures', () => {
           predictedSafe,
           contractNetworks
         })
+        const safeSdkExistingSafe = await Safe.create({
+          ethAdapter,
+          safeAddress: safe.address,
+          contractNetworks
+        })
         const safeTransactionData: SafeTransactionDataPartial = {
-          to: safe.address,
+          to: await safeSdkExistingSafe.getAddress(),
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdkExistingSafe.createTransaction({ safeTransactionData })
         chai.expect(tx.signatures.size).to.be.eq(0)
         const signedTx = await safeSdk.signTransaction(tx)
         chai.expect(tx.signatures.size).to.be.eq(0)

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -76,7 +76,7 @@ describe('Off-chain signatures', () => {
 
   describe('signTransaction', async () => {
     itif(safeVersionDeployed < '1.3.0')(
-      'should sign a transaction with the current signer if the Safe with version <v1.3.0 is using predicted config',
+      'should fail to sign a transaction if the Safe with version <v1.3.0 is using predicted config',
       async () => {
         const { safe, predictedSafe, accounts, contractNetworks } = await setupTests()
         const account = accounts[0]


### PR DESCRIPTION
## What it solves
Resolves #428 

## How this PR fixes it
Enable `protocol-kit` to resolve owners from the config set when using predictedSafe