### PR TITLE
fix(protocol-kit): safeDeploymentConfig is an optional parameter in PredictedSafeProps

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -246,7 +246,7 @@ class Safe {
       return this.#contractManager.safeContract.getVersion()
     }
 
-    if (this.#predictedSafe?.safeDeploymentConfig.safeVersion) {
+    if (this.#predictedSafe?.safeDeploymentConfig?.safeVersion) {
       return Promise.resolve(this.#predictedSafe.safeDeploymentConfig.safeVersion)
     }
 

--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -20,7 +20,7 @@ import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
 export const PREDETERMINED_SALT_NONCE =
   '0xb1073742015cbcf5a3a4d9d1ae33ecf619439710b89475f92e2abd2117e90f90'
 
-export interface PredictSafeProps {
+export interface PredictSafeAddressProps {
   ethAdapter: EthAdapter
   safeAccountConfig: SafeAccountConfig
   safeDeploymentConfig?: SafeDeploymentConfig
@@ -108,7 +108,7 @@ export async function predictSafeAddress({
   safeDeploymentConfig = {},
   isL1SafeMasterCopy = false,
   customContracts
-}: PredictSafeProps): Promise<string> {
+}: PredictSafeAddressProps): Promise<string> {
   validateSafeAccountConfig(safeAccountConfig)
   validateSafeDeploymentConfig(safeDeploymentConfig)
 

--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -23,7 +23,7 @@ export const PREDETERMINED_SALT_NONCE =
 export interface PredictSafeProps {
   ethAdapter: EthAdapter
   safeAccountConfig: SafeAccountConfig
-  safeDeploymentConfig: SafeDeploymentConfig
+  safeDeploymentConfig?: SafeDeploymentConfig
   isL1SafeMasterCopy?: boolean
   customContracts?: ContractNetworkConfig
 }
@@ -105,7 +105,7 @@ export async function encodeSetupCallData({
 export async function predictSafeAddress({
   ethAdapter,
   safeAccountConfig,
-  safeDeploymentConfig,
+  safeDeploymentConfig = {},
   isL1SafeMasterCopy = false,
   customContracts
 }: PredictSafeProps): Promise<string> {

--- a/packages/protocol-kit/src/managers/contractManager.ts
+++ b/packages/protocol-kit/src/managers/contractManager.ts
@@ -37,7 +37,7 @@ class ContractManager {
     let safeVersion: SafeVersion
 
     if (isSafeConfigWithPredictedSafe(config)) {
-      safeVersion = config.predictedSafe.safeDeploymentConfig.safeVersion ?? SAFE_LAST_VERSION
+      safeVersion = config.predictedSafe.safeDeploymentConfig?.safeVersion ?? SAFE_LAST_VERSION
     } else {
       const temporarySafeContract = await getSafeContract({
         ethAdapter,

--- a/packages/protocol-kit/src/types/index.ts
+++ b/packages/protocol-kit/src/types/index.ts
@@ -26,7 +26,7 @@ export interface SafeDeploymentConfig {
 
 export interface PredictedSafeProps {
   safeAccountConfig: SafeAccountConfig
-  safeDeploymentConfig: SafeDeploymentConfig
+  safeDeploymentConfig?: SafeDeploymentConfig
 }
 
 export interface ContractNetworkConfig {

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -52,7 +52,7 @@ export async function standardizeSafeTransactionData({
   }
 
   let safeVersion: SafeVersion
-  if (predictedSafe?.safeDeploymentConfig.safeVersion) {
+  if (predictedSafe?.safeDeploymentConfig?.safeVersion) {
     safeVersion = predictedSafe?.safeDeploymentConfig.safeVersion
   } else {
     if (!safeContract) {

--- a/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
+++ b/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
@@ -453,5 +453,38 @@ describe('Contract utils', () => {
       chai.expect(secondPredictedSafeAddress).to.be.equal(expectedSafeAddress)
       chai.expect(thirdPredictedSafeAddress).to.be.equal(expectedSafeAddress)
     })
+
+    it('safeDeploymentConfig is an optional parameter', async () => {
+      const { accounts, contractNetworks, chainId } = await setupTests()
+
+      // 1/1 Safe
+      const [owner1] = accounts
+      const owners = [owner1.address]
+      const threshold = 1
+      const ethAdapter = await getEthAdapter(owner1.signer)
+      const customContracts = contractNetworks[chainId]
+
+      const safeAccountConfig: SafeAccountConfig = {
+        owners,
+        threshold
+      }
+
+      const predictedSafeAddress = await predictSafeAddress({
+        ethAdapter,
+        safeAccountConfig,
+        customContracts
+      })
+
+      // we deploy the Safe by providing only the safeAccountConfig (owners & threshold)
+      const deployedSafe = await deploySafe({ safeAccountConfig }, ethAdapter, contractNetworks)
+
+      // We ensure the Safe is deployed
+      const isSafeDeployed = await deployedSafe.isSafeDeployed()
+      chai.expect(isSafeDeployed).to.be.true
+
+      // The deployed Safe address should be equal to the predicted address
+      const expectedSafeAddress = await deployedSafe.getAddress()
+      chai.expect(predictedSafeAddress).to.be.equal(expectedSafeAddress)
+    })
   })
 })

--- a/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
+++ b/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@safe-global/protocol-kit/types'
 import Safe, { SafeFactory, DeploySafeProps } from '@safe-global/protocol-kit/index'
 import { EthAdapter } from '@safe-global/safe-core-sdk-types'
+import { itif } from './utils/helpers'
 
 // test util funcion to deploy a safe (needed to check the expected Safe Address)
 async function deploySafe(
@@ -454,37 +455,40 @@ describe('Contract utils', () => {
       chai.expect(thirdPredictedSafeAddress).to.be.equal(expectedSafeAddress)
     })
 
-    it('safeDeploymentConfig is an optional parameter', async () => {
-      const { accounts, contractNetworks, chainId } = await setupTests()
+    itif(safeVersionDeployed > '1.0.0')(
+      'safeDeploymentConfig is an optional parameter',
+      async () => {
+        const { accounts, contractNetworks, chainId } = await setupTests()
 
-      // 1/1 Safe
-      const [owner1] = accounts
-      const owners = [owner1.address]
-      const threshold = 1
-      const ethAdapter = await getEthAdapter(owner1.signer)
-      const customContracts = contractNetworks[chainId]
+        // 1/1 Safe
+        const [owner1] = accounts
+        const owners = [owner1.address]
+        const threshold = 1
+        const ethAdapter = await getEthAdapter(owner1.signer)
+        const customContracts = contractNetworks[chainId]
 
-      const safeAccountConfig: SafeAccountConfig = {
-        owners,
-        threshold
+        const safeAccountConfig: SafeAccountConfig = {
+          owners,
+          threshold
+        }
+
+        const predictedSafeAddress = await predictSafeAddress({
+          ethAdapter,
+          safeAccountConfig,
+          customContracts
+        })
+
+        // we deploy the Safe by providing only the safeAccountConfig (owners & threshold)
+        const deployedSafe = await deploySafe({ safeAccountConfig }, ethAdapter, contractNetworks)
+
+        // We ensure the Safe is deployed
+        const isSafeDeployed = await deployedSafe.isSafeDeployed()
+        chai.expect(isSafeDeployed).to.be.true
+
+        // The deployed Safe address should be equal to the predicted address
+        const expectedSafeAddress = await deployedSafe.getAddress()
+        chai.expect(predictedSafeAddress).to.be.equal(expectedSafeAddress)
       }
-
-      const predictedSafeAddress = await predictSafeAddress({
-        ethAdapter,
-        safeAccountConfig,
-        customContracts
-      })
-
-      // we deploy the Safe by providing only the safeAccountConfig (owners & threshold)
-      const deployedSafe = await deploySafe({ safeAccountConfig }, ethAdapter, contractNetworks)
-
-      // We ensure the Safe is deployed
-      const isSafeDeployed = await deployedSafe.isSafeDeployed()
-      chai.expect(isSafeDeployed).to.be.true
-
-      // The deployed Safe address should be equal to the predicted address
-      const expectedSafeAddress = await deployedSafe.getAddress()
-      chai.expect(predictedSafeAddress).to.be.equal(expectedSafeAddress)
-    })
+    )
   })
 })


### PR DESCRIPTION
## What it solves
Resolves #426

## How this PR fixes it

`safeDeploymentConfig` is an optional parameter in the `PredictSafeProps` type

```
export interface PredictedSafeProps {
  safeAccountConfig: SafeAccountConfig
  safeDeploymentConfig?: SafeDeploymentConfig
}
```