### PR TITLE
fix(protocol-kit): fix standardizeSafeTransactionData for predictedSafe flow

### DIFF
--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -53,7 +53,7 @@ export async function standardizeSafeTransactionData({
   }
 
   let safeVersion: SafeVersion
-  if (!!predictedSafe) {
+  if (predictedSafe) {
     safeVersion = predictedSafe?.safeDeploymentConfig?.safeVersion || SAFE_LAST_VERSION
   } else {
     if (!safeContract) {

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -4,6 +4,7 @@ import { pack as solidityPack } from '@ethersproject/solidity'
 import { StandardizeSafeTransactionDataProps } from '@safe-global/protocol-kit/types'
 import { hasSafeFeature, SAFE_FEATURES } from '@safe-global/protocol-kit/utils'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
+import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import {
   MetaTransactionData,
   OperationType,
@@ -52,8 +53,8 @@ export async function standardizeSafeTransactionData({
   }
 
   let safeVersion: SafeVersion
-  if (predictedSafe?.safeDeploymentConfig?.safeVersion) {
-    safeVersion = predictedSafe?.safeDeploymentConfig.safeVersion
+  if (!!predictedSafe) {
+    safeVersion = predictedSafe?.safeDeploymentConfig?.safeVersion || SAFE_LAST_VERSION
   } else {
     if (!safeContract) {
       throw new Error('Safe is not deployed')


### PR DESCRIPTION
## What it solves
Resolves #427

I should be able to create a Safe transaction even if there is not explicit Safe version in the safeSDK predict config object.

## How this PR fixes it

```
  if (predictedSafe) {
    safeVersion = predictedSafe?.safeDeploymentConfig?.safeVersion || SAFE_LAST_VERSION
```

https://github.com/safe-global/safe-core-sdk/blob/f2e8e82d88d815d7b278f605a125f4cfb2816020/packages/protocol-kit/src/utils/transactions/utils.ts#L54-L62
