### PR TITLE
fix(onramp-kit): Remove onramp-kit peerDeps

### DIFF
--- a/packages/onramp-kit/package.json
+++ b/packages/onramp-kit/package.json
@@ -35,21 +35,16 @@
     "access": "public"
   },
   "dependencies": {
+    "@monerium/sdk": "^2.3.0",
     "@safe-global/api-kit": "^1.1.0",
     "@safe-global/protocol-kit": "^1.0.1",
     "@safe-global/safe-core-sdk-types": "^2.0.0",
+    "@stripe/crypto": "^0.0.4",
+    "@stripe/stripe-js": "^1.52.0",
     "ethers": "^5.7.0"
   },
   "devDependencies": {
-    "@monerium/sdk": "^2.3.0",
-    "@stripe/crypto": "^0.0.4",
-    "@stripe/stripe-js": "^1.52.0",
     "events": "^3.3.0",
     "jest-environment-jsdom": "^29.5.0"
-  },
-  "peerDependencies": {
-    "@monerium/sdk": "^2.3.0",
-    "@stripe/crypto": "^0.0.4",
-    "@stripe/stripe-js": "^1.52.0"
   }
 }


### PR DESCRIPTION
## What it solves

We need to consider how to deliver the packs more effectively. To quickly address this, we are removing `peerDependencies`. If the destination app is only using one pack, the execution will fail requiring other packs