### PR TITLE
chore: fix relay playground types

### DIFF
--- a/playground/relay-kit/paid-transaction.ts
+++ b/playground/relay-kit/paid-transaction.ts
@@ -1,10 +1,9 @@
 import AccountAbstraction, {
   AccountAbstractionConfig,
-  MetaTransactionData,
-  MetaTransactionOptions,
   OperationType
 } from '@safe-global/account-abstraction-kit-poc'
 import { GelatoRelayPack } from '@safe-global/relay-kit'
+import { MetaTransactionData, MetaTransactionOptions } from '@safe-global/safe-core-sdk-types'
 import { BigNumber, ethers } from 'ethers'
 
 // Check the status of a transaction after it is relayed:
@@ -28,7 +27,7 @@ const txConfig = {
   DATA: '<DATA>',
   VALUE: '<VALUE>',
   // Options:
-  GAS_LIMIT: BigNumber.from('<GAS_LIMIT>'),
+  GAS_LIMIT: '<GAS_LIMIT>',
   GAS_TOKEN: ethers.constants.AddressZero
 }
 
@@ -67,7 +66,7 @@ async function main() {
   if (safeBalance.lt(relayFee)) {
     const fakeOnRampSigner = new ethers.Wallet(mockOnRampConfig.PRIVATE_KEY, provider)
     const fundingAmount = safeBalance.lt(relayFee)
-      ? relayFee.sub(safeBalance)
+      ? BigNumber.from(relayFee).sub(safeBalance)
       : safeBalance.sub(relayFee)
     const onRampResponse = await fakeOnRampSigner.sendTransaction({
       to: predictedSafeAddress,

--- a/playground/relay-kit/sponsored-transaction.ts
+++ b/playground/relay-kit/sponsored-transaction.ts
@@ -1,10 +1,7 @@
-import AccountAbstraction, {
-  MetaTransactionData,
-  MetaTransactionOptions,
-  OperationType
-} from '@safe-global/account-abstraction-kit-poc'
+import AccountAbstraction, { OperationType } from '@safe-global/account-abstraction-kit-poc'
 import { GelatoRelayPack } from '@safe-global/relay-kit'
-import { BigNumber, ethers } from 'ethers'
+import { MetaTransactionData, MetaTransactionOptions } from '@safe-global/safe-core-sdk-types'
+import { ethers } from 'ethers'
 import { AccountAbstractionConfig } from './../../packages/account-abstraction-kit/src/types/index'
 
 // Fund the 1Balance account that will sponsor the transaction and get the API key:
@@ -32,7 +29,7 @@ const txConfig = {
   DATA: '<DATA>',
   VALUE: '<VALUE>',
   // Options:
-  GAS_LIMIT: BigNumber.from('<GAS_LIMIT>')
+  GAS_LIMIT: '<GAS_LIMIT>'
 }
 
 async function main() {


### PR DESCRIPTION
## What it solves
Updates the relay playground scripts after `gasLimit` type was changed to `string`
