### PR TITLE
feat(protocol-kit): smart contract signatures (EIP-1271)

### DIFF
--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -640,7 +640,7 @@ const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const signature = await safeSdk.signTransactionHash(txHash)
 ```
 
-### signTypedData
+### signTransactionTypedData
 
 Signs a transaction according to the EIP-712 using the current signer account.
 
@@ -649,7 +649,7 @@ const safeTransactionData: SafeTransactionDataPartial = {
   // ...
 }
 const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
-const signature = await safeSdk.signTypedData(safeTransaction)
+const signature = await safeSdk.signTransactionTypedData(safeTransaction)
 ```
 
 ### signTransaction

--- a/packages/protocol-kit/hardhat.config.ts
+++ b/packages/protocol-kit/hardhat.config.ts
@@ -43,7 +43,7 @@ const config: HardhatUserConfig = {
     artifacts: 'artifacts',
     deploy: 'hardhat/deploy',
     sources: 'contracts',
-    tests: 'tests/e2e'
+    tests: 'tests'
   },
   networks: {
     localhost: {

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import {
+  Eip712MessageTypes,
   EthAdapter,
   OperationType,
   SafeMultisigTransactionResponse,
@@ -500,7 +501,7 @@ class Safe {
    * @param methodVersion - EIP-712 version. Optional
    * @returns The Safe signature
    */
-  async signTypedData(
+  async signTransactionTypedData(
     safeTransaction: SafeTransaction,
     methodVersion?: 'v3' | 'v4'
   ): Promise<SafeSignature> {
@@ -547,11 +548,11 @@ class Safe {
 
     let signature: SafeSignature
     if (signingMethod === 'eth_signTypedData_v4') {
-      signature = await this.signTypedData(transaction, 'v4')
+      signature = await this.signTransactionTypedData(transaction, 'v4')
     } else if (signingMethod === 'eth_signTypedData_v3') {
-      signature = await this.signTypedData(transaction, 'v3')
+      signature = await this.signTransactionTypedData(transaction, 'v3')
     } else if (signingMethod === 'eth_signTypedData') {
-      signature = await this.signTypedData(transaction)
+      signature = await this.signTransactionTypedData(transaction)
     } else {
       const safeVersion = await this.getContractVersion()
       if (!hasSafeFeature(SAFE_FEATURES.ETH_SIGN, safeVersion)) {

--- a/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
+++ b/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
@@ -2,7 +2,10 @@ import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Provider } from '@ethersproject/providers'
-import { generateTypedData, validateEip3770Address } from '@safe-global/protocol-kit/utils'
+import {
+  generateTransactionTypedData,
+  validateEip3770Address
+} from '@safe-global/protocol-kit/utils'
 import {
   Eip3770Address,
   EthAdapter,
@@ -232,7 +235,7 @@ class EthersAdapter implements EthAdapter {
       throw new Error('EthAdapter must be initialized with a signer to use this method')
     }
     if (isTypedDataSigner(this.#signer)) {
-      const typedData = generateTypedData(safeTransactionEIP712Args)
+      const typedData = generateTransactionTypedData(safeTransactionEIP712Args)
       const signature = await this.#signer._signTypedData(
         typedData.domain,
         { SafeTx: typedData.types.SafeTx },

--- a/packages/protocol-kit/src/adapters/web3/Web3Adapter.ts
+++ b/packages/protocol-kit/src/adapters/web3/Web3Adapter.ts
@@ -1,5 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { generateTypedData, validateEip3770Address } from '@safe-global/protocol-kit/utils'
+import {
+  generateTransactionTypedData,
+  validateEip3770Address
+} from '@safe-global/protocol-kit/utils'
 import {
   Eip3770Address,
   EthAdapter,
@@ -253,7 +256,7 @@ class Web3Adapter implements EthAdapter {
     if (!this.#signerAddress) {
       throw new Error('This method requires a signer')
     }
-    const typedData = generateTypedData(safeTransactionEIP712Args)
+    const typedData = generateTransactionTypedData(safeTransactionEIP712Args)
     let method = 'eth_signTypedData_v3'
     if (methodVersion === 'v4') {
       method = 'eth_signTypedData_v4'

--- a/packages/protocol-kit/src/utils/signatures/SmartContractSignature.ts
+++ b/packages/protocol-kit/src/utils/signatures/SmartContractSignature.ts
@@ -1,6 +1,7 @@
+import { hexlify, hexZeroPad } from 'ethers/lib/utils'
 import { SafeSignature } from '@safe-global/safe-core-sdk-types'
 
-export class EthSafeSignature implements SafeSignature {
+export class SmartContractSafeSignature implements SafeSignature {
   signer: string
   data: string
 
@@ -21,9 +22,8 @@ export class EthSafeSignature implements SafeSignature {
    *
    * @returns The static part of the Safe signature
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  staticPart(_dynamicOffset: number) {
-    return this.data
+  staticPart(dynamicOffset: number) {
+    return hexZeroPad(this.signer, 32) + hexZeroPad(hexlify(dynamicOffset), 32).slice(2) + '00'
   }
 
   /**
@@ -32,6 +32,7 @@ export class EthSafeSignature implements SafeSignature {
    * @returns The dynamic part of the Safe signature
    */
   dynamicPart() {
-    return ''
+    const byteLength = hexZeroPad(hexlify(this.data.slice(2).length / 2), 32)
+    return (byteLength + this.data.slice(2)).slice(2)
   }
 }

--- a/packages/protocol-kit/src/utils/transactions/SafeTransaction.ts
+++ b/packages/protocol-kit/src/utils/transactions/SafeTransaction.ts
@@ -23,7 +23,7 @@ class EthSafeTransaction implements SafeTransaction {
     let dynamicParts = ''
     signers.forEach((signerAddress) => {
       const signature = this.signatures.get(signerAddress)
-      staticParts += signature?.staticPart(/*baseOffset + dynamicParts.length / 2*/).slice(2)
+      staticParts += signature?.staticPart(baseOffset + dynamicParts.length / 2).slice(2)
       dynamicParts += signature?.dynamicPart()
     })
     return '0x' + staticParts + dynamicParts

--- a/packages/protocol-kit/tests/unit/eip-712.test.ts
+++ b/packages/protocol-kit/tests/unit/eip-712.test.ts
@@ -1,10 +1,12 @@
 import { SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+
 import chai from 'chai'
 import {
   EIP712_DOMAIN,
   EIP712_DOMAIN_BEFORE_V130,
-  generateTypedData,
-  getEip712MessageTypes
+  generateSafeMessageTypedData,
+  generateTransactionTypedData,
+  getEip712TransactionMessageTypes
 } from '@safe-global/protocol-kit/utils'
 
 const safeAddress = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
@@ -13,9 +15,9 @@ const safeTransactionData: SafeTransactionData = {
   value: '111',
   data: '0x222',
   operation: 333,
-  safeTxGas: 444,
-  baseGas: 555,
-  gasPrice: 666,
+  safeTxGas: '444',
+  baseGas: '555',
+  gasPrice: '666',
   gasToken: '0x777',
   refundReceiver: '0x888',
   nonce: 999
@@ -24,29 +26,29 @@ const safeTransactionData: SafeTransactionData = {
 describe('EIP-712 sign typed data', () => {
   describe('getEip712MessageTypes', async () => {
     it('should have the domain typed as EIP712_DOMAIN_BEFORE_V130 for Safes == v1.0.0', async () => {
-      const { EIP712Domain } = getEip712MessageTypes('1.0.0')
+      const { EIP712Domain } = getEip712TransactionMessageTypes('1.0.0')
       chai.expect(EIP712Domain).to.be.eq(EIP712_DOMAIN_BEFORE_V130)
     })
 
     it('should have the domain typed as EIP712_DOMAIN_BEFORE_V130 for Safes == v1.1.1', async () => {
-      const { EIP712Domain } = getEip712MessageTypes('1.1.1')
+      const { EIP712Domain } = getEip712TransactionMessageTypes('1.1.1')
       chai.expect(EIP712Domain).to.be.eq(EIP712_DOMAIN_BEFORE_V130)
     })
 
     it('should have the domain typed as EIP712_DOMAIN_BEFORE_V130 for Safes == v1.2.0', async () => {
-      const { EIP712Domain } = getEip712MessageTypes('1.2.0')
+      const { EIP712Domain } = getEip712TransactionMessageTypes('1.2.0')
       chai.expect(EIP712Domain).to.be.eq(EIP712_DOMAIN_BEFORE_V130)
     })
 
     it('should have the domain typed as EIP712_DOMAIN for Safes >= v1.3.0', async () => {
-      const { EIP712Domain } = getEip712MessageTypes('1.3.0')
+      const { EIP712Domain } = getEip712TransactionMessageTypes('1.3.0')
       chai.expect(EIP712Domain).to.be.eq(EIP712_DOMAIN)
     })
   })
 
   describe('generateTypedData', async () => {
     it('should generate the typed data for Safes == v1.0.0', async () => {
-      const { domain } = generateTypedData({
+      const { domain } = generateTransactionTypedData({
         safeAddress,
         safeVersion: '1.0.0',
         chainId: 4,
@@ -57,7 +59,7 @@ describe('EIP-712 sign typed data', () => {
     })
 
     it('should generate the typed data for Safes == v1.1.1', async () => {
-      const { domain } = generateTypedData({
+      const { domain } = generateTransactionTypedData({
         safeAddress,
         safeVersion: '1.1.1',
         chainId: 4,
@@ -68,7 +70,7 @@ describe('EIP-712 sign typed data', () => {
     })
 
     it('should generate the typed data for Safes == v1.2.0', async () => {
-      const { domain } = generateTypedData({
+      const { domain } = generateTransactionTypedData({
         safeAddress,
         safeVersion: '1.2.0',
         chainId: 4,
@@ -80,7 +82,7 @@ describe('EIP-712 sign typed data', () => {
 
     it('should generate the typed data for for Safes >= v1.3.0', async () => {
       const chainId = 4
-      const { domain } = generateTypedData({
+      const { domain } = generateTransactionTypedData({
         safeAddress,
         safeVersion: '1.3.0',
         chainId,
@@ -88,6 +90,264 @@ describe('EIP-712 sign typed data', () => {
       })
       chai.expect(domain.verifyingContract).to.be.eq(safeAddress)
       chai.expect(domain.chainId).to.be.eq(chainId)
+    })
+  })
+
+  describe('safe-messages', () => {
+    describe('createSafeMessage', () => {
+      it('should generate the correct types for a EIP-191 message for >= 1.3.0 Safes', () => {
+        const message = 'Hello world!'
+
+        const safeMessage = generateSafeMessageTypedData({
+          safeAddress,
+          safeVersion: '1.3.0',
+          chainId: 1,
+          message
+        })
+
+        chai.expect(safeMessage).to.deep.eq({
+          types: {
+            EIP712Domain: [
+              {
+                name: 'chainId',
+                type: 'uint256'
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address'
+              }
+            ],
+            SafeMessage: [{ name: 'message', type: 'bytes' }]
+          },
+          domain: {
+            chainId: 1,
+            verifyingContract: safeAddress
+          },
+          primaryType: 'SafeMessage',
+          message: {
+            message: '0xaa05af77f274774b8bdc7b61d98bc40da523dc2821fdea555f4d6aa413199bcc'
+          }
+        })
+      })
+
+      it('should generate the correct types for a EIP-191 message for < 1.3.0 Safes', () => {
+        const message = 'Hello world!'
+
+        const safeMessage = generateSafeMessageTypedData({
+          safeAddress,
+          safeVersion: '1.1.1',
+          chainId: 1,
+          message
+        })
+
+        chai.expect(safeMessage).to.deep.eq({
+          types: {
+            EIP712Domain: [
+              {
+                name: 'verifyingContract',
+                type: 'address'
+              }
+            ],
+            SafeMessage: [{ name: 'message', type: 'bytes' }]
+          },
+          domain: {
+            verifyingContract: safeAddress
+          },
+          primaryType: 'SafeMessage',
+          message: {
+            message: '0xaa05af77f274774b8bdc7b61d98bc40da523dc2821fdea555f4d6aa413199bcc'
+          }
+        })
+      })
+
+      it('should generate the correct types for an EIP-712 message for >=1.3.0 Safes', () => {
+        const message = {
+          domain: {
+            chainId: 1,
+            name: 'Ether Mail',
+            verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+            version: '1'
+          },
+          message: {
+            contents: 'Hello, Bob!',
+            from: {
+              name: 'Cow',
+              wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'
+            },
+            to: {
+              name: 'Bob',
+              wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB'
+            }
+          },
+          primaryType: 'Mail',
+          types: {
+            EIP712Domain: [
+              {
+                name: 'name',
+                type: 'string'
+              },
+              {
+                name: 'version',
+                type: 'string'
+              },
+              {
+                name: 'chainId',
+                type: 'uint256'
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address'
+              }
+            ],
+            Mail: [
+              {
+                name: 'from',
+                type: 'Person'
+              },
+              {
+                name: 'to',
+                type: 'Person'
+              },
+              {
+                name: 'contents',
+                type: 'string'
+              }
+            ],
+            Person: [
+              {
+                name: 'name',
+                type: 'string'
+              },
+              {
+                name: 'wallet',
+                type: 'address'
+              }
+            ]
+          }
+        }
+        const safeMessage = generateSafeMessageTypedData({
+          safeAddress,
+          safeVersion: '1.3.0',
+          chainId: 1,
+          message
+        })
+
+        chai.expect(safeMessage).to.deep.eq({
+          types: {
+            EIP712Domain: [
+              {
+                name: 'chainId',
+                type: 'uint256'
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address'
+              }
+            ],
+            SafeMessage: [{ name: 'message', type: 'bytes' }]
+          },
+          domain: {
+            chainId: 1,
+            verifyingContract: safeAddress
+          },
+          primaryType: 'SafeMessage',
+          message: {
+            message: '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2'
+          }
+        })
+      })
+
+      it('should generate the correct types for an EIP-712 message for <1.3.0 Safes', () => {
+        const message = {
+          domain: {
+            chainId: 1,
+            name: 'Ether Mail',
+            verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+            version: '1'
+          },
+          message: {
+            contents: 'Hello, Bob!',
+            from: {
+              name: 'Cow',
+              wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'
+            },
+            to: {
+              name: 'Bob',
+              wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB'
+            }
+          },
+          primaryType: 'Mail',
+          types: {
+            EIP712Domain: [
+              {
+                name: 'name',
+                type: 'string'
+              },
+              {
+                name: 'version',
+                type: 'string'
+              },
+              {
+                name: 'chainId',
+                type: 'uint256'
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address'
+              }
+            ],
+            Mail: [
+              {
+                name: 'from',
+                type: 'Person'
+              },
+              {
+                name: 'to',
+                type: 'Person'
+              },
+              {
+                name: 'contents',
+                type: 'string'
+              }
+            ],
+            Person: [
+              {
+                name: 'name',
+                type: 'string'
+              },
+              {
+                name: 'wallet',
+                type: 'address'
+              }
+            ]
+          }
+        }
+
+        const safeMessage = generateSafeMessageTypedData({
+          safeAddress,
+          safeVersion: '1.1.1',
+          chainId: 1,
+          message
+        })
+        chai.expect(safeMessage).to.deep.eq({
+          types: {
+            EIP712Domain: [
+              {
+                name: 'verifyingContract',
+                type: 'address'
+              }
+            ],
+            SafeMessage: [{ name: 'message', type: 'bytes' }]
+          },
+          domain: {
+            verifyingContract: safeAddress
+          },
+          primaryType: 'SafeMessage',
+          message: {
+            message: '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2'
+          }
+        })
+      })
     })
   })
 })

--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -1,5 +1,6 @@
 import { ContractTransaction } from '@ethersproject/contracts'
 import { PromiEvent, TransactionReceipt } from 'web3-core/types'
+import { EthAdapter } from './ethereumLibs/EthAdapter'
 
 export type SafeVersion = '1.3.0' | '1.2.0' | '1.1.1' | '1.0.0'
 
@@ -91,7 +92,14 @@ export interface SafeTransactionEIP712Args {
   safeTransactionData: SafeTransactionData
 }
 
-export interface Eip712MessageTypes {
+export interface SafeMessageEIP712Args {
+  safeAddress: string
+  safeVersion: string
+  chainId: number
+  message: string | EIP712TypedData
+}
+
+export interface Eip712TransactionTypes {
   EIP712Domain: {
     type: string
     name: string
@@ -102,8 +110,8 @@ export interface Eip712MessageTypes {
   }[]
 }
 
-export interface GenerateTypedData {
-  types: Eip712MessageTypes
+export interface SafeTransactionTypedData {
+  types: Eip712TransactionTypes
   domain: {
     chainId?: number
     verifyingContract: string
@@ -121,6 +129,52 @@ export interface GenerateTypedData {
     refundReceiver: string
     nonce: number
   }
+}
+
+export interface Eip712MessageTypes {
+  EIP712Domain: {
+    type: string
+    name: string
+  }[]
+  SafeMessage: [
+    {
+      type: 'bytes'
+      name: 'message'
+    }
+  ]
+}
+
+export interface SafeMessageTypedData {
+  types: Eip712MessageTypes
+  domain: {
+    chainId?: number
+    verifyingContract: string
+  }
+  primaryType: 'SafeMessage'
+  message: {
+    message: string
+  }
+}
+// Types for arbitrary off-chain messages
+interface TypedDataDomain {
+  name?: string
+  version?: string
+  chainId?: unknown
+  verifyingContract?: string
+  salt?: ArrayLike<number> | string
+}
+interface TypedDataTypes {
+  name: string
+  type: string
+}
+type TypedMessageTypes = {
+  [key: string]: TypedDataTypes[]
+}
+
+export type EIP712TypedData = {
+  domain: TypedDataDomain
+  types: TypedMessageTypes
+  message: Record<string, unknown>
 }
 
 export type SafeMultisigConfirmationResponse = {

--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -48,7 +48,7 @@ export interface SafeTransactionDataPartial extends MetaTransactionData {
 export interface SafeSignature {
   readonly signer: string
   readonly data: string
-  staticPart(): string
+  staticPart(dynamicOffset: number): string
   dynamicPart(): string
 }
 


### PR DESCRIPTION
## What it solves
Currently we do not support off-chain signing for smart contract owners using EIP-1271.



Resolves #407 

## How this PR fixes it
- Adds new dynamic `SmartContractSafeSignature`
- When adding a signature to a transaction we check if the signer address is a smart contract and if it is we use the new signature for smart contracts

## Todo
- [ ] Extend e2e test with a test for nested Safes
- [ ] Check `isValidSignature` before adding the signature?
- [ ] Copy new signatures correctly
- [ ] Build SafeTransaction from transaction service response correctly