### PR TITLE
fix(protocol-kit): Only add executor signature if there are not enough signatures

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -966,12 +966,16 @@ class Safe {
       signedSafeTransaction.addSignature(generatePreValidatedSignature(owner))
     }
     const owners = await this.getOwners()
+    const threshold = await this.getThreshold()
     const signerAddress = await this.#ethAdapter.getSignerAddress()
-    if (signerAddress && owners.includes(signerAddress)) {
+    if (
+      threshold - signedSafeTransaction.signatures.size > 1 &&
+      signerAddress &&
+      owners.includes(signerAddress)
+    ) {
       signedSafeTransaction.addSignature(generatePreValidatedSignature(signerAddress))
     }
 
-    const threshold = await this.getThreshold()
     if (threshold > signedSafeTransaction.signatures.size) {
       const signaturesMissing = threshold - signedSafeTransaction.signatures.size
       throw new Error(

--- a/packages/protocol-kit/tests/e2e/execution.test.ts
+++ b/packages/protocol-kit/tests/e2e/execution.test.ts
@@ -68,7 +68,7 @@ describe('Transactions execution', () => {
       await waitSafeTxReceipt(txRejectResponse)
       const signedTx = await safeSdk1.signTransaction(tx)
       const isTxExecutable = await safeSdk2.isValidTransaction(signedTx)
-      await chai.expect(isTxExecutable).to.be.eq(false)
+      chai.expect(isTxExecutable).to.be.eq(false)
       const safeFinalBalance = await safeSdk1.getBalance()
       chai.expect(safeInitialBalance.toString()).to.be.eq(safeFinalBalance.toString())
     })
@@ -95,7 +95,7 @@ describe('Transactions execution', () => {
       }
       const tx = await safeSdk1.createTransaction({ safeTransactionData })
       const isTxExecutable = await safeSdk1.isValidTransaction(tx)
-      await chai.expect(isTxExecutable).to.be.eq(true)
+      chai.expect(isTxExecutable).to.be.eq(true)
       const safeFinalBalance = await safeSdk1.getBalance()
       chai.expect(safeInitialBalance.toString()).to.be.eq(safeFinalBalance.toString())
     })
@@ -402,7 +402,7 @@ describe('Transactions execution', () => {
       'should execute a transaction with threshold >1 and all different kind of signatures with ethers provider and safeVersion===1.0.0',
       async () => {
         const { accounts, contractNetworks } = await setupTests()
-        const [account1, account2, account3, account4, account5, account6] = accounts
+        const [account1, account2, account3, account4, account5] = accounts
         const safe = await getSafeWithOwners([
           account1.address,
           account2.address,


### PR DESCRIPTION
## What it solves

`Safe.executeTransaction` always adds the executor's signature, even if the transaction is already fully signed.
This leads to more signatures than the threshold.

Resolves https://github.com/5afe/safe-support/issues/224

## How this PR fixes it
Before adding the executor pre-validated-signature we check if the transaction is already fully signed.
