### PR TITLE
feat(protocol-kit):  add Mantle Mainnet chain

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -78,6 +78,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 4689, shortName: 'iotex-mainnet' },
   { chainId: 4918, shortName: 'txvm' },
   { chainId: 4919, shortName: 'xvm' },
+  { chainId: 5000, shortName: 'mantle' },
   { chainId: 5001, shortName: 'mantle-testnet' },
   { chainId: 7341, shortName: 'shyft' },
   { chainId: 7700, shortName: 'canto' },


### PR DESCRIPTION
Adds missing Mantle Mainnet chain to protocol-kit.
https://github.com/safe-global/safe-deployments/pull/227
https://github.com/safe-global/safe-deployments/pull/258