### PR TITLE
chore: Update cover image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![license](https://img.shields.io/github/license/safe-global/safe-core-sdk) [![Coverage Status](https://coveralls.io/repos/github/safe-global/safe-core-sdk/badge.svg?branch=main)](https://coveralls.io/github/safe-global/safe-core-sdk?branch=main)
 
-![Safe_Logos_Core_SDK_Black](https://github.com/safe-global/safe-core-sdk/assets/6764315/b6f87103-540f-4d36-a108-56ee9eb4e919)
+![Safe_Logos_Core_SDK_Black](https://github.com/safe-global/safe-core-sdk/assets/6764315/7202a24a-2981-4b31-9cf5-ace1c3b2c4fa)
 
 Software developer tools that facilitate the interaction with the Safe [contracts](https://github.com/safe-global/safe-contracts) and [services](https://github.com/safe-global/safe-transaction-service).
 


### PR DESCRIPTION
The current cover image has two issues:
- Not visible when using GitHub dark mode
- Is not following the right name convention at Safe{Core}
