### PR TITLE
Set default Safe version to 1.3.0

### DIFF
--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -98,7 +98,7 @@ const safeFactory = await SafeFactory.create({ ethAdapter, contractNetworks })
 const safeSdk = await Safe.create({ ethAdapter, safeAddress, contractNetworks })
 ```
 
-The `SafeFactory` constructor also accepts the property `safeVersion` to specify the Safe contract version that will deploy. This string can take the values `1.0.0`, `1.1.1`, `1.2.0` or `1.3.0`. If not specified, the most recent contract version will be used by default.
+The `SafeFactory` constructor also accepts the property `safeVersion` to specify the Safe contract version that will be deployed. This string can take the values `1.0.0`, `1.1.1`, `1.2.0`, `1.3.0` or `1.4.1`. If not specified, the `DEFAULT_SAFE_VERSION` value will be used.
 
 ```js
 const safeVersion = 'X.Y.Z'

--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -3,10 +3,10 @@ import {
   OperationType
 } from '@safe-global/account-abstraction-kit-poc/types'
 import Safe, {
+  DEFAULT_SAFE_VERSION,
   EthersAdapter,
   PREDETERMINED_SALT_NONCE,
   PredictedSafeProps,
-  SAFE_LAST_VERSION,
   SafeAccountConfig,
   SafeDeploymentConfig,
   encodeCreateProxyWithNonce,
@@ -27,7 +27,7 @@ import {
 } from '@safe-global/safe-core-sdk-types'
 import { ethers } from 'ethers'
 
-const safeVersion: SafeVersion = SAFE_LAST_VERSION
+const safeVersion: SafeVersion = DEFAULT_SAFE_VERSION
 
 class AccountAbstraction {
   #ethAdapter: EthersAdapter

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -207,7 +207,7 @@ const safeFactory = await SafeFactory.create({ ethAdapter })
 
 - The `safeVersion` property
 
-  The `SafeFactory` constructor also accepts the `safeVersion` property to specify the Safe contract version that will be deployed. This string can take the values `1.0.0`, `1.1.1`, `1.2.0`, `1.3.0` or `1.4.1`. If not specified, the most recent contract version will be used by default.
+  The `SafeFactory` constructor also accepts the `safeVersion` property to specify the Safe contract version that will be deployed. This string can take the values `1.0.0`, `1.1.1`, `1.2.0`, `1.3.0` or `1.4.1`. If not specified, the `DEFAULT_SAFE_VERSION` value will be used.
 
   ```js
   const safeVersion = 'X.Y.Z'

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -11,7 +11,7 @@ import {
   TransactionOptions,
   TransactionResult
 } from '@safe-global/safe-core-sdk-types'
-import { SAFE_LAST_VERSION } from './contracts/config'
+import { DEFAULT_SAFE_VERSION } from './contracts/config'
 import { predictSafeAddress } from './contracts/utils'
 import ContractManager from './managers/contractManager'
 import FallbackHandlerManager from './managers/fallbackHandlerManager'
@@ -250,7 +250,7 @@ class Safe {
       return Promise.resolve(this.#predictedSafe.safeDeploymentConfig.safeVersion)
     }
 
-    return Promise.resolve(SAFE_LAST_VERSION)
+    return Promise.resolve(DEFAULT_SAFE_VERSION)
   }
 
   /**

--- a/packages/protocol-kit/src/contracts/config.ts
+++ b/packages/protocol-kit/src/contracts/config.ts
@@ -1,6 +1,6 @@
 import { SafeVersion } from '@safe-global/safe-core-sdk-types'
 
-export const SAFE_LAST_VERSION: SafeVersion = '1.4.1'
+export const DEFAULT_SAFE_VERSION: SafeVersion = '1.3.0'
 export const SAFE_BASE_VERSION: SafeVersion = '1.0.0'
 
 type SafeDeploymentsVersions = {

--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -1,6 +1,6 @@
 import { isAddress } from '@ethersproject/address'
 import { BigNumber } from '@ethersproject/bignumber'
-import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
+import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
 import { createMemoizedFunction } from '@safe-global/protocol-kit/utils/memoized'
 import {
@@ -142,7 +142,7 @@ export async function predictSafeAddress({
   validateSafeAccountConfig(safeAccountConfig)
   validateSafeDeploymentConfig(safeDeploymentConfig)
 
-  const { safeVersion = SAFE_LAST_VERSION, saltNonce = PREDETERMINED_SALT_NONCE } =
+  const { safeVersion = DEFAULT_SAFE_VERSION, saltNonce = PREDETERMINED_SALT_NONCE } =
     safeDeploymentConfig
 
   const safeProxyFactoryContract = await memoizedGetProxyFactoryContract({

--- a/packages/protocol-kit/src/index.ts
+++ b/packages/protocol-kit/src/index.ts
@@ -25,7 +25,7 @@ import {
   Web3TransactionOptions,
   Web3TransactionResult
 } from './adapters/web3'
-import { SAFE_LAST_VERSION } from './contracts/config'
+import { DEFAULT_SAFE_VERSION } from './contracts/config'
 import {
   getCompatibilityFallbackHandlerContract,
   getCreateCallContract,
@@ -76,6 +76,7 @@ export {
   CreateEthersProxyProps,
   CreateTransactionProps,
   CreateWeb3ProxyProps,
+  DEFAULT_SAFE_VERSION,
   DeploySafeProps,
   EthSafeSignature,
   EthersAdapter,
@@ -89,7 +90,6 @@ export {
   PREDETERMINED_SALT_NONCE,
   PredictedSafeProps,
   RemoveOwnerTxParams,
-  SAFE_LAST_VERSION,
   SafeAccountConfig,
   SafeConfig,
   SafeConfigWithPredictedSafe,

--- a/packages/protocol-kit/src/managers/contractManager.ts
+++ b/packages/protocol-kit/src/managers/contractManager.ts
@@ -1,4 +1,4 @@
-import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
+import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import {
   getMultiSendCallOnlyContract,
   getMultiSendContract,
@@ -37,11 +37,11 @@ class ContractManager {
     let safeVersion: SafeVersion
 
     if (isSafeConfigWithPredictedSafe(config)) {
-      safeVersion = config.predictedSafe.safeDeploymentConfig?.safeVersion ?? SAFE_LAST_VERSION
+      safeVersion = config.predictedSafe.safeDeploymentConfig?.safeVersion ?? DEFAULT_SAFE_VERSION
     } else {
       const temporarySafeContract = await getSafeContract({
         ethAdapter,
-        safeVersion: SAFE_LAST_VERSION,
+        safeVersion: DEFAULT_SAFE_VERSION,
         isL1SafeMasterCopy,
         customSafeAddress: config.safeAddress,
         customContracts

--- a/packages/protocol-kit/src/safeFactory/index.ts
+++ b/packages/protocol-kit/src/safeFactory/index.ts
@@ -1,5 +1,5 @@
 import Safe from '@safe-global/protocol-kit/Safe'
-import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
+import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import {
   getProxyFactoryContract,
   getSafeContract
@@ -63,7 +63,7 @@ class SafeFactory {
 
   static async create({
     ethAdapter,
-    safeVersion = SAFE_LAST_VERSION,
+    safeVersion = DEFAULT_SAFE_VERSION,
     isL1SafeMasterCopy = false,
     contractNetworks
   }: SafeFactoryConfig): Promise<SafeFactory> {

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -1,7 +1,7 @@
 import { Interface } from '@ethersproject/abi'
 import { arrayify } from '@ethersproject/bytes'
 import { pack as solidityPack } from '@ethersproject/solidity'
-import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
+import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import { StandardizeSafeTransactionDataProps } from '@safe-global/protocol-kit/types'
 import { hasSafeFeature, SAFE_FEATURES } from '@safe-global/protocol-kit/utils'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
@@ -56,7 +56,7 @@ export async function standardizeSafeTransactionData({
 
   let safeVersion: SafeVersion
   if (predictedSafe) {
-    safeVersion = predictedSafe?.safeDeploymentConfig?.safeVersion || SAFE_LAST_VERSION
+    safeVersion = predictedSafe?.safeDeploymentConfig?.safeVersion || DEFAULT_SAFE_VERSION
   } else {
     if (!safeContract) {
       throw new Error('Safe is not deployed')

--- a/packages/protocol-kit/tests/e2e/core.test.ts
+++ b/packages/protocol-kit/tests/e2e/core.test.ts
@@ -1,4 +1,4 @@
-import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
+import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import Safe, { PredictedSafeProps, SafeFactory } from '@safe-global/protocol-kit/index'
 import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
@@ -139,7 +139,7 @@ describe('Safe Info', () => {
         contractNetworks
       })
       const contractVersion = await safeSdk.getContractVersion()
-      chai.expect(contractVersion).to.be.eq(SAFE_LAST_VERSION)
+      chai.expect(contractVersion).to.be.eq(DEFAULT_SAFE_VERSION)
     })
 
     it('should return the Safe contract version', async () => {

--- a/packages/protocol-kit/tests/e2e/safeFactory.test.ts
+++ b/packages/protocol-kit/tests/e2e/safeFactory.test.ts
@@ -1,4 +1,4 @@
-import { SAFE_LAST_VERSION } from '@safe-global/protocol-kit/contracts/config'
+import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import {
   ContractNetworksConfig,
@@ -440,7 +440,7 @@ describe('SafeProxyFactory', () => {
       chai.expect(safeInstanceVersion).to.be.eq(safeVersionDeployed)
     })
 
-    itif(safeVersionDeployed === SAFE_LAST_VERSION)(
+    itif(safeVersionDeployed === DEFAULT_SAFE_VERSION)(
       'should deploy last Safe version by default',
       async () => {
         const { accounts, contractNetworks } = await setupTests()


### PR DESCRIPTION
The SDK supports the Safe Contracts `v1.4.1`, but because they are only deployed in a couple of networks, we will still have the `v1.3.0` as default.

In case developers want to deploy `v1.4.1` Safes, they will need to [pass](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit#create) the `safeVersion` property with value `1.4.1` in the initialization of the `SafeFactory` class in the `protocol-kit`. Existing `v1.4.1` Safes are compatible by default with no specific setups.