### PR TITLE
refactor(protocol-kit): Rename MasterCopy to singleton

### DIFF
--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -66,12 +66,12 @@ const safeSdk = await Safe.create({ ethAdapter, safeAddress })
 
 There are two versions of the Safe contracts: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that does not trigger events in order to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
-By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the property `isL1SafeMasterCopy` to force the use of the `Safe.sol` contract.
+By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the property `isL1SafeSingleton` to force the use of the `Safe.sol` contract.
 
 ```js
-const safeFactory = await SafeFactory.create({ ethAdapter, isL1SafeMasterCopy: true })
+const safeFactory = await SafeFactory.create({ ethAdapter, isL1SafeSingleton: true })
 
-const safeSdk = await Safe.create({ ethAdapter, safeAddress, isL1SafeMasterCopy: true })
+const safeSdk = await Safe.create({ ethAdapter, safeAddress, isL1SafeSingleton: true })
 ```
 
 If the Safe contracts are not deployed to your current network, the property `contractNetworks` will be required to point to the addresses of the Safe contracts previously deployed by you.

--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -82,7 +82,7 @@ import { ContractNetworksConfig } from '@safe-global/protocol-kit'
 const chainId = await ethAdapter.getChainId()
 const contractNetworks: ContractNetworksConfig = {
   [chainId]: {
-    safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
+    safeSingletonAddress: '<SINGLETON_ADDRESS>',
     safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
     multiSendAddress: '<MULTI_SEND_ADDRESS>',
     multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
@@ -90,7 +90,7 @@ const contractNetworks: ContractNetworksConfig = {
     signMessageLibAddress: '<SIGN_MESSAGE_LIB_ADDRESS>',
     createCallAddress: '<CREATE_CALL_ADDRESS>',
     simulateTxAccessorAddress: '<SIMULATE_TX_ACCESSOR_ADDRESS>',
-    safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+    safeSingletonAbi: '<SINGLETON_ABI>', // Optional. Only needed with web3.js
     safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>', // Optional. Only needed with web3.js
     multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
     multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js

--- a/packages/api-kit/README.md
+++ b/packages/api-kit/README.md
@@ -71,7 +71,7 @@ const serviceInfo: SafeServiceInfoResponse = await safeService.getServiceInfo()
 
 ### getServiceSingletonsInfo
 
-Returns the list of Safe master copies.
+Returns the list of Safe singleton copies.
 
 ```js
 const singletons: SafeSingletonResponse = await safeService.getServiceSingletonsInfo()

--- a/packages/api-kit/README.md
+++ b/packages/api-kit/README.md
@@ -74,7 +74,7 @@ const serviceInfo: SafeServiceInfoResponse = await safeService.getServiceInfo()
 Returns the list of Safe master copies.
 
 ```js
-const masterCopies: MasterCopyResponse = await safeService.getServiceMasterCopiesInfo()
+const masterCopies: SafeSingletonResponse = await safeService.getServiceMasterCopiesInfo()
 ```
 
 ### decodeData

--- a/packages/api-kit/README.md
+++ b/packages/api-kit/README.md
@@ -69,12 +69,12 @@ Returns the information and configuration of the service.
 const serviceInfo: SafeServiceInfoResponse = await safeService.getServiceInfo()
 ```
 
-### getServiceMasterCopiesInfo
+### getServiceSingletonsInfo
 
 Returns the list of Safe master copies.
 
 ```js
-const masterCopies: SafeSingletonResponse = await safeService.getServiceMasterCopiesInfo()
+const singletons: SafeSingletonResponse = await safeService.getServiceSingletonsInfo()
 ```
 
 ### decodeData

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -80,7 +80,7 @@ class SafeApiKit {
    *
    * @returns The list of Safe master copies
    */
-  async getServiceMasterCopiesInfo(): Promise<SafeSingletonResponse[]> {
+  async getServiceSingletonsInfo(): Promise<SafeSingletonResponse[]> {
     return sendRequest({
       url: `${this.#txServiceBaseUrl}/v1/about/master-copies`,
       method: HttpMethod.Get

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -4,7 +4,7 @@ import {
   AllTransactionsOptions,
   DeleteSafeDelegateProps,
   GetSafeDelegateProps,
-  MasterCopyResponse,
+  SafeSingletonResponse,
   ModulesResponse,
   OwnerResponse,
   ProposeTransactionProps,
@@ -80,7 +80,7 @@ class SafeApiKit {
    *
    * @returns The list of Safe master copies
    */
-  async getServiceMasterCopiesInfo(): Promise<MasterCopyResponse[]> {
+  async getServiceMasterCopiesInfo(): Promise<SafeSingletonResponse[]> {
     return sendRequest({
       url: `${this.#txServiceBaseUrl}/v1/about/master-copies`,
       method: HttpMethod.Get

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -76,9 +76,9 @@ class SafeApiKit {
   }
 
   /**
-   * Returns the list of Safe singleton copies.
+   * Returns the list of Safe singletons.
    *
-   * @returns The list of Safe singleton copies
+   * @returns The list of Safe singletons
    */
   async getServiceSingletonsInfo(): Promise<SafeSingletonResponse[]> {
     return sendRequest({

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -76,9 +76,9 @@ class SafeApiKit {
   }
 
   /**
-   * Returns the list of Safe master copies.
+   * Returns the list of Safe singleton copies.
    *
-   * @returns The list of Safe master copies
+   * @returns The list of Safe singleton copies
    */
   async getServiceSingletonsInfo(): Promise<SafeSingletonResponse[]> {
     return sendRequest({

--- a/packages/api-kit/src/types/safeTransactionServiceTypes.ts
+++ b/packages/api-kit/src/types/safeTransactionServiceTypes.ts
@@ -35,7 +35,7 @@ export type SafeInfoResponse = {
   readonly nonce: number
   readonly threshold: number
   readonly owners: string[]
-  readonly masterCopy: string
+  readonly singleton: string
   readonly modules: string[]
   readonly fallbackHandler: string
   readonly guard: string
@@ -51,7 +51,7 @@ export type SafeCreationInfoResponse = {
   readonly creator: string
   readonly transactionHash: string
   readonly factoryAddress: string
-  readonly masterCopy: string
+  readonly singleton: string
   readonly setupData: string
   readonly dataDecoded?: string
 }

--- a/packages/api-kit/src/types/safeTransactionServiceTypes.ts
+++ b/packages/api-kit/src/types/safeTransactionServiceTypes.ts
@@ -22,7 +22,7 @@ export type SafeServiceInfoResponse = {
   }
 }
 
-export type MasterCopyResponse = {
+export type SafeSingletonResponse = {
   address: string
   version: string
   deployer: string

--- a/packages/api-kit/tests/e2e/getServiceMastercopiesInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceMastercopiesInfo.test.ts
@@ -14,8 +14,8 @@ describe('getServiceMasterCopiesInfo', () => {
   it('should call getServiceMasterCopiesInfo', async () => {
     const masterCopiesResponse = await safeApiKit.getServiceMasterCopiesInfo()
     chai.expect(masterCopiesResponse.length).to.be.greaterThan(1)
-    masterCopiesResponse.map((masterCopy) => {
-      chai.expect(masterCopy.deployer).to.be.equal('Gnosis')
+    masterCopiesResponse.map((singleton) => {
+      chai.expect(singleton.deployer).to.be.equal('Gnosis')
     })
   })
 })

--- a/packages/api-kit/tests/e2e/getServiceMastercopiesInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceMastercopiesInfo.test.ts
@@ -4,17 +4,17 @@ import { getServiceClient } from '../utils/setupServiceClient'
 
 let safeApiKit: SafeApiKit
 
-describe('getServiceMasterCopiesInfo', () => {
+describe('getServiceSingletonsInfo', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
       '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
     ))
   })
 
-  it('should call getServiceMasterCopiesInfo', async () => {
-    const masterCopiesResponse = await safeApiKit.getServiceMasterCopiesInfo()
-    chai.expect(masterCopiesResponse.length).to.be.greaterThan(1)
-    masterCopiesResponse.map((singleton) => {
+  it('should call getServiceSingletonsInfo', async () => {
+    const singletonResponse = await safeApiKit.getServiceSingletonsInfo()
+    chai.expect(singletonResponse.length).to.be.greaterThan(1)
+    singletonResponse.map((singleton) => {
       chai.expect(singleton.deployer).to.be.equal('Gnosis')
     })
   })

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -62,9 +62,9 @@ describe('Endpoint tests', () => {
       })
     })
 
-    it('getServiceMasterCopiesInfo', async () => {
+    it('getServiceSingletonsInfo', async () => {
       await chai
-        .expect(safeApiKit.getServiceMasterCopiesInfo())
+        .expect(safeApiKit.getServiceSingletonsInfo())
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${txServiceBaseUrl}/v1/about/master-copies`,

--- a/packages/onramp-kit/example/client/src/components/monerium/Monerium.tsx
+++ b/packages/onramp-kit/example/client/src/components/monerium/Monerium.tsx
@@ -33,7 +33,7 @@ function Monerium() {
       const safeSdk = await Safe.create({
         ethAdapter: ethAdapter,
         safeAddress: selectedSafe,
-        isL1SafeMasterCopy: true
+        isL1SafeSingleton: true
       })
 
       const pack = new MoneriumPack({

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -216,7 +216,7 @@ const safeFactory = await SafeFactory.create({ ethAdapter })
 
 ### deploySafe
 
-Deploys a new Safe and returns an instance of the Protocol Kit connected to the deployed Safe. The address of the Master Copy, Safe contract version and the contract (`Safe.sol` or `SafeL2.sol`) of the deployed Safe will depend on the initialization of the `safeFactory` instance.
+Deploys a new Safe and returns an instance of the Protocol Kit connected to the deployed Safe. The address of the Safe Singleton, Safe contract version and the contract (`Safe.sol` or `SafeL2.sol`) of the deployed Safe will depend on the initialization of the `safeFactory` instance.
 
 ```js
 const safeAccountConfig: SafeAccountConfig = {
@@ -433,7 +433,7 @@ const safeAddress = await safeSdk.getAddress()
 
 ### getContractVersion
 
-Returns the Safe Master Copy contract version.
+Returns the Safe Singleton contract version.
 
 ```js
 const contractVersion = await safeSdk.getContractVersion()

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -163,14 +163,14 @@ import { SafeFactory } from '@safe-global/protocol-kit'
 const safeFactory = await SafeFactory.create({ ethAdapter })
 ```
 
-- The `isL1SafeMasterCopy` flag
+- The `isL1SafeSingleton` flag
 
   There are two versions of the Safe contracts: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that does not trigger events in order to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
-  By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeMasterCopy` flag to force the use of the `Safe.sol` contract.
+  By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeSingleton` flag to force the use of the `Safe.sol` contract.
 
   ```js
-  const safeFactory = await SafeFactory.create({ ethAdapter, isL1SafeMasterCopy: true })
+  const safeFactory = await SafeFactory.create({ ethAdapter, isL1SafeSingleton: true })
   ```
 
 - The `contractNetworks` property
@@ -317,14 +317,14 @@ const predictedSafe: PredictedSafeProps = {
 const safeSdk = await Safe.create({ ethAdapter, predictedSafe })
 ```
 
-- The `isL1SafeMasterCopy` flag
+- The `isL1SafeSingleton` flag
 
   There are two versions of the Safe contracts: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that does not trigger events in order to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
-  By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeMasterCopy` flag to force the use of the `Safe.sol` contract.
+  By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeSingleton` flag to force the use of the `Safe.sol` contract.
 
   ```js
-  const safeSdk = await Safe.create({ ethAdapter, safeAddress, isL1SafeMasterCopy: true })
+  const safeSdk = await Safe.create({ ethAdapter, safeAddress, isL1SafeSingleton: true })
   ```
 
 - The `contractNetworks` property
@@ -382,14 +382,14 @@ const predictedSafe: PredictedSafeProps = {
 const safeSdk = await safeSdk.connect({ ethAdapter, predictedSafe })
 ```
 
-- The `isL1SafeMasterCopy` flag
+- The `isL1SafeSingleton` flag
 
   There are two versions of the Safe contracts: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that does not trigger events in order to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
-  By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeMasterCopy` flag to force the use of the `Safe.sol` contract.
+  By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeSingleton` flag to force the use of the `Safe.sol` contract.
 
   ```js
-  const safeSdk = await Safe.connect({ ethAdapter, safeAddress, isL1SafeMasterCopy: true })
+  const safeSdk = await Safe.connect({ ethAdapter, safeAddress, isL1SafeSingleton: true })
   ```
 
 - The `contractNetworks` property

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -183,7 +183,7 @@ const safeFactory = await SafeFactory.create({ ethAdapter })
   const chainId = await ethAdapter.getChainId()
   const contractNetworks: ContractNetworksConfig = {
     [chainId]: {
-      safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
+      safeSingletonAddress: '<SINGLETON_ADDRESS>',
       safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
       multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
@@ -191,7 +191,7 @@ const safeFactory = await SafeFactory.create({ ethAdapter })
       signMessageLibAddress: '<SIGN_MESSAGE_LIB_ADDRESS>',
       createCallAddress: '<CREATE_CALL_ADDRESS>',
       simulateTxAccessorAddress: '<SIMULATE_TX_ACCESSOR_ADDRESS>',
-      safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+      safeSingletonAbi: '<SINGLETON_ABI>', // Optional. Only needed with web3.js
       safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>', // Optional. Only needed with web3.js
       multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
       multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js
@@ -337,7 +337,7 @@ const safeSdk = await Safe.create({ ethAdapter, predictedSafe })
   const chainId = await ethAdapter.getChainId()
   const contractNetworks: ContractNetworksConfig = {
     [chainId]: {
-      safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
+      safeSingletonAddress: '<SINGLETON_ADDRESS>',
       safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
       multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
@@ -345,7 +345,7 @@ const safeSdk = await Safe.create({ ethAdapter, predictedSafe })
       signMessageLibAddress: '<SIGN_MESSAGE_LIB_ADDRESS>',
       createCallAddress: '<CREATE_CALL_ADDRESS>',
       simulateTxAccessorAddress: '<SIMULATE_TX_ACCESSOR_ADDRESS>',
-      safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+      safeSingletonAbi: '<SINGLETON_ABI>', // Optional. Only needed with web3.js
       safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>', // Optional. Only needed with web3.js
       multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
       multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js
@@ -402,7 +402,7 @@ const safeSdk = await safeSdk.connect({ ethAdapter, predictedSafe })
   const chainId = await ethAdapter.getChainId()
   const contractNetworks: ContractNetworksConfig = {
     [chainId]: {
-      safeMasterCopyAddress: '<MASTER_COPY_ADDRESS>',
+      safeSingletonAddress: '<SINGLETON_ADDRESS>',
       safeProxyFactoryAddress: '<PROXY_FACTORY_ADDRESS>',
       multiSendAddress: '<MULTI_SEND_ADDRESS>',
       multiSendCallOnlyAddress: '<MULTI_SEND_CALL_ONLY_ADDRESS>',
@@ -410,7 +410,7 @@ const safeSdk = await safeSdk.connect({ ethAdapter, predictedSafe })
       signMessageLibAddress: '<SIGN_MESSAGE_LIB_ADDRESS>',
       createCallAddress: '<CREATE_CALL_ADDRESS>',
       simulateTxAccessorAddress: '<SIMULATE_TX_ACCESSOR_ADDRESS>',
-      safeMasterCopyAbi: '<MASTER_COPY_ABI>', // Optional. Only needed with web3.js
+      safeSingletonAbi: '<SINGLETON_ABI>', // Optional. Only needed with web3.js
       safeProxyFactoryAbi: '<PROXY_FACTORY_ABI>', // Optional. Only needed with web3.js
       multiSendAbi: '<MULTI_SEND_ABI>', // Optional. Only needed with web3.js
       multiSendCallOnlyAbi: '<MULTI_SEND_CALL_ONLY_ABI>', // Optional. Only needed with web3.js

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -248,9 +248,9 @@ class Safe {
   }
 
   /**
-   * Returns the Safe Master Copy contract version.
+   * Returns the Safe Singleton contract version.
    *
-   * @returns The Safe Master Copy contract version
+   * @returns The Safe Singleton contract version
    */
   async getContractVersion(): Promise<SafeVersion> {
     if (this.#contractManager.safeContract) {

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -94,7 +94,7 @@ class Safe {
    * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
   private async init(config: SafeConfig): Promise<void> {
-    const { ethAdapter, isL1SafeMasterCopy, contractNetworks } = config
+    const { ethAdapter, isL1SafeSingleton, contractNetworks } = config
 
     this.#ethAdapter = ethAdapter
 
@@ -103,14 +103,14 @@ class Safe {
       this.#contractManager = await ContractManager.create({
         ethAdapter: this.#ethAdapter,
         predictedSafe: this.#predictedSafe,
-        isL1SafeMasterCopy,
+        isL1SafeSingleton,
         contractNetworks
       })
     } else {
       this.#contractManager = await ContractManager.create({
         ethAdapter: this.#ethAdapter,
         safeAddress: config.safeAddress,
-        isL1SafeMasterCopy,
+        isL1SafeSingleton,
         contractNetworks
       })
     }
@@ -133,10 +133,10 @@ class Safe {
    * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
   async connect(config: ConnectSafeConfig): Promise<Safe> {
-    const { ethAdapter, safeAddress, predictedSafe, isL1SafeMasterCopy, contractNetworks } = config
+    const { ethAdapter, safeAddress, predictedSafe, isL1SafeSingleton, contractNetworks } = config
     const configProps: SafeConfigProps = {
       ethAdapter: ethAdapter || this.#ethAdapter,
-      isL1SafeMasterCopy: isL1SafeMasterCopy || this.#contractManager.isL1SafeMasterCopy,
+      isL1SafeSingleton: isL1SafeSingleton || this.#contractManager.isL1SafeSingleton,
       contractNetworks: contractNetworks || this.#contractManager.contractNetworks
     }
 
@@ -1031,12 +1031,12 @@ class Safe {
     const safeVersion = await this.getContractVersion()
     const chainId = await this.getChainId()
     const customContracts = this.#contractManager.contractNetworks?.[chainId]
-    const isL1SafeMasterCopy = this.#contractManager.isL1SafeMasterCopy
+    const isL1SafeSingleton = this.#contractManager.isL1SafeSingleton
 
     const safeSingletonContract = await getSafeContract({
       ethAdapter: this.#ethAdapter,
       safeVersion: safeVersion,
-      isL1SafeMasterCopy,
+      isL1SafeSingleton,
       customContracts
     })
 
@@ -1136,13 +1136,13 @@ class Safe {
     const safeVersion = await this.getContractVersion()
     const ethAdapter = this.#ethAdapter
     const chainId = await ethAdapter.getChainId()
-    const isL1SafeMasterCopy = this.#contractManager.isL1SafeMasterCopy
+    const isL1SafeSingleton = this.#contractManager.isL1SafeSingleton
     const customContracts = this.#contractManager.contractNetworks?.[chainId]
 
     const safeSingletonContract = await getSafeContract({
       ethAdapter: this.#ethAdapter,
       safeVersion,
-      isL1SafeMasterCopy,
+      isL1SafeSingleton,
       customContracts
     })
 

--- a/packages/protocol-kit/src/adapters/ethers/contracts/SafeProxyFactory/SafeProxyFactoryEthersContract.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/SafeProxyFactory/SafeProxyFactoryEthersContract.ts
@@ -8,7 +8,7 @@ import { Safe_proxy_factory as SafeProxyFactory_V1_4_1 } from '@safe-global/prot
 import { SafeProxyFactoryContract } from '@safe-global/safe-core-sdk-types'
 
 export interface CreateProxyProps {
-  safeMasterCopyAddress: string
+  safeSingletonAddress: string
   initializer: string
   saltNonce: string
   options?: EthersTransactionOptions
@@ -33,7 +33,7 @@ class SafeProxyFactoryEthersContract implements SafeProxyFactoryContract {
   }
 
   async createProxy({
-    safeMasterCopyAddress,
+    safeSingletonAddress,
     initializer,
     saltNonce,
     options,
@@ -44,14 +44,14 @@ class SafeProxyFactoryEthersContract implements SafeProxyFactoryContract {
     if (options && !options.gasLimit) {
       options.gasLimit = await this.estimateGas(
         'createProxyWithNonce',
-        [safeMasterCopyAddress, initializer, saltNonce],
+        [safeSingletonAddress, initializer, saltNonce],
         {
           ...options
         }
       )
     }
     const proxyAddress = this.contract
-      .createProxyWithNonce(safeMasterCopyAddress, initializer, saltNonce, options)
+      .createProxyWithNonce(safeSingletonAddress, initializer, saltNonce, options)
       .then(async (txResponse) => {
         if (callback) {
           callback(txResponse.hash)

--- a/packages/protocol-kit/src/adapters/ethers/contracts/contractInstancesEthers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/contractInstancesEthers.ts
@@ -1,14 +1,14 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { Provider } from '@ethersproject/providers'
-import { Gnosis_safe__factory as SafeMasterCopy_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.0.0/factories/Gnosis_safe__factory'
+import { Gnosis_safe__factory as SafeSingleton_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.0.0/factories/Gnosis_safe__factory'
 import { Proxy_factory__factory as SafeProxyFactory_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.0.0/factories/Proxy_factory__factory'
-import { Gnosis_safe__factory as SafeMasterCopy_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.1.1/factories/Gnosis_safe__factory'
+import { Gnosis_safe__factory as SafeSingleton_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.1.1/factories/Gnosis_safe__factory'
 import { Multi_send__factory as MultiSend_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.1.1/factories/Multi_send__factory'
 import { Proxy_factory__factory as SafeProxyFactory_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.1.1/factories/Proxy_factory__factory'
-import { Gnosis_safe__factory as SafeMasterCopy_V1_2_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.2.0/factories/Gnosis_safe__factory'
+import { Gnosis_safe__factory as SafeSingleton_V1_2_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.2.0/factories/Gnosis_safe__factory'
 import { Compatibility_fallback_handler__factory as CompatibilityFallbackHandler_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Compatibility_fallback_handler__factory'
 import { Create_call__factory as CreateCall_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Create_call__factory'
-import { Gnosis_safe__factory as SafeMasterCopy_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Gnosis_safe__factory'
+import { Gnosis_safe__factory as SafeSingleton_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Gnosis_safe__factory'
 import { Multi_send__factory as MultiSend_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Multi_send__factory'
 import { Multi_send_call_only__factory as MultiSendCallOnly_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Multi_send_call_only__factory'
 import { Proxy_factory__factory as SafeProxyFactory_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.3.0/factories/Proxy_factory__factory'
@@ -18,7 +18,7 @@ import { Compatibility_fallback_handler__factory as CompatibilityFallbackHandler
 import { Create_call__factory as CreateCall_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Create_call__factory'
 import { Multi_send__factory as MultiSend_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Multi_send__factory'
 import { Multi_send_call_only__factory as MultiSendCallOnly_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Multi_send_call_only__factory'
-import { Safe__factory as SafeMasterCopy_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Safe__factory'
+import { Safe__factory as SafeSingleton_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Safe__factory'
 import { Safe_proxy_factory__factory as SafeProxyFactory_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Safe_proxy_factory__factory'
 import { Sign_message_lib__factory as SignMessageLib_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Sign_message_lib__factory'
 import { Simulate_tx_accessor__factory as SimulateTxAccessor_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/ethers-v5/v1.4.1/factories/Simulate_tx_accessor__factory'
@@ -59,19 +59,19 @@ export function getSafeContractInstance(
   let safeContract
   switch (safeVersion) {
     case '1.4.1':
-      safeContract = SafeMasterCopy_V1_4_1.connect(contractAddress, signerOrProvider)
+      safeContract = SafeSingleton_V1_4_1.connect(contractAddress, signerOrProvider)
       return new SafeContract_V1_4_1_Ethers(safeContract)
     case '1.3.0':
-      safeContract = SafeMasterCopy_V1_3_0.connect(contractAddress, signerOrProvider)
+      safeContract = SafeSingleton_V1_3_0.connect(contractAddress, signerOrProvider)
       return new SafeContract_V1_3_0_Ethers(safeContract)
     case '1.2.0':
-      safeContract = SafeMasterCopy_V1_2_0.connect(contractAddress, signerOrProvider)
+      safeContract = SafeSingleton_V1_2_0.connect(contractAddress, signerOrProvider)
       return new SafeContract_V1_2_0_Ethers(safeContract)
     case '1.1.1':
-      safeContract = SafeMasterCopy_V1_1_1.connect(contractAddress, signerOrProvider)
+      safeContract = SafeSingleton_V1_1_1.connect(contractAddress, signerOrProvider)
       return new SafeContract_V1_1_1_Ethers(safeContract)
     case '1.0.0':
-      safeContract = SafeMasterCopy_V1_0_0.connect(contractAddress, signerOrProvider)
+      safeContract = SafeSingleton_V1_0_0.connect(contractAddress, signerOrProvider)
       return new SafeContract_V1_0_0_Ethers(safeContract)
     default:
       throw new Error('Invalid Safe version')

--- a/packages/protocol-kit/src/adapters/web3/contracts/SafeProxyFactory/SafeProxyFactoryWeb3Contract.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/SafeProxyFactory/SafeProxyFactoryWeb3Contract.ts
@@ -9,7 +9,7 @@ import { SafeProxyFactoryContract } from '@safe-global/safe-core-sdk-types'
 import { TransactionReceipt } from 'web3-core/types'
 
 export interface CreateProxyProps {
-  safeMasterCopyAddress: string
+  safeSingletonAddress: string
   initializer: string
   saltNonce: string
   options?: Web3TransactionOptions
@@ -34,7 +34,7 @@ class SafeProxyFactoryWeb3Contract implements SafeProxyFactoryContract {
   }
 
   async createProxy({
-    safeMasterCopyAddress,
+    safeSingletonAddress,
     initializer,
     saltNonce,
     options,
@@ -45,14 +45,14 @@ class SafeProxyFactoryWeb3Contract implements SafeProxyFactoryContract {
     if (options && !options.gas) {
       options.gas = await this.estimateGas(
         'createProxyWithNonce',
-        [safeMasterCopyAddress, initializer, saltNonce],
+        [safeSingletonAddress, initializer, saltNonce],
         {
           ...options
         }
       )
     }
     const txResponse = this.contract.methods
-      .createProxyWithNonce(safeMasterCopyAddress, initializer, saltNonce)
+      .createProxyWithNonce(safeSingletonAddress, initializer, saltNonce)
       .send(options)
 
     if (callback) {

--- a/packages/protocol-kit/src/adapters/web3/contracts/contractInstancesWeb3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/contractInstancesWeb3.ts
@@ -1,12 +1,12 @@
-import { Gnosis_safe as SafeMasterCopy_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Gnosis_safe'
+import { Gnosis_safe as SafeSingleton_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Gnosis_safe'
 import { Proxy_factory as SafeProxyFactory_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Proxy_factory'
-import { Gnosis_safe as SafeMasterCopy_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.1.1/Gnosis_safe'
+import { Gnosis_safe as SafeSingleton_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.1.1/Gnosis_safe'
 import { Multi_send as MultiSend_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.1.1/Multi_send'
 import { Proxy_factory as SafeProxyFactory_V1_1_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.1.1/Proxy_factory'
-import { Gnosis_safe as SafeMasterCopy_V1_2_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.2.0/Gnosis_safe'
+import { Gnosis_safe as SafeSingleton_V1_2_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.2.0/Gnosis_safe'
 import { Compatibility_fallback_handler as CompatibilityFallbackHandler_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Compatibility_fallback_handler'
 import { Create_call as CreateCall_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Create_call'
-import { Gnosis_safe as SafeMasterCopy_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Gnosis_safe'
+import { Gnosis_safe as SafeSingleton_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Gnosis_safe'
 import { Multi_send as MultiSend_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Multi_send'
 import { Multi_send_call_only as MultiSendCallOnly_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Multi_send_call_only'
 import { Proxy_factory as SafeProxyFactory_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Proxy_factory'
@@ -16,7 +16,7 @@ import { Compatibility_fallback_handler as CompatibilityFallbackHandler_V1_4_1 }
 import { Create_call as CreateCall_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Create_call'
 import { Multi_send as MultiSend_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Multi_send'
 import { Multi_send_call_only as MultiSendCallOnly_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Multi_send_call_only'
-import { Safe as SafeMasterCopy_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Safe'
+import { Safe as SafeSingleton_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Safe'
 import { Safe_proxy_factory as SafeProxyFactory_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Safe_proxy_factory'
 import { Sign_message_lib as SignMessageLib_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Sign_message_lib'
 import { Simulate_tx_accessor as SimulateTxAccessor_V1_4_1 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.4.1/Simulate_tx_accessor'
@@ -47,11 +47,11 @@ import SimulateTxAccessorContract_V1_4_1_Web3 from './SimulateTxAccessor/v1.4.1/
 export function getSafeContractInstance(
   safeVersion: SafeVersion,
   safeContract:
-    | SafeMasterCopy_V1_4_1
-    | SafeMasterCopy_V1_3_0
-    | SafeMasterCopy_V1_2_0
-    | SafeMasterCopy_V1_1_1
-    | SafeMasterCopy_V1_0_0
+    | SafeSingleton_V1_4_1
+    | SafeSingleton_V1_3_0
+    | SafeSingleton_V1_2_0
+    | SafeSingleton_V1_1_1
+    | SafeSingleton_V1_0_0
 ):
   | SafeContract_V1_4_1_Web3
   | SafeContract_V1_3_0_Web3
@@ -60,15 +60,15 @@ export function getSafeContractInstance(
   | SafeContract_V1_0_0_Web3 {
   switch (safeVersion) {
     case '1.4.1':
-      return new SafeContract_V1_4_1_Web3(safeContract as SafeMasterCopy_V1_4_1)
+      return new SafeContract_V1_4_1_Web3(safeContract as SafeSingleton_V1_4_1)
     case '1.3.0':
-      return new SafeContract_V1_3_0_Web3(safeContract as SafeMasterCopy_V1_3_0)
+      return new SafeContract_V1_3_0_Web3(safeContract as SafeSingleton_V1_3_0)
     case '1.2.0':
-      return new SafeContract_V1_2_0_Web3(safeContract as SafeMasterCopy_V1_2_0)
+      return new SafeContract_V1_2_0_Web3(safeContract as SafeSingleton_V1_2_0)
     case '1.1.1':
-      return new SafeContract_V1_1_1_Web3(safeContract as SafeMasterCopy_V1_1_1)
+      return new SafeContract_V1_1_1_Web3(safeContract as SafeSingleton_V1_1_1)
     case '1.0.0':
-      return new SafeContract_V1_0_0_Web3(safeContract as SafeMasterCopy_V1_0_0)
+      return new SafeContract_V1_0_0_Web3(safeContract as SafeSingleton_V1_0_0)
     default:
       throw new Error('Invalid Safe version')
   }

--- a/packages/protocol-kit/src/contracts/config.ts
+++ b/packages/protocol-kit/src/contracts/config.ts
@@ -5,8 +5,8 @@ export const SAFE_BASE_VERSION: SafeVersion = '1.0.0'
 
 type SafeDeploymentsVersions = {
   [version: string]: {
-    safeMasterCopyVersion: string
-    safeMasterCopyL2Version?: string
+    safeSingletonVersion: string
+    safeSingletonL2Version?: string
     safeProxyFactoryVersion: string
     compatibilityFallbackHandler: string
     multiSendVersion: string
@@ -18,8 +18,8 @@ type SafeDeploymentsVersions = {
 
 export const safeDeploymentsVersions: SafeDeploymentsVersions = {
   '1.4.1': {
-    safeMasterCopyVersion: '1.4.1',
-    safeMasterCopyL2Version: '1.4.1',
+    safeSingletonVersion: '1.4.1',
+    safeSingletonL2Version: '1.4.1',
     safeProxyFactoryVersion: '1.4.1',
     compatibilityFallbackHandler: '1.4.1',
     multiSendVersion: '1.4.1',
@@ -28,8 +28,8 @@ export const safeDeploymentsVersions: SafeDeploymentsVersions = {
     createCallVersion: '1.4.1'
   },
   '1.3.0': {
-    safeMasterCopyVersion: '1.3.0',
-    safeMasterCopyL2Version: '1.3.0',
+    safeSingletonVersion: '1.3.0',
+    safeSingletonL2Version: '1.3.0',
     safeProxyFactoryVersion: '1.3.0',
     compatibilityFallbackHandler: '1.3.0',
     multiSendVersion: '1.3.0',
@@ -38,8 +38,8 @@ export const safeDeploymentsVersions: SafeDeploymentsVersions = {
     createCallVersion: '1.3.0'
   },
   '1.2.0': {
-    safeMasterCopyVersion: '1.2.0',
-    safeMasterCopyL2Version: undefined,
+    safeSingletonVersion: '1.2.0',
+    safeSingletonL2Version: undefined,
     safeProxyFactoryVersion: '1.1.1',
     compatibilityFallbackHandler: '1.3.0',
     multiSendVersion: '1.1.1',
@@ -48,8 +48,8 @@ export const safeDeploymentsVersions: SafeDeploymentsVersions = {
     createCallVersion: '1.3.0'
   },
   '1.1.1': {
-    safeMasterCopyVersion: '1.1.1',
-    safeMasterCopyL2Version: undefined,
+    safeSingletonVersion: '1.1.1',
+    safeSingletonL2Version: undefined,
     safeProxyFactoryVersion: '1.1.1',
     compatibilityFallbackHandler: '1.3.0',
     multiSendVersion: '1.1.1',
@@ -58,8 +58,8 @@ export const safeDeploymentsVersions: SafeDeploymentsVersions = {
     createCallVersion: '1.3.0'
   },
   '1.0.0': {
-    safeMasterCopyVersion: '1.0.0',
-    safeMasterCopyL2Version: undefined,
+    safeSingletonVersion: '1.0.0',
+    safeSingletonL2Version: undefined,
     safeProxyFactoryVersion: '1.0.0',
     compatibilityFallbackHandler: '1.3.0',
     multiSendVersion: '1.1.1',

--- a/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
+++ b/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
@@ -42,7 +42,7 @@ export function getSafeContractDeployment(
   chainId: number,
   isL1SafeSingleton = false
 ): SingletonDeployment | undefined {
-  const version = safeDeploymentsVersions[safeVersion].safeMasterCopyVersion
+  const version = safeDeploymentsVersions[safeVersion].safeSingletonVersion
   const filters: DeploymentFilter = { version, network: chainId.toString(), released: true }
   if (safeDeploymentsL1ChainIds.includes(chainId) || isL1SafeSingleton) {
     return getSafeSingletonDeployment(filters)

--- a/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
+++ b/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
@@ -122,8 +122,8 @@ export async function getSafeContract({
   const safeContract = await ethAdapter.getSafeContract({
     safeVersion,
     singletonDeployment,
-    customContractAddress: customSafeAddress ?? customContracts?.safeMasterCopyAddress,
-    customContractAbi: customContracts?.safeMasterCopyAbi
+    customContractAddress: customSafeAddress ?? customContracts?.safeSingletonAddress,
+    customContractAbi: customContracts?.safeSingletonAbi
   })
   const isContractDeployed = await ethAdapter.isContractDeployed(safeContract.getAddress())
   if (!isContractDeployed) {

--- a/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
+++ b/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts
@@ -33,18 +33,18 @@ interface GetContractInstanceProps {
 }
 
 interface GetSafeContractInstanceProps extends GetContractInstanceProps {
-  isL1SafeMasterCopy?: boolean
+  isL1SafeSingleton?: boolean
   customSafeAddress?: string
 }
 
 export function getSafeContractDeployment(
   safeVersion: SafeVersion,
   chainId: number,
-  isL1SafeMasterCopy = false
+  isL1SafeSingleton = false
 ): SingletonDeployment | undefined {
   const version = safeDeploymentsVersions[safeVersion].safeMasterCopyVersion
   const filters: DeploymentFilter = { version, network: chainId.toString(), released: true }
-  if (safeDeploymentsL1ChainIds.includes(chainId) || isL1SafeMasterCopy) {
+  if (safeDeploymentsL1ChainIds.includes(chainId) || isL1SafeSingleton) {
     return getSafeSingletonDeployment(filters)
   }
   return getSafeL2SingletonDeployment(filters)
@@ -114,11 +114,11 @@ export async function getSafeContract({
   ethAdapter,
   safeVersion,
   customSafeAddress,
-  isL1SafeMasterCopy,
+  isL1SafeSingleton,
   customContracts
 }: GetSafeContractInstanceProps): Promise<SafeContract> {
   const chainId = await ethAdapter.getChainId()
-  const singletonDeployment = getSafeContractDeployment(safeVersion, chainId, isL1SafeMasterCopy)
+  const singletonDeployment = getSafeContractDeployment(safeVersion, chainId, isL1SafeSingleton)
   const safeContract = await ethAdapter.getSafeContract({
     safeVersion,
     singletonDeployment,

--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -46,7 +46,7 @@ export interface PredictSafeAddressProps {
   ethAdapter: EthAdapter
   safeAccountConfig: SafeAccountConfig
   safeDeploymentConfig?: SafeDeploymentConfig
-  isL1SafeMasterCopy?: boolean
+  isL1SafeSingleton?: boolean
   customContracts?: ContractNetworkConfig
 }
 
@@ -156,7 +156,7 @@ export async function predictSafeAddress({
   ethAdapter,
   safeAccountConfig,
   safeDeploymentConfig = {},
-  isL1SafeMasterCopy = false,
+  isL1SafeSingleton = false,
   customContracts
 }: PredictSafeAddressProps): Promise<string> {
   validateSafeAccountConfig(safeAccountConfig)
@@ -180,7 +180,7 @@ export async function predictSafeAddress({
   const safeContract = await memoizedGetSafeContract({
     ethAdapter,
     safeVersion,
-    isL1SafeMasterCopy,
+    isL1SafeSingleton,
     customContracts
   })
 

--- a/packages/protocol-kit/src/managers/contractManager.ts
+++ b/packages/protocol-kit/src/managers/contractManager.ts
@@ -15,7 +15,7 @@ import { isSafeConfigWithPredictedSafe } from '../utils/types'
 
 class ContractManager {
   #contractNetworks?: ContractNetworksConfig
-  #isL1SafeMasterCopy?: boolean
+  #isL1SafeSingleton?: boolean
   #safeContract?: SafeContract
   #multiSendContract!: MultiSendContract
   #multiSendCallOnlyContract!: MultiSendCallOnlyContract
@@ -27,12 +27,12 @@ class ContractManager {
   }
 
   async init(config: SafeConfig): Promise<void> {
-    const { ethAdapter, isL1SafeMasterCopy, contractNetworks, predictedSafe, safeAddress } = config
+    const { ethAdapter, isL1SafeSingleton, contractNetworks, predictedSafe, safeAddress } = config
 
     const chainId = await ethAdapter.getChainId()
     const customContracts = contractNetworks?.[chainId]
     this.#contractNetworks = contractNetworks
-    this.#isL1SafeMasterCopy = isL1SafeMasterCopy
+    this.#isL1SafeSingleton = isL1SafeSingleton
 
     let safeVersion: SafeVersion
 
@@ -43,7 +43,7 @@ class ContractManager {
       const defaultSafeContractInstance = await getSafeContract({
         ethAdapter,
         safeVersion: DEFAULT_SAFE_VERSION,
-        isL1SafeMasterCopy,
+        isL1SafeSingleton,
         customSafeAddress: safeAddress,
         customContracts
       })
@@ -59,7 +59,7 @@ class ContractManager {
         : await getSafeContract({
             ethAdapter,
             safeVersion,
-            isL1SafeMasterCopy,
+            isL1SafeSingleton,
             customSafeAddress: safeAddress,
             customContracts
           })
@@ -82,8 +82,8 @@ class ContractManager {
     return this.#contractNetworks
   }
 
-  get isL1SafeMasterCopy(): boolean | undefined {
-    return this.#isL1SafeMasterCopy
+  get isL1SafeSingleton(): boolean | undefined {
+    return this.#isL1SafeSingleton
   }
 
   get safeContract(): SafeContract | undefined {

--- a/packages/protocol-kit/src/safeFactory/index.ts
+++ b/packages/protocol-kit/src/safeFactory/index.ts
@@ -36,8 +36,8 @@ export interface SafeFactoryConfig {
   ethAdapter: EthAdapter
   /** safeVersion - Versions of the Safe deployed by this Factory contract */
   safeVersion?: SafeVersion
-  /** isL1SafeMasterCopy - Forces to use the Safe L1 version of the contract instead of the L2 version */
-  isL1SafeMasterCopy?: boolean
+  /** isL1SafeSingleton - Forces to use the Safe L1 version of the contract instead of the L2 version */
+  isL1SafeSingleton?: boolean
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
 }
@@ -47,15 +47,15 @@ interface SafeFactoryInitConfig {
   ethAdapter: EthAdapter
   /** safeVersion - Versions of the Safe deployed by this Factory contract */
   safeVersion: SafeVersion
-  /** isL1SafeMasterCopy - Forces to use the Safe L1 version of the contract instead of the L2 version */
-  isL1SafeMasterCopy?: boolean
+  /** isL1SafeSingleton - Forces to use the Safe L1 version of the contract instead of the L2 version */
+  isL1SafeSingleton?: boolean
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
 }
 
 class SafeFactory {
   #contractNetworks?: ContractNetworksConfig
-  #isL1SafeMasterCopy?: boolean
+  #isL1SafeSingleton?: boolean
   #safeVersion!: SafeVersion
   #ethAdapter!: EthAdapter
   #safeProxyFactoryContract!: SafeProxyFactoryContract
@@ -64,23 +64,23 @@ class SafeFactory {
   static async create({
     ethAdapter,
     safeVersion = DEFAULT_SAFE_VERSION,
-    isL1SafeMasterCopy = false,
+    isL1SafeSingleton = false,
     contractNetworks
   }: SafeFactoryConfig): Promise<SafeFactory> {
     const safeFactorySdk = new SafeFactory()
-    await safeFactorySdk.init({ ethAdapter, safeVersion, isL1SafeMasterCopy, contractNetworks })
+    await safeFactorySdk.init({ ethAdapter, safeVersion, isL1SafeSingleton, contractNetworks })
     return safeFactorySdk
   }
 
   private async init({
     ethAdapter,
     safeVersion,
-    isL1SafeMasterCopy,
+    isL1SafeSingleton,
     contractNetworks
   }: SafeFactoryInitConfig): Promise<void> {
     this.#ethAdapter = ethAdapter
     this.#safeVersion = safeVersion
-    this.#isL1SafeMasterCopy = isL1SafeMasterCopy
+    this.#isL1SafeSingleton = isL1SafeSingleton
     this.#contractNetworks = contractNetworks
     const chainId = await this.#ethAdapter.getChainId()
     const customContracts = contractNetworks?.[chainId]
@@ -92,7 +92,7 @@ class SafeFactory {
     this.#safeContract = await getSafeContract({
       ethAdapter,
       safeVersion,
-      isL1SafeMasterCopy,
+      isL1SafeSingleton,
       customContracts
     })
   }
@@ -126,7 +126,7 @@ class SafeFactory {
       ethAdapter: this.#ethAdapter,
       safeAccountConfig,
       safeDeploymentConfig,
-      isL1SafeMasterCopy: this.#isL1SafeMasterCopy,
+      isL1SafeSingleton: this.#isL1SafeSingleton,
       customContracts
     })
   }
@@ -174,7 +174,7 @@ class SafeFactory {
     const safe = await Safe.create({
       ethAdapter: this.#ethAdapter,
       safeAddress,
-      isL1SafeMasterCopy: this.#isL1SafeMasterCopy,
+      isL1SafeSingleton: this.#isL1SafeSingleton,
       contractNetworks: this.#contractNetworks
     })
     return safe

--- a/packages/protocol-kit/src/safeFactory/index.ts
+++ b/packages/protocol-kit/src/safeFactory/index.ts
@@ -158,7 +158,7 @@ class SafeFactory {
       throw new Error('Cannot specify gas and gasLimit together in transaction options')
     }
     const safeAddress = await this.#safeProxyFactoryContract.createProxy({
-      safeMasterCopyAddress: this.#safeContract.getAddress(),
+      safeSingletonAddress: this.#safeContract.getAddress(),
       initializer,
       saltNonce,
       options: {

--- a/packages/protocol-kit/src/types/index.ts
+++ b/packages/protocol-kit/src/types/index.ts
@@ -30,9 +30,9 @@ export interface PredictedSafeProps {
 }
 
 export interface ContractNetworkConfig {
-  /** safeSingletonAddress - Address of the Safe Master Copy contract deployed on a specific network */
+  /** safeSingletonAddress - Address of the Safe Singleton contract deployed on a specific network */
   safeSingletonAddress: string
-  /** safeSingletonAbi - Abi of the Safe Master Copy contract deployed on a specific network */
+  /** safeSingletonAbi - Abi of the Safe Singleton contract deployed on a specific network */
   safeSingletonAbi?: AbiItem | AbiItem[]
   /** safeProxyFactoryAddress - Address of the SafeProxyFactory contract deployed on a specific network */
   safeProxyFactoryAddress: string

--- a/packages/protocol-kit/src/types/index.ts
+++ b/packages/protocol-kit/src/types/index.ts
@@ -86,8 +86,8 @@ type SafeConfigWithPredictedSafeProps = {
 export type SafeConfigProps = {
   /** ethAdapter - Ethereum adapter */
   ethAdapter: EthAdapter
-  /** isL1SafeMasterCopy - Forces to use the Safe L1 version of the contract instead of the L2 version */
-  isL1SafeMasterCopy?: boolean
+  /** isL1SafeSingleton - Forces to use the Safe L1 version of the contract instead of the L2 version */
+  isL1SafeSingleton?: boolean
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
 }
@@ -113,8 +113,8 @@ type ConnectSafeConfigWithPredictedSafeProps = {
 type ConnectSafeConfigProps = {
   /** ethAdapter - Ethereum adapter */
   ethAdapter?: EthAdapter
-  /** isL1SafeMasterCopy - Forces to use the Safe L1 version of the contract instead of the L2 version */
-  isL1SafeMasterCopy?: boolean
+  /** isL1SafeSingleton - Forces to use the Safe L1 version of the contract instead of the L2 version */
+  isL1SafeSingleton?: boolean
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
 }

--- a/packages/protocol-kit/src/types/index.ts
+++ b/packages/protocol-kit/src/types/index.ts
@@ -30,10 +30,10 @@ export interface PredictedSafeProps {
 }
 
 export interface ContractNetworkConfig {
-  /** safeMasterCopyAddress - Address of the Safe Master Copy contract deployed on a specific network */
-  safeMasterCopyAddress: string
-  /** safeMasterCopyAbi - Abi of the Safe Master Copy contract deployed on a specific network */
-  safeMasterCopyAbi?: AbiItem | AbiItem[]
+  /** safeSingletonAddress - Address of the Safe Master Copy contract deployed on a specific network */
+  safeSingletonAddress: string
+  /** safeSingletonAbi - Abi of the Safe Master Copy contract deployed on a specific network */
+  safeSingletonAbi?: AbiItem | AbiItem[]
   /** safeProxyFactoryAddress - Address of the SafeProxyFactory contract deployed on a specific network */
   safeProxyFactoryAddress: string
   /** safeProxyFactoryAbi - Abi of the SafeProxyFactory contract deployed on a specific network */

--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -205,14 +205,14 @@ export async function estimateTxBaseGas(
 
   const safeVersion = await safe.getContractVersion()
   const ethAdapter = safe.getEthAdapter()
-  const isL1SafeMasterCopy = safe.getContractManager().isL1SafeMasterCopy
+  const isL1SafeSingleton = safe.getContractManager().isL1SafeSingleton
   const chainId = await safe.getChainId()
   const customContracts = safe.getContractManager().contractNetworks?.[chainId]
 
   const safeSingletonContract = await getSafeContract({
     ethAdapter,
     safeVersion,
-    isL1SafeMasterCopy,
+    isL1SafeSingleton,
     customContracts
   })
 
@@ -315,14 +315,14 @@ async function estimateSafeTxGasWithRequiredTxGas(
   const safeAddress = await safe.getAddress()
   const safeVersion = await safe.getContractVersion()
   const ethAdapter = safe.getEthAdapter()
-  const isL1SafeMasterCopy = safe.getContractManager().isL1SafeMasterCopy
+  const isL1SafeSingleton = safe.getContractManager().isL1SafeSingleton
   const chainId = await safe.getChainId()
   const customContracts = safe.getContractManager().contractNetworks?.[chainId]
 
   const safeSingletonContract = await getSafeContract({
     ethAdapter,
     safeVersion,
-    isL1SafeMasterCopy,
+    isL1SafeSingleton,
     customContracts
   })
 
@@ -418,12 +418,12 @@ async function estimateSafeTxGasWithSimulate(
   const ethAdapter = safe.getEthAdapter()
   const chainId = await safe.getChainId()
   const customContracts = safe.getContractManager().contractNetworks?.[chainId]
-  const isL1SafeMasterCopy = safe.getContractManager().isL1SafeMasterCopy
+  const isL1SafeSingleton = safe.getContractManager().isL1SafeSingleton
 
   const safeSingletonContract = await getSafeContract({
     ethAdapter,
     safeVersion,
-    isL1SafeMasterCopy,
+    isL1SafeSingleton,
     customContracts
   })
 

--- a/packages/protocol-kit/tests/e2e/contractManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/contractManager.test.ts
@@ -94,8 +94,8 @@ describe('Safe contracts manager', () => {
       const { safe, accounts, chainId } = await setupTests()
       const customContractNetworks: ContractNetworksConfig = {
         [chainId]: {
-          safeMasterCopyAddress: ZERO_ADDRESS,
-          safeMasterCopyAbi: (await getSafeSingleton()).abi,
+          safeSingletonAddress: ZERO_ADDRESS,
+          safeSingletonAbi: (await getSafeSingleton()).abi,
           safeProxyFactoryAddress: ZERO_ADDRESS,
           safeProxyFactoryAbi: (await getFactory()).abi,
           multiSendAddress: ZERO_ADDRESS,

--- a/packages/protocol-kit/tests/e2e/createSafeDeploymentTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createSafeDeploymentTransaction.test.ts
@@ -177,8 +177,8 @@ describe('createSafeDeploymentTransaction', () => {
     const customContract = contractNetworks[chainId]
     const safeContract = await ethAdapter.getSafeContract({
       safeVersion: safeVersionDeployed,
-      customContractAddress: customContract?.safeMasterCopyAddress,
-      customContractAbi: customContract?.safeMasterCopyAbi
+      customContractAddress: customContract?.safeSingletonAddress,
+      customContractAbi: customContract?.safeSingletonAbi
     })
 
     // this is the call to the setup method that sets the threshold & owners of the new Safe

--- a/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
+++ b/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
@@ -72,12 +72,8 @@ describe('Safe contracts', () => {
       const ethAdapter = await getEthAdapter(getNetworkProvider('gnosis'))
       const safeVersion: SafeVersion = '1.3.0'
       const chainId = 100
-      const isL1SafeMasterCopy = true
-      const singletonDeployment = getSafeContractDeployment(
-        safeVersion,
-        chainId,
-        isL1SafeMasterCopy
-      )
+      const isL1SafeSingleton = true
+      const singletonDeployment = getSafeContractDeployment(safeVersion, chainId, isL1SafeSingleton)
       const safeContract = await ethAdapter.getSafeContract({
         safeVersion,
         singletonDeployment

--- a/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
+++ b/packages/protocol-kit/tests/e2e/ethAdapters.test.ts
@@ -91,8 +91,8 @@ describe('Safe contracts', () => {
       const customContract = contractNetworks[chainId]
       const safeContract = await ethAdapter.getSafeContract({
         safeVersion,
-        customContractAddress: customContract?.safeMasterCopyAddress,
-        customContractAbi: customContract?.safeMasterCopyAbi
+        customContractAddress: customContract?.safeSingletonAddress,
+        customContractAbi: customContract?.safeSingletonAbi
       })
       chai
         .expect(await safeContract.getAddress())

--- a/packages/protocol-kit/tests/e2e/safeFactory.test.ts
+++ b/packages/protocol-kit/tests/e2e/safeFactory.test.ts
@@ -57,8 +57,8 @@ describe('SafeProxyFactory', () => {
       const ethAdapter = await getEthAdapter(account1.signer)
       const contractNetworks: ContractNetworksConfig = {
         [chainId]: {
-          safeMasterCopyAddress: ZERO_ADDRESS,
-          safeMasterCopyAbi: (await getSafeSingleton()).abi,
+          safeSingletonAddress: ZERO_ADDRESS,
+          safeSingletonAbi: (await getSafeSingleton()).abi,
           safeProxyFactoryAddress: ZERO_ADDRESS,
           safeProxyFactoryAbi: (await getFactory()).abi,
           multiSendAddress: ZERO_ADDRESS,

--- a/packages/protocol-kit/tests/e2e/utils/setupContractNetworks.ts
+++ b/packages/protocol-kit/tests/e2e/utils/setupContractNetworks.ts
@@ -13,8 +13,8 @@ import {
 export async function getContractNetworks(chainId: number): Promise<ContractNetworksConfig> {
   return {
     [chainId]: {
-      safeMasterCopyAddress: (await getSafeSingleton()).contract.address,
-      safeMasterCopyAbi: (await getSafeSingleton()).abi,
+      safeSingletonAddress: (await getSafeSingleton()).contract.address,
+      safeSingletonAbi: (await getSafeSingleton()).abi,
       safeProxyFactoryAddress: (await getFactory()).contract.address,
       safeProxyFactoryAbi: (await getFactory()).abi,
       multiSendAddress: (await getMultiSend()).contract.address,

--- a/packages/safe-core-sdk-types/src/contracts/SafeProxyFactoryContract.ts
+++ b/packages/safe-core-sdk-types/src/contracts/SafeProxyFactoryContract.ts
@@ -1,7 +1,7 @@
 import { TransactionOptions } from '@safe-global/safe-core-sdk-types/types'
 
 export interface CreateProxyProps {
-  safeMasterCopyAddress: string
+  safeSingletonAddress: string
   initializer: string
   saltNonce: string
   options?: TransactionOptions


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-core-sdk/issues/494

## ⚠️ Breaking Changes

#### protocol-kit
- Rename `isL1SafeMasterCopy` to `isL1SafeSingleton`
```js
old: SafeFactory.create({ ethAdapter, isL1SafeMasterCopy: true })
new: SafeFactory.create({ ethAdapter, isL1SafeSingleton: true })
```

#### api-kit
- Rename type `MasterCopyResponse` to `SafeSingletonResponse`
- Rename method `getServiceMasterCopiesInfo()` to `getServiceSingletonsInfo()`
