### PR TITLE
feat(protocol-kit): add short names for rootstock networks

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -15,6 +15,8 @@ export const networks: NetworkShortName[] = [
   { chainId: 18, shortName: 'tst' },
   { chainId: 25, shortName: 'cro' },
   { chainId: 28, shortName: 'bobarinkeby' },
+  { chainId: 30, shortName: 'rsk' },
+  { chainId: 31, shortName: 'trsk' },
   { chainId: 39, shortName: 'u2u' },
   { chainId: 40, shortName: 'telosevm' },
   { chainId: 41, shortName: 'telosevmtestnet' },


### PR DESCRIPTION
## What it solves
Adds short names for both RSK Mainnet and RSK Testnet:
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-30.json
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-31.json

## Blockers
**UPD: NO BLOCKERS** :tada: 
- ~~https://github.com/safe-global/safe-deployments/issues/286~~
- ~~https://github.com/safe-global/safe-deployments/issues/287~~
- ~~1.28.0 release of `safe-deployments`~~