### PR TITLE
fix: options added in executeRelayTransaction

### DIFF
--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -106,7 +106,8 @@ class AccountAbstraction {
 
     const response = await this.#relayPack.executeRelayTransaction(
       signedSafeTransaction,
-      this.#safeSdk
+      this.#safeSdk,
+      options
     )
 
     return response.taskId


### PR DESCRIPTION
## What it solves
**spondoredCalls are not routed properly**

In the account-abstraction-kit-poc@1.3.0 when calling
```
    const response = await this.#relayPack.executeRelayTransaction(
      signedSafeTransaction,
      this.#safeSdk
    )
```
the options are not passed so that the relay-kit will route all calls through `this.sendSyncTransaction(target, encodedTransaction, chainId, options)`


## How this PR fixes it
Adding the options to the executeRelayTransaction call
```
    const response = await this.#relayPack.executeRelayTransaction(
      signedSafeTransaction,
      this.#safeSdk,
      options
    )
```
