### PR TITLE
Adds Particle Network Auth Kit Pack

### DIFF
--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -46,6 +46,8 @@
     "@web3auth/base": "^4.3.0",
     "@web3auth/modal": "^4.3.1",
     "@web3auth/openlogin-adapter": "^4.3.0",
+    "@particle-network/auth": "^1.2.2",
+    "@particle-network/provider": "^1.2.1",
     "ethers": "^5.7.2"
   }
 }

--- a/packages/auth-kit/src/index.ts
+++ b/packages/auth-kit/src/index.ts
@@ -1,5 +1,8 @@
 export * from './packs/web3auth/Web3AuthModalPack'
 export * from './packs/web3auth/types'
 
+export * from './packs/particle-network/ParticleModalPack'
+export * from './packs/particle-network/types'
+
 export * from './AuthKitBasePack'
 export * from './types'

--- a/packages/auth-kit/src/packs/particle-network/ParticleModalPack.ts
+++ b/packages/auth-kit/src/packs/particle-network/ParticleModalPack.ts
@@ -28,7 +28,6 @@ export class ParticleModalPack extends AuthKitBasePack {
    * @throws Error when initialization fails
    */
   async init(config: ParticleConfig) {
-    config.txServiceUrl = this.#txServiceUrl;
     this.particle = new ParticleNetwork(config);
     this.#provider = new ParticleProvider(this.particle.auth);
   }

--- a/packages/auth-kit/src/packs/particle-network/ParticleModalPack.ts
+++ b/packages/auth-kit/src/packs/particle-network/ParticleModalPack.ts
@@ -1,0 +1,93 @@
+import { ParticleNetwork, WalletEntryPosition } from "@particle-network/auth";
+import { ParticleProvider } from "@particle-network/provider";
+import { AuthKitSignInData } from '@safe-global/auth-kit/types';
+import { AuthKitBasePack } from '@safe-global/auth-kit/AuthKitBasePack';
+import { ParticleConfig, ParticleEvent, ParticleEventListener } from './types';
+
+/**
+ * Implements the SafeAuthClient interface for adapting the Particle service provider.
+ * 
+ */
+export class ParticleModalPack extends AuthKitBasePack {
+  #provider: ParticleProvider | null = null;
+  #txServiceUrl: string;
+  particle?: ParticleNetwork;
+
+  /**
+   * Instantiate the ParticleModalPack with txServiceUrl.
+   * @param options - Contains the txServiceUrl
+   */
+  constructor(options: { txServiceUrl: string }) {
+    super();
+    this.#txServiceUrl = options.txServiceUrl;
+  }
+
+  /**
+   * Initialize the Particle service provider using the larger config.
+   * @param config - The larger configuration for initializing Particle
+   * @throws Error when initialization fails
+   */
+  async init(config: ParticleConfig) {
+    config.txServiceUrl = this.#txServiceUrl;
+    this.particle = new ParticleNetwork(config);
+    this.#provider = new ParticleProvider(this.particle.auth);
+  }
+
+  /**
+   * Connect to the Particle service provider and get sign-in data.
+   * @returns The sign-in data from the provider
+   * @throws Error when not initialized
+   */
+  async signIn(): Promise<AuthKitSignInData> {
+    if (!this.particle) throw new Error('ParticleModalPack is not initialized');
+
+    await this.particle.auth.login();
+    const eoa = await this.particle.evm.getAddress() || '';
+    const safes = await this.getSafes(this.#txServiceUrl);
+
+    return { eoa, safes };
+  }
+
+  /**
+   * Returns the ParticleProvider instance.
+   * @returns The ParticleProvider instance or null
+   */
+  getProvider(): ParticleProvider | null {
+    return this.#provider;
+  }
+
+  /**
+   * Disconnect from the Particle service provider.
+   * @throws Error when not initialized
+   */
+  async signOut() {
+    if (!this.particle) throw new Error('ParticleModalPack is not initialized');
+
+    this.particle.auth.logout();
+  }
+
+  /**
+   * Get authenticated user information.
+   * @returns The user info
+   * @throws Error when not initialized
+   */
+  async getUserInfo(): Promise<any> {
+    if (!this.particle) throw new Error('ParticleModalPack is not initialized');
+
+    return this.particle.auth.getUserInfo();
+  }
+
+  /**
+   * Subscribe to Particle events.
+   * @param event - The event to subscribe to
+   * @param handler - The event handler
+   */
+  subscribe(event: ParticleEvent, handler: ParticleEventListener) {
+    this.particle?.auth.on(event, handler);
+  }
+
+  /** 
+  * Blank placeholder function for unsubscribe; not relevant
+  */
+  unsubscribe() {}
+}

--- a/packages/auth-kit/src/packs/particle-network/types.ts
+++ b/packages/auth-kit/src/packs/particle-network/types.ts
@@ -1,0 +1,24 @@
+export type ParticleEvent = 'connect' | 'disconnect' | 'chainChanged';
+export type ParticleEventListener = (...args: any[]) => void;
+
+export type ParticleWalletConfig = {
+  displayWalletEntry?: boolean;
+  uiMode?: 'light' | 'dark';
+  supportChains?: Array<{ id: number; name: string }>;
+  customStyle?: Record<string, unknown>;
+};
+
+export type ParticleSecurityAccountConfig = {
+  promptSettingWhenSign?: number;
+  promptMasterPasswordSettingWhenLogin?: number;
+};
+
+export type ParticleConfig = {
+  projectId: string;
+  clientKey: string;
+  appId: string;
+  chainName?: string;
+  chainId?: number;
+  wallet?: ParticleWalletConfig;
+  securityAccount?: ParticleSecurityAccountConfig;
+};


### PR DESCRIPTION
## Introduction of Particle Network as a pack within Auth Kit

This pull request adds Particle Network (Particle Wallet-as-a-Service) alongside Web3Auth within Auth Kit.
- New folder, `particle-network` within packs
- ModalPack, `ParticleModalPack` has been created; modeled after the existing Web3Auth modal
- Relevant types have been included in `types`.

Essentially, this enables full utilization of Particle Network within Auth Kit (to the same degree of the other pack, Web3Auth). This has also been reflected in a written (and tested) tutorial currently in a [drafted PR on the Safe Docs](https://github.com/safe-global/safe-docs/pull/264)

All relevant packages, existing documentation pages, and other relevant files have been updated to reflect the addition of Particle Network's Auth Kit pack.