### PR TITLE
fix: safeTxGas estimation parse for Ethers v6

### DIFF
--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -381,7 +381,7 @@ function parseSafeTxGasErrorResponse(error: any) {
   // Ethers v6
   const Ethersv6RevertData = error?.info?.error?.data
   if (Ethersv6RevertData) {
-    return decodeSafeTxGas(Ethersv6RevertData)
+    return decodeSafeTxGas(Ethersv6RevertData?.originalError?.data || Ethersv6RevertData)
   }
 
   // Web3 v1


### PR DESCRIPTION
## What it solves
Issue with the `safeTxGas` estimation.

## How this PR fixes it

The `parseSafeTxGasErrorResponse ` function has been enhanced to check for the existence of `Ethersv6RevertData?.originalError?.data`. If this data is present, it is now correctly used to decode the `safeTxGas`.

This issue has been found in our Demo Dapp:

![Captura de pantalla 2023-11-15 a las 16 49 12](https://github.com/safe-global/safe-core-sdk/assets/26763673/e17507d1-c061-4f1a-9032-32e388b04ee1)
