### PR TITLE
fix: createTransaction to accept only transactions array

### DIFF
--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -136,38 +136,15 @@ Calling the method `deploySafe` will deploy the desired Safe and return a Protoc
 
 The Protocol Kit supports the execution of single Safe transactions but also MultiSend transactions. We can create a transaction object by calling the method `createTransaction` in our `Safe` instance.
 
-- **Create a single transaction**
+This method takes an array of `MetaTransactionData` objects that represent the individual transactions we want to include in our MultiSend transaction. If we want to specify some of the optional properties in our MultiSend transaction, we can pass a second argument to the method `createTransaction` with the `SafeTransactionOptionalProps` object.
 
-  This method can take an object of type `SafeTransactionDataPartial` that represents the transaction we want to execute (once the signatures are collected). It accepts some optional properties as follows.
-
-  ```js
-  import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
-
-  const safeTransactionData: SafeTransactionDataPartial = {
-    to,
-    data,
-    value,
-    operation, // Optional
-    safeTxGas, // Optional
-    baseGas, // Optional
-    gasPrice, // Optional
-    gasToken, // Optional
-    refundReceiver, // Optional
-    nonce // Optional
-  }
-
-  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
-  ```
-
-- **Create a MultiSend transaction**
-
-  This method can take an array of `MetaTransactionData` objects that represent the multiple transactions we want to include in our MultiSend transaction. If we want to specify some of the optional properties in our MultiSend transaction, we can pass a second argument to the method `createTransaction` with the `SafeTransactionOptionalProps` object.
+When the array contains only one transaction is not wrapped in the MultiSend.
 
   ```js
   import { SafeTransactionOptionalProps } from '@safe-global/protocol-kit'
   import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 
-  const safeTransactionData: MetaTransactionData[] = [
+  const transactions: MetaTransactionData[] = [
     {
       to,
       data,
@@ -192,7 +169,7 @@ The Protocol Kit supports the execution of single Safe transactions but also Mul
     nonce // Optional
   }
 
-  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData, options })
+  const safeTransaction = await safeSdk.createTransaction({ transactions, options })
   ```
 
 We can specify the `nonce` of our Safe transaction as long as it is not lower than the current Safe nonce. If multiple transactions are created but not executed they will share the same `nonce` if no `nonce` is specified, validating the first executed transaction and invalidating all the rest. We can prevent this by calling the method `getNextNonce` from the Safe API Kit instance. This method takes all queued/pending transactions into account when calculating the next nonce, creating a unique one for all different transactions.

--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -138,7 +138,7 @@ The Protocol Kit supports the execution of single Safe transactions but also Mul
 
 This method takes an array of `MetaTransactionData` objects that represent the individual transactions we want to include in our MultiSend transaction. If we want to specify some of the optional properties in our MultiSend transaction, we can pass a second argument to the method `createTransaction` with the `SafeTransactionOptionalProps` object.
 
-When the array contains only one transaction is not wrapped in the MultiSend.
+When the array contains only one transaction, it is not wrapped in the MultiSend.
 
   ```js
   import { SafeTransactionOptionalProps } from '@safe-global/protocol-kit'

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -6,7 +6,7 @@ import SafeApiKit, {
 } from '@safe-global/api-kit/index'
 import * as httpRequests from '@safe-global/api-kit/utils/httpRequests'
 import Safe from '@safe-global/protocol-kit'
-import { EthAdapter, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
+import { EthAdapter } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import sinon from 'sinon'
@@ -347,11 +347,13 @@ describe('Endpoint tests', () => {
     })
 
     it('proposeTransaction', async () => {
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         data: '0x',
         value: '123456789',
-        operation: 1,
+        operation: 1
+      }
+      const options = {
         safeTxGas: '0',
         baseGas: '0',
         gasPrice: '0',
@@ -362,7 +364,10 @@ describe('Endpoint tests', () => {
       const origin = 'Safe Core SDK: Safe API Kit'
       const signerAddress = await signer.getAddress()
       const safeSdk = await Safe.create({ ethAdapter, safeAddress })
-      const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+      const safeTransaction = await safeSdk.createTransaction({
+        transactions: [safeTransactionData],
+        options
+      })
       const senderSignature = await safeSdk.signTransactionHash(safeTxHash)
       await chai
         .expect(
@@ -390,11 +395,13 @@ describe('Endpoint tests', () => {
     })
 
     it('proposeTransaction EIP-3770', async () => {
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         data: '0x',
         value: '123456789',
-        operation: 1,
+        operation: 1
+      }
+      const options = {
         safeTxGas: '0',
         baseGas: '0',
         gasPrice: '0',
@@ -405,7 +412,10 @@ describe('Endpoint tests', () => {
       const origin = 'Safe Core SDK: Safe API Kit'
       const signerAddress = await signer.getAddress()
       const safeSdk = await Safe.create({ ethAdapter, safeAddress })
-      const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+      const safeTransaction = await safeSdk.createTransaction({
+        transactions: [safeTransactionData],
+        options
+      })
       const senderSignature = await safeSdk.signTransactionHash(safeTxHash)
       await chai
         .expect(

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -386,6 +386,7 @@ describe('Endpoint tests', () => {
         method: 'post',
         body: {
           ...safeTransactionData,
+          ...options,
           contractTransactionHash: safeTxHash,
           sender: signerAddress,
           signature: senderSignature.data,
@@ -434,6 +435,7 @@ describe('Endpoint tests', () => {
         method: 'post',
         body: {
           ...safeTransactionData,
+          ...options,
           contractTransactionHash: safeTxHash,
           sender: signerAddress,
           signature: senderSignature.data,

--- a/packages/onramp-kit/src/packs/monerium/SafeMoneriumClient.ts
+++ b/packages/onramp-kit/src/packs/monerium/SafeMoneriumClient.ts
@@ -116,13 +116,14 @@ export class SafeMoneriumClient extends MoneriumClient {
 
       const txData = signMessageContract.encode('signMessage', [hashMessage(message)])
 
+      const safeTransactionData = {
+        to: await signMessageContract.getAddress(),
+        value: '0',
+        data: txData,
+        operation: OperationType.DelegateCall
+      }
       const safeTransaction = await this.#safeSdk.createTransaction({
-        safeTransactionData: {
-          to: await signMessageContract.getAddress(),
-          value: '0',
-          data: txData,
-          operation: OperationType.DelegateCall
-        }
+        transactions: [safeTransactionData]
       })
 
       const safeTxHash = await this.#safeSdk.getTransactionHash(safeTransaction)

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -517,7 +517,7 @@ Returns a Safe transaction ready to be signed by the owners and executed. The Pr
 
 This method takes an array of `MetaTransactionData` objects that represent the individual transactions we want to include in our MultiSend transaction.
 
-When the array contains only one transaction is not wrapped in the MultiSend.
+When the array contains only one transaction, it is not wrapped in the MultiSend.
 
 ```js
 const transactions: MetaTransactionData[] = [

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -109,7 +109,7 @@ const safeTransactionData: SafeTransactionDataPartial = {
   value: '<eth_value_in_wei>',
   data: '0x<data>'
 }
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const safeTransaction = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
 ```
 
 Check the `createTransaction` method in the [API Reference](#sdk-api) for additional details on creating MultiSend transactions.
@@ -515,90 +515,68 @@ const isOwner = await safeSdk.isOwner(address)
 
 Returns a Safe transaction ready to be signed by the owners and executed. The Protocol Kit supports the creation of single Safe transactions but also MultiSend transactions.
 
-- **Single transactions**
+This method takes an array of `MetaTransactionData` objects that represent the individual transactions we want to include in our MultiSend transaction.
 
-  This method can take an object of type `SafeTransactionDataPartial` that represents the transaction we want to execute (once the signatures are collected). It accepts some optional properties as follows.
+When the array contains only one transaction is not wrapped in the MultiSend.
 
-  ```js
-  import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
-
-  const safeTransactionData: SafeTransactionDataPartial = {
+```js
+const transactions: MetaTransactionData[] = [
+  {
     to,
     data,
     value,
-    operation, // Optional
-    safeTxGas, // Optional
-    baseGas, // Optional
-    gasPrice, // Optional
-    gasToken, // Optional
-    refundReceiver, // Optional
-    nonce // Optional
+    operation // Optional
+  },
+  {
+    to,
+    data,
+    value,
+    operation // Optional
   }
-  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
-  ```
+  // ...
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
+```
 
-- **MultiSend transactions**
+This method can also receive the `options` parameter to set the optional properties in the MultiSend transaction:
 
-  This method can take an array of `MetaTransactionData` objects that represent the multiple transactions we want to include in our MultiSend transaction. If we want to specify some of the optional properties in our MultiSend transaction, we can pass a second argument to the `createTransaction` method with the `SafeTransactionOptionalProps` object.
-
-  ```js
-  const safeTransactionData: MetaTransactionData[] = [
-    {
-      to,
-      data,
-      value,
-      operation // Optional
-    },
-    {
-      to,
-      data,
-      value,
-      operation // Optional
-    }
-    // ...
-  ]
-  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
-  ```
-
-  This method can also receive the `options` parameter to set the optional properties in the MultiSend transaction:
-
-  ```js
-  const safeTransactionData: MetaTransactionData[] = [
-    {
-      to,
-      data,
-      value,
-      operation // Optional
-    },
-    {
-      to,
-      data,
-      value,
-      operation // Optional
-    }
-    // ...
-  ]
-  const options: SafeTransactionOptionalProps = {
-    safeTxGas, // Optional
-    baseGas, // Optional
-    gasPrice, // Optional
-    gasToken, // Optional
-    refundReceiver, // Optional
-    nonce // Optional
+```js
+const transactions: MetaTransactionData[] = [
+  {
+    to,
+    data,
+    value,
+    operation // Optional
+  },
+  {
+    to,
+    data,
+    value,
+    operation // Optional
   }
-  const safeTransaction = await safeSdk.createTransaction({ safeTransactionData, options })
-  ```
+  // ...
+]
+const options: SafeTransactionOptionalProps = {
+  safeTxGas, // Optional
+  baseGas, // Optional
+  gasPrice, // Optional
+  gasToken, // Optional
+  refundReceiver, // Optional
+  nonce // Optional
+}
+const safeTransaction = await safeSdk.createTransaction({ transactions, options })
+```
 
-  In addition, the optional `callsOnly` parameter, which is `false` by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
+In addition, the optional `callsOnly` parameter, which is `false` by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
 
-  ```js
-  const callsOnly = true
-  const safeTransaction = await safeSdk.createTransaction({
-    safeTransactionData,
-    options,
-    callsOnly
-  })
-  ```
+```js
+const callsOnly = true
+const safeTransaction = await safeSdk.createTransaction({
+  transactions,
+  options,
+  callsOnly
+})
+```
 
 If the optional properties are not manually set, the Safe transaction returned will have the default value for each one:
 
@@ -617,10 +595,12 @@ Read more about [create transactions from a Safe](https://docs.safe.global/safe-
 Returns a Safe transaction ready to be signed by the owners that invalidates the pending Safe transaction/s with a specific nonce.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const rejectionTransaction = await safeSdk.createRejectionTransaction(safeTransaction.data.nonce)
 ```
 
@@ -629,7 +609,7 @@ const rejectionTransaction = await safeSdk.createRejectionTransaction(safeTransa
 Copies a Safe transaction.
 
 ```js
-const safeTransaction1 = await safeSdk.createTransaction({ safeTransactionData })
+const safeTransaction1 = await safeSdk.createTransaction({ transactions })
 const safeTransaction2 = await copyTransaction(safeTransaction1)
 ```
 
@@ -638,10 +618,12 @@ const safeTransaction2 = await copyTransaction(safeTransaction1)
 Returns the transaction hash of a Safe transaction.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 ```
 
@@ -650,10 +632,12 @@ const txHash = await safeSdk.getTransactionHash(safeTransaction)
 Signs a hash using the current owner account.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const signature = await safeSdk.signTransactionHash(txHash)
 ```
@@ -663,10 +647,12 @@ const signature = await safeSdk.signTransactionHash(txHash)
 Signs a transaction according to the EIP-712 using the current signer account.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const signature = await safeSdk.signTypedData(safeTransaction)
 ```
 
@@ -675,10 +661,12 @@ const signature = await safeSdk.signTypedData(safeTransaction)
 Returns a new `SafeTransaction` object that includes the signature of the current owner. `eth_sign` will be used by default to generate the signature.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const signedSafeTransaction = await safeSdk.signTransaction(safeTransaction)
 ```
 
@@ -697,10 +685,12 @@ const signedSafeTransaction = await safeSdk.signTransaction(safeTransaction, 'et
 Approves a hash on-chain using the current owner account.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const txResponse = await safeSdk.approveTransactionHash(txHash)
 await txResponse.transactionResponse?.wait()
@@ -739,10 +729,12 @@ const txResponse = await safeSdk.approveTransactionHash(txHash, options)
 Returns a list of owners who have approved a specific Safe transaction.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const txHash = await safeSdk.getTransactionHash(safeTransaction)
 const ownerAddresses = await safeSdk.getOwnersWhoApprovedTx(txHash)
 ```
@@ -948,10 +940,12 @@ const safeTransaction = await safeSdk.createChangeThresholdTx(newThreshold, opti
 Checks if a Safe transaction can be executed successfully with no errors.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const isValidTx = await safeSdk.isValidTransaction(safeTransaction)
 ```
 
@@ -988,10 +982,12 @@ const isValidTx = await safeSdk.isValidTransaction(safeTransaction, options)
 Executes a Safe transaction.
 
 ```js
-const safeTransactionData: SafeTransactionDataPartial = {
-  // ...
-}
-const safeTransaction = await safeSdk.createTransaction({ safeTransactionData })
+const transactions: MetaTransactionData[] = [
+  {
+    // ...
+  }
+]
+const safeTransaction = await safeSdk.createTransaction({ transactions })
 const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.transactionResponse?.wait()
 ```

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -102,9 +102,9 @@ Check the `create` method in the [API Reference](#sdk-api) for more details on a
 ### 3. Create a Safe transaction
 
 ```js
-import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
+import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 
-const safeTransactionData: SafeTransactionDataPartial = {
+const safeTransactionData: MetaTransactionData = {
   to: '0x<address>',
   value: '<eth_value_in_wei>',
   data: '0x<data>'

--- a/packages/protocol-kit/src/types/index.ts
+++ b/packages/protocol-kit/src/types/index.ts
@@ -128,7 +128,7 @@ export type ConnectSafeConfig =
   | ConnectSafeConfigWithPredictedSafe
 
 export interface CreateTransactionProps {
-  /** safeTransactionData - The transaction array to process */
+  /** transactions - The transaction array to process */
   transactions: MetaTransactionData[]
   /** options - The transaction array optional properties */
   options?: SafeTransactionOptionalProps

--- a/packages/protocol-kit/src/types/index.ts
+++ b/packages/protocol-kit/src/types/index.ts
@@ -128,8 +128,8 @@ export type ConnectSafeConfig =
   | ConnectSafeConfigWithPredictedSafe
 
 export interface CreateTransactionProps {
-  /** safeTransactionData - The transaction or transaction array to process */
-  safeTransactionData: SafeTransactionDataPartial | MetaTransactionData[]
+  /** safeTransactionData - The transaction array to process */
+  transactions: MetaTransactionData[]
   /** options - The transaction array optional properties */
   options?: SafeTransactionOptionalProps
   /** onlyCalls - Forces the execution of the transaction array with MultiSendCallOnly contract */

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -150,12 +150,6 @@ export function decodeMultiSendData(encodedData: string): MetaTransactionData[] 
   return txs
 }
 
-export function isMetaTransactionArray(
-  safeTransactions: SafeTransactionDataPartial | MetaTransactionData[]
-): safeTransactions is MetaTransactionData[] {
-  return (safeTransactions as MetaTransactionData[])?.length !== undefined
-}
-
 export function isSafeMultisigTransactionResponse(
   safeTransaction: SafeTransaction | SafeMultisigTransactionResponse
 ): safeTransaction is SafeMultisigTransactionResponse {

--- a/packages/protocol-kit/tests/e2e/core.test.ts
+++ b/packages/protocol-kit/tests/e2e/core.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import Safe, { PredictedSafeProps, SafeFactory } from '@safe-global/protocol-kit/index'
-import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
+import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'
@@ -262,12 +262,13 @@ describe('Safe Info', () => {
         contractNetworks
       })
       chai.expect(await safeSdk.getNonce()).to.be.eq(0)
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       const txResponse = await safeSdk.executeTransaction(tx)
       await waitSafeTxReceipt(txResponse)
       chai.expect(await safeSdk.getNonce()).to.be.eq(1)

--- a/packages/protocol-kit/tests/e2e/core.test.ts
+++ b/packages/protocol-kit/tests/e2e/core.test.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_SAFE_VERSION } from '@safe-global/protocol-kit/contracts/config'
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import Safe, { PredictedSafeProps, SafeFactory } from '@safe-global/protocol-kit/index'
-import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'

--- a/packages/protocol-kit/tests/e2e/createTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransaction.test.ts
@@ -68,7 +68,7 @@ describe('Transactions creation', () => {
           safeAddress,
           contractNetworks
         })
-        const txDataPartial: SafeTransactionDataPartial = {
+        const txDataPartial: MetaTransactionData = {
           to: account2.address,
           value: '0',
           data: '0x'
@@ -241,14 +241,16 @@ describe('Transactions creation', () => {
         predictedSafe,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
-        ...BASE_OPTIONS,
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
-        data: '0x',
+        data: '0x'
+      }
+      const options = {
+        ...BASE_OPTIONS,
         gasPrice: '0'
       }
-      const tx = safeSdk.createTransaction({ safeTransactionData })
+      const tx = safeSdk.createTransaction({ transactions: [safeTransactionData], options })
       chai.expect(tx).to.be.rejectedWith('Safe is not deployed')
     })
 
@@ -264,12 +266,14 @@ describe('Transactions creation', () => {
         contractNetworks
       })
       const safeTransactionData: SafeTransactionDataPartial = {
-        ...BASE_OPTIONS,
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({
+        transactions: [safeTransactionData],
+        options: BASE_OPTIONS
+      })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -293,12 +297,14 @@ describe('Transactions creation', () => {
         contractNetworks
       })
       const safeTransactionData: SafeTransactionDataPartial = {
-        ...BASE_OPTIONS,
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({
+        transactions: [safeTransactionData],
+        options: BASE_OPTIONS
+      })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -321,14 +327,12 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: MetaTransactionData[] = [
-        {
-          to: account2.address,
-          value: '500000000000000000', // 0.5 ETH
-          data: '0x'
-        }
-      ]
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const safeTransactionData = {
+        to: account2.address,
+        value: '500000000000000000', // 0.5 ETH
+        data: '0x'
+      }
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -345,15 +349,13 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: MetaTransactionData[] = [
-        {
-          to: account2.address,
-          value: '500000000000000000', // 0.5 ETH
-          data: '0x'
-        }
-      ]
+      const safeTransactionData = {
+        to: account2.address,
+        value: '500000000000000000', // 0.5 ETH
+        data: '0x'
+      }
       const options: SafeTransactionOptionalProps = BASE_OPTIONS
-      const tx = await safeSdk.createTransaction({ safeTransactionData, options })
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData], options })
       chai.expect(tx.data.to).to.be.eq(account2.address)
       chai.expect(tx.data.value).to.be.eq('500000000000000000')
       chai.expect(tx.data.data).to.be.eq('0x')
@@ -376,8 +378,7 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: MetaTransactionData[] = []
-      const tx = safeSdk.createTransaction({ safeTransactionData })
+      const tx = safeSdk.createTransaction({ transactions: [] })
       await chai.expect(tx).to.be.rejectedWith('Invalid empty array of transactions')
     })
 
@@ -392,7 +393,7 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: MetaTransactionData[] = [
+      const transactions = [
         {
           to: await erc20Mintable.getAddress(),
           value: '0',
@@ -410,7 +411,7 @@ describe('Transactions creation', () => {
           ])
         }
       ]
-      const multiSendTx = await safeSdk.createTransaction({ safeTransactionData })
+      const multiSendTx = await safeSdk.createTransaction({ transactions })
       chai
         .expect(multiSendTx.data.to)
         .to.be.eq(contractNetworks[chainId.toString()].multiSendAddress)
@@ -427,9 +428,9 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const options: SafeTransactionOptionalProps = BASE_OPTIONS
+      const options = BASE_OPTIONS
 
-      const safeTransactionData: MetaTransactionData[] = [
+      const transactions = [
         {
           to: await erc20Mintable.getAddress(),
           value: '0',
@@ -447,7 +448,7 @@ describe('Transactions creation', () => {
           ])
         }
       ]
-      const multiSendTx = await safeSdk.createTransaction({ safeTransactionData, options })
+      const multiSendTx = await safeSdk.createTransaction({ transactions, options })
       chai
         .expect(multiSendTx.data.to)
         .to.be.eq(contractNetworks[chainId.toString()].multiSendAddress)
@@ -472,12 +473,12 @@ describe('Transactions creation', () => {
           predictedSafe,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = safeSdk.createTransaction({ safeTransactionData })
+        const tx = safeSdk.createTransaction({ transactions: [safeTransactionData] })
         await chai
           .expect(tx)
           .to.be.rejectedWith(

--- a/packages/protocol-kit/tests/e2e/createTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransaction.test.ts
@@ -4,11 +4,7 @@ import Safe, {
   SafeTransactionOptionalProps,
   standardizeSafeTransactionData
 } from '@safe-global/protocol-kit/index'
-import {
-  MetaTransactionData,
-  SafeContract,
-  SafeTransactionDataPartial
-} from '@safe-global/safe-core-sdk-types'
+import { SafeContract, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'
@@ -68,7 +64,7 @@ describe('Transactions creation', () => {
           safeAddress,
           contractNetworks
         })
-        const txDataPartial: MetaTransactionData = {
+        const txDataPartial: SafeTransactionDataPartial = {
           to: account2.address,
           value: '0',
           data: '0x'
@@ -265,7 +261,7 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
@@ -296,7 +292,7 @@ describe('Transactions creation', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'

--- a/packages/protocol-kit/tests/e2e/createTransactionBatch.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransactionBatch.test.ts
@@ -1,4 +1,3 @@
-import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'
@@ -64,7 +63,7 @@ describe('createTransactionBatch', () => {
       operation: OperationType.Call
     }
 
-    const transactions: MetaTransactionData[] = [dumpTransfer, dumpTransfer]
+    const transactions = [dumpTransfer, dumpTransfer]
 
     const batchTransaction = await safeSdk.createTransactionBatch(transactions)
 

--- a/packages/protocol-kit/tests/e2e/execution.test.ts
+++ b/packages/protocol-kit/tests/e2e/execution.test.ts
@@ -822,7 +822,7 @@ describe('Transactions execution', () => {
         value: 2_000_000_000_000_000_000n // 2 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const safeTransactionData: MetaTransactionData[] = [
+      const transactions: MetaTransactionData[] = [
         {
           to: account2.address,
           value: '1100000000000000000', // 1.1 ETH
@@ -834,7 +834,7 @@ describe('Transactions execution', () => {
           data: '0x'
         }
       ]
-      const multiSendTx = await safeSdk1.createTransaction({ safeTransactionData })
+      const multiSendTx = await safeSdk1.createTransaction({ transactions })
       const signedMultiSendTx = await safeSdk1.signTransaction(multiSendTx)
       const txHash = await safeSdk2.getTransactionHash(multiSendTx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)
@@ -844,11 +844,7 @@ describe('Transactions execution', () => {
       const safeFinalBalance = await safeSdk1.getBalance()
       chai
         .expect(safeInitialBalance)
-        .to.be.eq(
-          safeFinalBalance +
-            BigInt(safeTransactionData[0].value) +
-            BigInt(safeTransactionData[1].value)
-        )
+        .to.be.eq(safeFinalBalance + BigInt(transactions[0].value) + BigInt(transactions[1].value))
     })
 
     it('should execute a batch transaction with contract calls and threshold >1', async () => {
@@ -873,7 +869,7 @@ describe('Transactions execution', () => {
       const accountInitialERC20Balance = await erc20Mintable.balanceOf(account2.address)
       chai.expect(accountInitialERC20Balance.toString()).to.be.eq('0') // 0 ERC20
 
-      const safeTransactionData: MetaTransactionData[] = [
+      const transactions: MetaTransactionData[] = [
         {
           to: await erc20Mintable.getAddress(),
           value: '0',
@@ -891,7 +887,7 @@ describe('Transactions execution', () => {
           ])
         }
       ]
-      const multiSendTx = await safeSdk1.createTransaction({ safeTransactionData })
+      const multiSendTx = await safeSdk1.createTransaction({ transactions })
       const signedMultiSendTx = await safeSdk1.signTransaction(multiSendTx)
       const txHash = await safeSdk2.getTransactionHash(multiSendTx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)

--- a/packages/protocol-kit/tests/e2e/execution.test.ts
+++ b/packages/protocol-kit/tests/e2e/execution.test.ts
@@ -3,11 +3,7 @@ import Safe, {
   EthersTransactionOptions,
   Web3TransactionOptions
 } from '@safe-global/protocol-kit/index'
-import {
-  MetaTransactionData,
-  SafeTransactionDataPartial,
-  TransactionOptions
-} from '@safe-global/safe-core-sdk-types'
+import { MetaTransactionData, TransactionOptions } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'
@@ -56,12 +52,12 @@ describe('Transactions execution', () => {
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const rejectTx = await safeSdk1.createRejectionTransaction(tx.data.nonce)
       const signedRejectTx = await safeSdk1.signTransaction(rejectTx)
       const txRejectResponse = await safeSdk2.executeTransaction(signedRejectTx)
@@ -89,12 +85,12 @@ describe('Transactions execution', () => {
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const isTxExecutable = await safeSdk1.isValidTransaction(tx)
       chai.expect(isTxExecutable).to.be.eq(true)
       const safeFinalBalance = await safeSdk1.getBalance()
@@ -116,12 +112,12 @@ describe('Transactions execution', () => {
       })
       const safeInitialBalance = await safeSdk1.getBalance()
       chai.expect(safeInitialBalance.toString()).to.be.eq('0')
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       await chai
         .expect(safeSdk1.executeTransaction(tx))
         .to.be.rejectedWith('Not enough Ether funds')
@@ -140,12 +136,12 @@ describe('Transactions execution', () => {
       })
       const ethAdapter2 = await getEthAdapter(account2.signer)
       const safeSdk2 = await safeSdk1.connect({ ethAdapter: ethAdapter2 })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const signedTx = await safeSdk1.signTransaction(tx)
       const txHash = await safeSdk2.getTransactionHash(tx)
       const txResponse = await safeSdk2.approveTransactionHash(txHash)
@@ -166,12 +162,12 @@ describe('Transactions execution', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       await chai
         .expect(safeSdk1.executeTransaction(tx))
         .to.be.rejectedWith('There are 2 signatures missing')
@@ -197,12 +193,12 @@ describe('Transactions execution', () => {
         to: safeAddress,
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const rejectTx = await safeSdk1.createRejectionTransaction(tx.data.nonce)
       const signedRejectTx = await safeSdk1.signTransaction(rejectTx)
       const txRejectResponse = await safeSdk2.executeTransaction(signedRejectTx)
@@ -228,12 +224,12 @@ describe('Transactions execution', () => {
         to: safeAddress,
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const options: TransactionOptions = { gas: 123456, gasLimit: 123456 }
       await chai
         .expect(safeSdk1.executeTransaction(tx, options))
@@ -255,12 +251,12 @@ describe('Transactions execution', () => {
         to: safeAddress,
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const execOptions: EthersTransactionOptions = { nonce: 123456789 }
       await chai
         .expect(safeSdk1.executeTransaction(tx, execOptions))
@@ -283,12 +279,12 @@ describe('Transactions execution', () => {
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const initNumSignatures = tx.signatures.size
       const txResponse = await safeSdk1.executeTransaction(tx)
       const finalNumSignatures = tx.signatures.size
@@ -320,12 +316,12 @@ describe('Transactions execution', () => {
         const safeSdk2 = await safeSdk1.connect({ ethAdapter: ethAdapter2 })
         const safeSdk3 = await safeSdk1.connect({ ethAdapter: ethAdapter3 })
         const safeInitialBalance = await safeSdk1.getBalance()
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
 
         // Signature: on-chain
         const txHash = await safeSdk1.getTransactionHash(tx)
@@ -374,12 +370,12 @@ describe('Transactions execution', () => {
         const safeSdk3 = await safeSdk1.connect({ ethAdapter: ethAdapter3 })
         const safeSdk4 = await safeSdk1.connect({ ethAdapter: ethAdapter4 })
         const safeInitialBalance = await safeSdk1.getBalance()
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
 
         // Signature: on-chain
         const txHash = await safeSdk1.getTransactionHash(tx)
@@ -434,12 +430,12 @@ describe('Transactions execution', () => {
         const safeSdk4 = await safeSdk1.connect({ ethAdapter: ethAdapter4 })
         const safeSdk5 = await safeSdk1.connect({ ethAdapter: ethAdapter5 })
         const safeInitialBalance = await safeSdk1.getBalance()
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
 
         // Signature: on-chain
         const txHash = await safeSdk1.getTransactionHash(tx)
@@ -500,12 +496,12 @@ describe('Transactions execution', () => {
         const safeSdk5 = await safeSdk1.connect({ ethAdapter: ethAdapter5 })
         const safeSdk6 = await safeSdk1.connect({ ethAdapter: ethAdapter6 })
         const safeInitialBalance = await safeSdk1.getBalance()
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
 
         // Signature: on-chain
         const txHash = await safeSdk1.getTransactionHash(tx)
@@ -553,12 +549,12 @@ describe('Transactions execution', () => {
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
       const safeInitialBalance = await safeSdk1.getBalance()
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const signedTx = await safeSdk1.signTransaction(tx)
       const txHash = await safeSdk2.getTransactionHash(tx)
       const txResponse1 = await safeSdk2.approveTransactionHash(txHash)
@@ -586,12 +582,12 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
         const execOptions: EthersTransactionOptions = { gasLimit: 123456 }
         const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
         await waitSafeTxReceipt(txResponse)
@@ -617,12 +613,12 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
         const execOptions: EthersTransactionOptions = {
           gasLimit: 123456,
           gasPrice: 170000000
@@ -652,12 +648,12 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
         const execOptions = {
           maxFeePerGas: 200_000_000, //higher than hardhat's block baseFeePerGas
           maxPriorityFeePerGas: 1
@@ -689,12 +685,12 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
         const execOptions: Web3TransactionOptions = { gas: 123456 }
         const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
         await waitSafeTxReceipt(txResponse)
@@ -720,12 +716,12 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
         const execOptions: Web3TransactionOptions = {
           gas: 123456,
           gasPrice: 170000000
@@ -755,12 +751,12 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: account2.address,
           value: '500000000000000000', // 0.5 ETH
           data: '0x'
         }
-        const tx = await safeSdk1.createTransaction({ safeTransactionData })
+        const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
         const execOptions = {
           maxFeePerGas: 200000000, //higher than hardhat's block baseFeePerGas
           maxPriorityFeePerGas: 1
@@ -790,13 +786,13 @@ describe('Transactions execution', () => {
         to: safeAddress,
         value: 1_000_000_000_000_000_000n // 1 ETH
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: account2.address,
         value: '500000000000000000', // 0.5 ETH
         data: '0x'
       }
       const currentNonce = await ethAdapter.getNonce(account1.address, 'pending')
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const execOptions: EthersTransactionOptions = { nonce: currentNonce }
       const txResponse = await safeSdk1.executeTransaction(tx, execOptions)
       await waitSafeTxReceipt(txResponse)

--- a/packages/protocol-kit/tests/e2e/getEncodedTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/getEncodedTransaction.test.ts
@@ -1,5 +1,4 @@
 import Safe from '@safe-global/protocol-kit/index'
-import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import chai from 'chai'
 import { deployments } from 'hardhat'
@@ -35,13 +34,13 @@ describe('getEncodedTransaction', () => {
       contractNetworks
     })
 
-    const safeTransactionData: SafeTransactionDataPartial = {
+    const safeTransactionData = {
       to: account2.address,
       value: '500000000000000000', // 0.5 ETH
       data: '0x'
     }
 
-    const transaction = await safeSdk.createTransaction({ safeTransactionData })
+    const transaction = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
 
     const encodedTransaction = await safeSdk.getEncodedTransaction(transaction)
 
@@ -66,13 +65,13 @@ describe('getEncodedTransaction', () => {
       contractNetworks
     })
 
-    const safeTransactionData: SafeTransactionDataPartial = {
+    const safeTransactionData = {
       to: account2.address,
       value: '500000000000000000', // 0.5 ETH
       data: '0x'
     }
 
-    const transaction = await safeSdk.createTransaction({ safeTransactionData })
+    const transaction = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
 
     const encodedTransaction = await safeSdk.getEncodedTransaction(transaction)
 
@@ -97,13 +96,13 @@ describe('getEncodedTransaction', () => {
       contractNetworks
     })
 
-    const safeTransactionData: SafeTransactionDataPartial = {
+    const safeTransactionData = {
       to: account2.address,
       value: '500000000000000000', // 0.5 ETH
       data: '0x'
     }
 
-    const transaction = await safeSdk.createTransaction({ safeTransactionData })
+    const transaction = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
 
     const signedTransaction = await safeSdk.signTransaction(transaction)
 

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -1,9 +1,6 @@
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import Safe, { PredictedSafeProps } from '@safe-global/protocol-kit/index'
-import {
-  SafeMultisigTransactionResponse,
-  SafeTransactionDataPartial
-} from '@safe-global/safe-core-sdk-types'
+import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'
@@ -63,12 +60,12 @@ describe('Off-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       const txHash = await safeSdk.getTransactionHash(tx)
       const signature = await safeSdk.signTransactionHash(txHash)
       chai.expect(signature.staticPart().length).to.be.eq(132)
@@ -93,12 +90,14 @@ describe('Off-chain signatures', () => {
           safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: await safeSdkExistingSafe.getAddress(),
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdkExistingSafe.createTransaction({ safeTransactionData })
+        const tx = await safeSdkExistingSafe.createTransaction({
+          transactions: [safeTransactionData]
+        })
         const signedTx = safeSdk.signTransaction(tx)
         await chai
           .expect(signedTx)
@@ -120,12 +119,12 @@ describe('Off-chain signatures', () => {
           contractNetworks
         })
         const safeAddress = await safe.getAddress()
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         chai.expect(tx.signatures.size).to.be.eq(0)
         const signedTx = await safeSdk.signTransaction(tx)
         chai.expect(tx.signatures.size).to.be.eq(0)
@@ -143,12 +142,12 @@ describe('Off-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       await chai
         .expect(safeSdk.signTransaction(tx))
         .to.be.rejectedWith('Transactions can only be signed by Safe owners')
@@ -164,12 +163,12 @@ describe('Off-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       chai.expect(tx.signatures.size).to.be.eq(0)
       const signedTx1 = await safeSdk.signTransaction(tx)
       chai.expect(signedTx1.signatures.size).to.be.eq(1)
@@ -190,12 +189,12 @@ describe('Off-chain signatures', () => {
           safeAddress: safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         await chai
           .expect(safeSdk.signTransaction(tx, 'eth_sign'))
           .to.be.rejectedWith('eth_sign is only supported by Safes >= v1.1.0')
@@ -214,12 +213,12 @@ describe('Off-chain signatures', () => {
           safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         chai.expect(tx.signatures.size).to.be.eq(0)
         const signedTx = await safeSdk.signTransaction(tx, 'eth_sign')
         chai.expect(tx.signatures.size).to.be.eq(0)
@@ -239,12 +238,12 @@ describe('Off-chain signatures', () => {
           safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         chai.expect(tx.signatures.size).to.be.eq(0)
         const signedTx = await safeSdk.signTransaction(tx, 'eth_signTypedData')
         chai.expect(tx.signatures.size).to.be.eq(0)
@@ -264,12 +263,12 @@ describe('Off-chain signatures', () => {
           safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         await chai
           .expect(safeSdk.signTransaction(tx, 'eth_signTypedData'))
           .to.be.rejectedWith("EIP-712 is not supported by user's wallet")
@@ -288,12 +287,12 @@ describe('Off-chain signatures', () => {
           safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         chai.expect(tx.signatures.size).to.be.eq(0)
         const signedTx = await safeSdk.signTransaction(tx, 'eth_signTypedData_v3')
         chai.expect(tx.signatures.size).to.be.eq(0)
@@ -313,12 +312,12 @@ describe('Off-chain signatures', () => {
           safeAddress,
           contractNetworks
         })
-        const safeTransactionData: SafeTransactionDataPartial = {
+        const safeTransactionData = {
           to: safeAddress,
           value: '0',
           data: '0x'
         }
-        const tx = await safeSdk.createTransaction({ safeTransactionData })
+        const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
         await chai
           .expect(safeSdk.signTransaction(tx, 'eth_signTypedData_v3'))
           .to.be.rejectedWith("EIP-712 is not supported by user's wallet")
@@ -335,12 +334,12 @@ describe('Off-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       chai.expect(tx.signatures.size).to.be.eq(0)
       const signedTx = await safeSdk.signTransaction(tx, 'eth_signTypedData_v4')
       chai.expect(tx.signatures.size).to.be.eq(0)
@@ -357,12 +356,12 @@ describe('Off-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk.createTransaction({ safeTransactionData })
+      const tx = await safeSdk.createTransaction({ transactions: [safeTransactionData] })
       chai.expect(tx.signatures.size).to.be.eq(0)
       const signedTx = await safeSdk.signTransaction(tx)
       chai.expect(tx.signatures.size).to.be.eq(0)

--- a/packages/protocol-kit/tests/e2e/onChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainSignatures.test.ts
@@ -1,6 +1,5 @@
 import { safeVersionDeployed } from '@safe-global/protocol-kit/hardhat/deploy/deploy-contracts'
 import Safe, { PredictedSafeProps } from '@safe-global/protocol-kit/index'
-import { SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { deployments } from 'hardhat'

--- a/packages/protocol-kit/tests/e2e/onChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainSignatures.test.ts
@@ -61,12 +61,12 @@ describe('On-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const hash = await safeSdk1.getTransactionHash(tx)
       await chai
         .expect(safeSdk1.approveTransactionHash(hash))
@@ -83,12 +83,12 @@ describe('On-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const txHash = await safeSdk1.getTransactionHash(tx)
       const txResponse = await safeSdk1.approveTransactionHash(txHash)
       await waitSafeTxReceipt(txResponse)
@@ -105,12 +105,12 @@ describe('On-chain signatures', () => {
         safeAddress,
         contractNetworks
       })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const txHash = await safeSdk1.getTransactionHash(tx)
       chai.expect(await safe.approvedHashes(account1.address, txHash)).to.be.equal(0n)
       const txResponse1 = await safeSdk1.approveTransactionHash(txHash)
@@ -149,12 +149,12 @@ describe('On-chain signatures', () => {
       })
       const ethAdapter2 = await getEthAdapter(account2.signer)
       const safeSdk2 = await safeSdk1.connect({ ethAdapter: ethAdapter2 })
-      const safeTransactionData: SafeTransactionDataPartial = {
+      const safeTransactionData = {
         to: safeAddress,
         value: '0',
         data: '0x'
       }
-      const tx = await safeSdk1.createTransaction({ safeTransactionData })
+      const tx = await safeSdk1.createTransaction({ transactions: [safeTransactionData] })
       const txHash = await safeSdk1.getTransactionHash(tx)
       const ownersWhoApproved0 = await safeSdk1.getOwnersWhoApprovedTx(txHash)
       chai.expect(ownersWhoApproved0.length).to.be.eq(0)

--- a/packages/protocol-kit/tests/e2e/wrapSafeTransactionIntoDeploymentBatch.test.ts
+++ b/packages/protocol-kit/tests/e2e/wrapSafeTransactionIntoDeploymentBatch.test.ts
@@ -52,12 +52,14 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
       contractNetworks
     })
 
+    const safeTransactionData = {
+      to: account2.address,
+      value: AMOUNT_TO_TRANSFER,
+      data: '0x'
+    }
+
     const safeTransaction = await safeSdk.createTransaction({
-      safeTransactionData: {
-        to: account2.address,
-        value: AMOUNT_TO_TRANSFER,
-        data: '0x'
-      }
+      transactions: [safeTransactionData]
     })
 
     await chai
@@ -79,12 +81,14 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
         contractNetworks
       })
 
+      const safeTransactionData = {
+        to: account2.address,
+        value: AMOUNT_TO_TRANSFER,
+        data: '0x'
+      }
+
       const safeTransaction = await safeSdk.createTransaction({
-        safeTransactionData: {
-          to: account2.address,
-          value: AMOUNT_TO_TRANSFER,
-          data: '0x'
-        }
+        transactions: [safeTransactionData]
       })
 
       const batchTransaction = await safeSdk.wrapSafeTransactionIntoDeploymentBatch(safeTransaction)
@@ -113,12 +117,14 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
         contractNetworks
       })
 
+      const safeTransactionData = {
+        to: account2.address,
+        value: AMOUNT_TO_TRANSFER,
+        data: '0x'
+      }
+
       const safeTransaction = await safeSdk.createTransaction({
-        safeTransactionData: {
-          to: account2.address,
-          value: AMOUNT_TO_TRANSFER,
-          data: '0x'
-        }
+        transactions: [safeTransactionData]
       })
 
       const batchTransaction = await safeSdk.wrapSafeTransactionIntoDeploymentBatch(safeTransaction)
@@ -147,12 +153,14 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
         contractNetworks
       })
 
+      const safeTransactionData = {
+        to: account2.address,
+        value: AMOUNT_TO_TRANSFER,
+        data: '0x'
+      }
+
       const safeTransaction = await safeSdk.createTransaction({
-        safeTransactionData: {
-          to: account2.address,
-          value: AMOUNT_TO_TRANSFER,
-          data: '0x'
-        }
+        transactions: [safeTransactionData]
       })
 
       const customSaltNonce = '123456789'

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayPack.test.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayPack.test.ts
@@ -185,7 +185,7 @@ describe('GelatoRelayPack', () => {
         await relayPack.createRelayedTransaction({ transactions, options })
 
         expect(safe.createTransaction).toHaveBeenCalledWith({
-          safeTransactionData: transactions,
+          transactions,
           onlyCalls: false,
           options: {
             nonce: 0
@@ -200,7 +200,7 @@ describe('GelatoRelayPack', () => {
         })
 
         expect(safe.createTransaction).toHaveBeenCalledWith({
-          safeTransactionData: transactions,
+          transactions,
           onlyCalls: false,
           options: {
             baseGas: FEE_ESTIMATION.toString(),
@@ -220,7 +220,7 @@ describe('GelatoRelayPack', () => {
         })
 
         expect(safe.createTransaction).toHaveBeenCalledWith({
-          safeTransactionData: transactions,
+          transactions,
           onlyCalls: false,
           options: {
             baseGas: FEE_ESTIMATION.toString(),
@@ -254,7 +254,7 @@ describe('GelatoRelayPack', () => {
         await relayPack.createRelayedTransaction({ transactions, options })
 
         expect(safe.createTransaction).toHaveBeenCalledWith({
-          safeTransactionData: [...transactions, transferToGelato], // the transfer to Gelato is prensent
+          transactions: [...transactions, transferToGelato], // the transfer to Gelato is prensent
           onlyCalls: false,
           options: {
             gasToken: GAS_TOKEN, // non standard ERC20 gas token
@@ -292,7 +292,7 @@ describe('GelatoRelayPack', () => {
         await relayPack.createRelayedTransaction({ transactions, options })
 
         expect(safe.createTransaction).toHaveBeenCalledWith({
-          safeTransactionData: transactions,
+          transactions,
           onlyCalls: false,
           options: {
             nonce: 0
@@ -310,7 +310,7 @@ describe('GelatoRelayPack', () => {
           await relayPack.createRelayedTransaction({ transactions })
 
           expect(safe.createTransaction).toHaveBeenCalledWith({
-            safeTransactionData: transactions,
+            transactions,
             onlyCalls: false,
             options: {
               baseGas: FEE_ESTIMATION.toString(),
@@ -331,7 +331,7 @@ describe('GelatoRelayPack', () => {
           await relayPack.createRelayedTransaction({ transactions, options })
 
           expect(safe.createTransaction).toHaveBeenCalledWith({
-            safeTransactionData: transactions,
+            transactions,
             onlyCalls: false,
             options: {
               baseGas: FEE_ESTIMATION.toString(),
@@ -367,7 +367,7 @@ describe('GelatoRelayPack', () => {
           await relayPack.createRelayedTransaction({ transactions, options })
 
           expect(safe.createTransaction).toHaveBeenCalledWith({
-            safeTransactionData: [...transactions, transferToGelato], // the transfer to Gelato is prensent
+            transactions: [...transactions, transferToGelato], // the transfer to Gelato is prensent
             onlyCalls: false,
             options: {
               gasToken: GAS_TOKEN, // non standard ERC20 gas token

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts
@@ -113,7 +113,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
       const nonce = await this.protocolKit.getNonce()
 
       const sponsoredTransaction = await this.protocolKit.createTransaction({
-        safeTransactionData: transactions,
+        transactions,
         onlyCalls,
         options: {
           nonce
@@ -162,7 +162,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
 
     // this transaction is only used for gas estimations
     const transactionToEstimateGas = await this.protocolKit.createTransaction({
-      safeTransactionData: transactions,
+      transactions,
       onlyCalls,
       options: {
         nonce
@@ -181,7 +181,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
       const paymentToGelato = await this.getEstimateFee(chainId, gasLimit, gasToken)
 
       const syncTransaction = await this.protocolKit.createTransaction({
-        safeTransactionData: transactions,
+        transactions,
         onlyCalls,
         options: {
           baseGas: paymentToGelato,
@@ -210,7 +210,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
     const paymentToGelato = await this.getEstimateFee(chainId, String(totalGas), gasToken)
 
     const syncTransaction = await this.protocolKit.createTransaction({
-      safeTransactionData: transactions,
+      transactions,
       onlyCalls,
       options: {
         baseGas: paymentToGelato, // payment to Gelato
@@ -249,7 +249,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
       const transferToGelato = await this.createPaymentToGelato(gasLimit, options)
 
       const syncTransaction = await this.protocolKit.createTransaction({
-        safeTransactionData: [...transactions, transferToGelato],
+        transactions: [...transactions, transferToGelato],
         onlyCalls,
         options: {
           nonce,
@@ -264,7 +264,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
 
     // this transaction is only used for gas estimations
     const transactionToEstimateGas = await this.protocolKit.createTransaction({
-      safeTransactionData: transactions,
+      transactions,
       onlyCalls,
       options: {
         nonce
@@ -285,7 +285,7 @@ export class GelatoRelayPack extends RelayKitBasePack {
     const transferToGelato = await this.createPaymentToGelato(String(totalGas), options)
 
     const syncTransaction = await this.protocolKit.createTransaction({
-      safeTransactionData: [...transactions, transferToGelato],
+      transactions: [...transactions, transferToGelato],
       onlyCalls,
       options: {
         nonce,

--- a/playground/api-kit/propose-transaction.ts
+++ b/playground/api-kit/propose-transaction.ts
@@ -49,7 +49,7 @@ async function main() {
     data: '0x',
     operation: OperationType.Call
   }
-  const safeTransaction = await safe.createTransaction({ safeTransactionData })
+  const safeTransaction = await safe.createTransaction({ transactions: [safeTransactionData] })
 
   const senderAddress = await signer.getAddress()
   const safeTxHash = await safe.getTransactionHash(safeTransaction)


### PR DESCRIPTION
## What it solves
Resolves #334 

Create transaction accepted either an object or an array to create a new Safe transaction. This felxibility was OK, but it generates confusion and all scenarios can be covered by accepting an array only, as we also had an options object in place. Also this way, the protocol-kit create transaction aligns with the relay-kit method signature.

## How this PR fixes it
Accepts only an array of transactions, even if it only contains one transaction.