### PR TITLE
fix: getServiceSingletons test

### DIFF
--- a/packages/api-kit/package.json
+++ b/packages/api-kit/package.json
@@ -48,6 +48,7 @@
     "chai-as-promised": "^7.1.1",
     "hardhat": "^2.19.0",
     "mocha": "^10.2.0",
+    "semver": "^7.5.4",
     "sinon": "^14.0.2",
     "sinon-chai": "^3.7.0",
     "ts-generator": "^0.1.1",

--- a/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
@@ -1,5 +1,6 @@
 import chai from 'chai'
 import SafeApiKit from '@safe-global/api-kit/index'
+import semverSatisfies from 'semver/functions/satisfies'
 import { getServiceClient } from '../utils/setupServiceClient'
 
 let safeApiKit: SafeApiKit
@@ -15,7 +16,12 @@ describe('getServiceSingletonsInfo', () => {
     const singletonsResponse = await safeApiKit.getServiceSingletonsInfo()
     chai.expect(singletonsResponse.length).to.be.greaterThan(1)
     singletonsResponse.map((singleton) => {
-      chai.expect(singleton.deployer).to.be.equal('Gnosis')
+      if (semverSatisfies(singleton.version, '<=1.3.0')) {
+        chai.expect(singleton.deployer).to.be.equal('Gnosis')
+      }
+      if (semverSatisfies(singleton.version, '>1.3.0')) {
+        chai.expect(singleton.deployer).to.be.equal('Safe')
+      }
     })
   })
 })


### PR DESCRIPTION
## What it solves
Fixes getServiceSingletons test as now the deployer can also be Safe apart from Gnosis

## How this PR fixes it
Check and keep Gnosis as deployer for the older versions, uses Safe for the new ones