### PR TITLE
fix(account-abstraction-kit): getNonce unit test

### DIFF
--- a/packages/account-abstraction-kit/src/AccountAbstraction.test.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.test.ts
@@ -90,16 +90,16 @@ describe('AccountAbstraction', () => {
     let accountAbstraction: AccountAbstraction
 
     beforeEach(async () => {
-      accountAbstraction = await initAccountAbstraction()
       jest.clearAllMocks()
       SafeMock.create = () => Promise.resolve(safeInstanceMock as unknown as Safe)
+      accountAbstraction = await initAccountAbstraction()
     })
 
     describe('getNonce', () => {
       const nonceMock = 123
       safeInstanceMock.getNonce.mockResolvedValueOnce(nonceMock)
 
-      it.skip('should return the nonce from the protocol-kit', async () => {
+      it('should return the nonce from the protocol-kit', async () => {
         const result = await accountAbstraction.protocolKit.getNonce()
         expect(result).toBe(nonceMock)
         expect(safeInstanceMock.getNonce).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Setup `Safe.create` mock before initializing the AccountAbstraction instance

## What it solves
Resolves #593

## How this PR fixes it
The unit test was failing because the `Safe.create` mock had been defined only after creating the `AccountAbstraction` instance, resulting in its `protocolKit` property being undefined when running the test.
