### PR TITLE
fix exception handling in signature decoding for Monerium Pack

### DIFF
--- a/packages/onramp-kit/src/lib/errors.ts
+++ b/packages/onramp-kit/src/lib/errors.ts
@@ -26,3 +26,48 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 export function getErrorMessage(error: unknown) {
   return toErrorWithMessage(error).message
 }
+type GnosisChainEstimationError = { info: { error: { data: string | { data: string } } } }
+type EthersEstimationError = { data: string }
+type EstimationError = Error & EthersEstimationError & GnosisChainEstimationError
+
+/**
+ * Parses the isValidSignature call response from different providers.
+ * It extracts and decodes the signature value from the Error object.
+ *
+ * @param {ProviderEstimationError} error - The estimation object with the estimation data.
+ * @returns {string} The signature value.
+ * @throws It Will throw an error if the signature cannot be parsed.
+ */
+export function parseIsValidSignatureErrorResponse(error: EstimationError): string {
+  // Ethers v6
+  const ethersData = error?.data
+  if (ethersData) {
+    return decodeSignatureData(ethersData)
+  }
+
+  // gnosis-chain
+  const gnosisChainProviderData = error?.info?.error?.data
+
+  if (gnosisChainProviderData) {
+    const isString = typeof gnosisChainProviderData === 'string'
+
+    const encodedDataResponse = isString ? gnosisChainProviderData : gnosisChainProviderData.data
+    return decodeSignatureData(encodedDataResponse)
+  }
+
+  // Error message
+  const isEncodedDataPresent = error?.message?.includes('0x')
+
+  if (isEncodedDataPresent) {
+    return decodeSignatureData(error?.message)
+  }
+
+  throw new Error('Could not parse Signature from Error response, Details: ' + error?.message)
+}
+
+export function decodeSignatureData(encodedSignatureData: string): string {
+  const [, encodedSignature] = encodedSignatureData.split('0x')
+  const data = '0x' + encodedSignature
+
+  return data.slice(0, 10).toLowerCase()
+}

--- a/packages/onramp-kit/src/lib/errors.ts
+++ b/packages/onramp-kit/src/lib/errors.ts
@@ -26,19 +26,19 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 export function getErrorMessage(error: unknown) {
   return toErrorWithMessage(error).message
 }
-type GnosisChainEstimationError = { info: { error: { data: string | { data: string } } } }
-type EthersEstimationError = { data: string }
-type EstimationError = Error & EthersEstimationError & GnosisChainEstimationError
+type GnosisChainSignatureError = { info: { error: { data: string | { data: string } } } }
+type EthersSignatureError = { data: string }
+type SignatureError = Error & EthersSignatureError & GnosisChainSignatureError
 
 /**
  * Parses the isValidSignature call response from different providers.
  * It extracts and decodes the signature value from the Error object.
  *
- * @param {ProviderEstimationError} error - The estimation object with the estimation data.
+ * @param {ProviderSignatureError} error - The error object with the signature data.
  * @returns {string} The signature value.
  * @throws It Will throw an error if the signature cannot be parsed.
  */
-export function parseIsValidSignatureErrorResponse(error: EstimationError): string {
+export function parseIsValidSignatureErrorResponse(error: SignatureError): string {
   // Ethers v6
   const ethersData = error?.data
   if (ethersData) {

--- a/packages/onramp-kit/src/packs/monerium/SafeMoneriumClient.ts
+++ b/packages/onramp-kit/src/packs/monerium/SafeMoneriumClient.ts
@@ -3,7 +3,11 @@ import { hashMessage, getBytes } from 'ethers'
 import { Chain, IBAN, MoneriumClient, Networks, NewOrder } from '@monerium/sdk'
 import Safe, { getSignMessageLibContract } from '@safe-global/protocol-kit'
 import SafeApiKit from '@safe-global/api-kit'
-import { getErrorMessage } from '@safe-global/onramp-kit/lib/errors'
+import {
+  decodeSignatureData,
+  getErrorMessage,
+  parseIsValidSignatureErrorResponse
+} from '@safe-global/onramp-kit/lib/errors'
 import {
   EthAdapter,
   OperationType,
@@ -227,13 +231,23 @@ export class SafeMoneriumClient extends MoneriumClient {
         })
       ]
 
-      const response = await Promise.all(checks)
+      const responses = await Promise.allSettled(checks)
 
-      return (
-        !!response.length &&
-        (response[0].slice(0, 10).toLowerCase() === MAGIC_VALUE ||
-          response[1].slice(0, 10).toLowerCase() === MAGIC_VALUE_BYTES)
-      )
+      return responses.reduce((prev, response) => {
+        if (response.status === 'fulfilled') {
+          return (
+            prev ||
+            decodeSignatureData(response.value) === MAGIC_VALUE ||
+            decodeSignatureData(response.value) === MAGIC_VALUE_BYTES
+          )
+        }
+
+        return (
+          prev ||
+          parseIsValidSignatureErrorResponse(response.reason) === MAGIC_VALUE ||
+          parseIsValidSignatureErrorResponse(response.reason) === MAGIC_VALUE_BYTES
+        )
+      }, false)
     } catch (error) {
       throw new Error(getErrorMessage(error))
     }


### PR DESCRIPTION
## What it solves

Improve exception handling in signature decoding for Monerium.pack

Added a couple of unit tests

## How this PR fixes it

Now we are using `Promise.allSettled` instead of `Promise.all`
Added `parseIsValidSignatureErrorResponse` and `decodeSignatureData` to parse the error