### PR TITLE
fix(auth-kit): wrap ApiKit instance creation with a try..catch

### DIFF
--- a/packages/auth-kit/src/AuthKitBasePack.ts
+++ b/packages/auth-kit/src/AuthKitBasePack.ts
@@ -55,11 +55,11 @@ export abstract class AuthKitBasePack {
    * @returns The list of Safe addresses owned by the user in the chain
    */
   async getSafes(chainId: bigint, txServiceUrl?: string): Promise<string[]> {
-    const apiKit = this.#getApiKit(chainId, txServiceUrl)
-
-    const address = await this.getAddress()
-
     try {
+      const apiKit = this.#getApiKit(chainId, txServiceUrl)
+
+      const address = await this.getAddress()
+
       const safesByOwner = await apiKit.getSafesByOwner(address)
 
       return safesByOwner.safes


### PR DESCRIPTION
This prevents an error being thrown for chains to which the TX service is not available (like Mumbai). The auth-kit should still be usable for those chains.

## Demo
![Kapture 2023-11-23 at 15 37 34](https://github.com/safe-global/safe-core-sdk/assets/4171783/5f20a0cd-ed3b-4684-b36d-c98cbb358757)