### PR TITLE
feat: add missing `proposer` field to `SafeMultisigTransactionWithTransfersResponse`

### DIFF
--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -165,6 +165,7 @@ export type SafeMultisigTransactionResponse = {
   readonly transactionHash: string
   readonly safeTxHash: string
   readonly executor?: string
+  readonly proposer?: string
   readonly isExecuted: boolean
   readonly isSuccessful?: boolean
   readonly ethGasPrice?: string

--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -165,7 +165,7 @@ export type SafeMultisigTransactionResponse = {
   readonly transactionHash: string
   readonly safeTxHash: string
   readonly executor?: string
-  readonly proposer?: string
+  readonly proposer: string
   readonly isExecuted: boolean
   readonly isSuccessful?: boolean
   readonly ethGasPrice?: string


### PR DESCRIPTION
## What it solves

The `proposer` field is missing from the typescript definition but returned by the Safe API.

## How this PR fixes it

Add the missing field in the type.