### PR TITLE
feat: Add `value` to `TransactionOptions`

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -1179,8 +1179,11 @@ class Safe {
 
     const value = BigInt(signedSafeTransaction.data.value)
     if (value !== 0n) {
+      const signerValue = BigInt(options?.value || 0)
       const balance = await this.getBalance()
-      if (value > balance) {
+      const totalBalance = signerValue + balance
+
+      if (value > totalBalance) {
         throw new Error('Not enough Ether funds')
       }
     }

--- a/packages/protocol-kit/src/adapters/ethers/types.ts
+++ b/packages/protocol-kit/src/adapters/ethers/types.ts
@@ -3,6 +3,7 @@ import { BaseTransactionResult } from '@safe-global/safe-core-sdk-types'
 
 export interface EthersTransactionOptions {
   from?: string
+  value?: string
   gasLimit?: number | string
   gasPrice?: number | string
   maxFeePerGas?: number | string

--- a/packages/protocol-kit/src/adapters/web3/types.ts
+++ b/packages/protocol-kit/src/adapters/web3/types.ts
@@ -3,6 +3,7 @@ import { PromiEvent, TransactionReceipt } from 'web3-core/types'
 
 export interface Web3TransactionOptions {
   from?: string
+  value?: string
   gas?: number | string
   gasPrice?: number | string
   maxFeePerGas?: number | string

--- a/packages/protocol-kit/tests/e2e/eip1271.test.ts
+++ b/packages/protocol-kit/tests/e2e/eip1271.test.ts
@@ -437,10 +437,10 @@ describe('The EIP1271 implementation', () => {
             data: '0x'
           }
 
-          await account1.signer.sendTransaction({
-            to: safeAddress,
-            value: 1_000_000_000_000_000_000n // 1 ETH
-          })
+          // await account1.signer.sendTransaction({
+          //   to: safeAddress,
+          //   value: 1_000_000_000_000_000_000n // 1 ETH
+          // })
 
           chai.expect(await safeSdk1.getNonce()).to.be.eq(0)
 
@@ -464,7 +464,9 @@ describe('The EIP1271 implementation', () => {
 
           tx.addSignature(signerSafeSig)
 
-          const execResponse = await safeSdk1.executeTransaction(tx)
+          const execResponse = await safeSdk1.executeTransaction(tx, {
+            value: '100000000000000000'
+          })
           await waitSafeTxReceipt(execResponse)
 
           chai.expect(await safeSdk1.getNonce()).to.be.eq(1)

--- a/packages/safe-core-sdk-types/src/types.ts
+++ b/packages/safe-core-sdk-types/src/types.ts
@@ -78,6 +78,7 @@ interface TransactionBase {
 
 export interface TransactionOptions {
   from?: string
+  value?: string
   gas?: number | string
   gasLimit?: number | string
   gasPrice?: number | string


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-core-sdk/issues/638

## How this PR fixes it
This PR adds the value to the `TransactionOptions` object used to execute transactions. The value will be used in the internal transaction produced by `ethers` or `web3` so it's possible to send funds before executing the transaction
