### PR TITLE
feat: add short name for PGN(Public Goods Network) and Sepolia PGN

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -132,6 +132,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 54211n, shortName: 'islmt' },
   { chainId: 56288n, shortName: 'boba-bnb' },
   { chainId: 57000n, shortName: 'tsys-rollux' },
+  { chainId: 58008n, shortName: 'sepPGN' },
   { chainId: 59140n, shortName: 'linea-testnet' },
   { chainId: 59144n, shortName: 'linea' },
   { chainId: 71401n, shortName: 'gw-testnet-v1' },

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -55,6 +55,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 336n, shortName: 'sdn' },
   { chainId: 338n, shortName: 'tcro' },
   { chainId: 420n, shortName: 'ogor' },
+  { chainId: 424n, shortName: 'PGN' },
   { chainId: 570n, shortName: 'sys-rollux' },
   { chainId: 588n, shortName: 'metis-stardust' },
   { chainId: 592n, shortName: 'astr' },


### PR DESCRIPTION
## What it solves
Adds short names for PGN and Sepolia PGN:

- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-424.json
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-58008.json

Contracts we published at [v1.29.0 of safe-deployments](https://github.com/safe-global/safe-deployments/releases/tag/v1.29.0#:~:text=PGN%20mainnet%20and%20testnet)

Thanks in advance!