### PR TITLE
feat: add short name for Mode Mainnet

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -119,6 +119,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 17000n, shortName: 'holesky' },
   { chainId: 23294n, shortName: 'sapphire' },
   { chainId: 23295n, shortName: 'sapphire-testnet' },
+  { chainId: 34443n, shortName: 'mode' },
   { chainId: 42161n, shortName: 'arb1' },
   { chainId: 42170n, shortName: 'arb-nova' },
   { chainId: 42220n, shortName: 'celo' },


### PR DESCRIPTION
## What it solves
Adds short name for Mode Mainnet:

https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-34443.json

Contracts we merged into safe-deployment at https://github.com/safe-global/safe-deployments/pull/356

Thanks in advance!