### PR TITLE
chore: Rename protocol-kit in onramp-kit

### DIFF
--- a/packages/onramp-kit/example/client/src/components/monerium/Monerium.tsx
+++ b/packages/onramp-kit/example/client/src/components/monerium/Monerium.tsx
@@ -28,7 +28,7 @@ function Monerium() {
       const safeOwner = await provider.getSigner()
       const ethAdapter = new EthersAdapter({ ethers, signerOrProvider: safeOwner })
 
-      const safeSdk = await Safe.create({
+      const protocolKit = await Safe.create({
         ethAdapter: ethAdapter,
         safeAddress: selectedSafe,
         isL1SafeSingleton: true
@@ -41,7 +41,7 @@ function Monerium() {
       })
 
       await pack.init({
-        safeSdk
+        protocolKit
       })
 
       pack.subscribe(OrderState.pending, (notification) => {
@@ -66,8 +66,8 @@ function Monerium() {
         }, 5000)
       })
 
-      const threshold = await safeSdk.getThreshold()
-      const owners = await safeSdk.getOwners()
+      const threshold = await protocolKit.getThreshold()
+      const owners = await protocolKit.getOwners()
 
       setSafeThreshold(`${threshold}/${owners.length}`)
       setMoneriumPack(pack)

--- a/packages/onramp-kit/src/packs/monerium/MoneriumPack.test.ts
+++ b/packages/onramp-kit/src/packs/monerium/MoneriumPack.test.ts
@@ -48,9 +48,9 @@ describe('MoneriumPack', () => {
     })
 
     it('should initialize the pack', async () => {
-      const safeSdk = new Safe()
+      const protocolKit = new Safe()
 
-      await moneriumPack.init({ safeSdk })
+      await moneriumPack.init({ protocolKit })
 
       expect(safeMoneriumClient.SafeMoneriumClient).toHaveBeenCalledWith(
         {
@@ -58,7 +58,7 @@ describe('MoneriumPack', () => {
           environment: 'sandbox',
           redirectUrl: 'http://localhost:3000'
         },
-        safeSdk
+        protocolKit
       )
     })
 
@@ -72,9 +72,9 @@ describe('MoneriumPack', () => {
 
   describe('open()', () => {
     beforeEach(async () => {
-      const safeSdk = new Safe()
+      const protocolKit = new Safe()
 
-      await moneriumPack.init({ safeSdk })
+      await moneriumPack.init({ protocolKit })
     })
 
     it('should call order socket', async () => {
@@ -128,9 +128,9 @@ describe('MoneriumPack', () => {
         safeMoneriumClient.SafeMoneriumClient.prototype,
         'revokeAccess'
       )
-      const safeSdk = new Safe()
+      const protocolKit = new Safe()
 
-      await moneriumPack.init({ safeSdk })
+      await moneriumPack.init({ protocolKit })
 
       await moneriumPack.close()
 

--- a/packages/onramp-kit/src/packs/monerium/MoneriumPack.ts
+++ b/packages/onramp-kit/src/packs/monerium/MoneriumPack.ts
@@ -31,7 +31,7 @@ export class MoneriumPack extends OnRampKitBasePack {
    * @throws {Error} If the Monerium client is not initialized
    */
   async init(options: MoneriumInitOptions) {
-    if (!options?.safeSdk) {
+    if (!options?.protocolKit) {
       throw new Error('You need to provide an instance of the protocol kit')
     }
 
@@ -41,7 +41,7 @@ export class MoneriumPack extends OnRampKitBasePack {
         clientId: this.#config.clientId,
         redirectUrl: this.#config.redirectUrl
       },
-      options.safeSdk
+      options.protocolKit
     )
   }
 

--- a/packages/onramp-kit/src/packs/monerium/SafeMoneriumClient.ts
+++ b/packages/onramp-kit/src/packs/monerium/SafeMoneriumClient.ts
@@ -32,19 +32,19 @@ import {
 import { SafeMoneriumOrder } from './types'
 
 export class SafeMoneriumClient extends MoneriumClient {
-  #safeSdk: Safe
+  #protocolKit: Safe
   #ethAdapter: EthAdapter
 
   /**
    * Constructor where the Monerium environment and the Protocol kit instance are set
    * @param moneriumOptions The Monerium options object
-   * @param safeSdk The Protocol kit instance
+   * @param protocolKit The Protocol kit instance
    */
-  constructor(moneriumOptions: ClassOptions, safeSdk: Safe) {
+  constructor(moneriumOptions: ClassOptions, protocolKit: Safe) {
     super(moneriumOptions)
 
-    this.#safeSdk = safeSdk
-    this.#ethAdapter = safeSdk.getEthAdapter()
+    this.#protocolKit = protocolKit
+    this.#ethAdapter = protocolKit.getEthAdapter()
   }
 
   /**
@@ -52,7 +52,7 @@ export class SafeMoneriumClient extends MoneriumClient {
    * @returns The Safe address
    */
   async getSafeAddress(): Promise<string> {
-    return await this.#safeSdk.getAddress()
+    return await this.#protocolKit.getAddress()
   }
 
   /**
@@ -94,7 +94,7 @@ export class SafeMoneriumClient extends MoneriumClient {
    * @returns A boolean indicating if the message is signed
    */
   async isSignMessagePending(safeAddress: string, message: string): Promise<boolean> {
-    const chainId = await this.#safeSdk.getChainId()
+    const chainId = await this.#protocolKit.getChainId()
 
     const apiKit = new SafeApiKit({ chainId })
 
@@ -120,7 +120,7 @@ export class SafeMoneriumClient extends MoneriumClient {
     message: string
   ): Promise<SafeMultisigTransactionResponse> {
     try {
-      const safeVersion = await this.#safeSdk.getContractVersion()
+      const safeVersion = await this.#protocolKit.getContractVersion()
 
       const signMessageContract = await getSignMessageLibContract({
         ethAdapter: this.#ethAdapter,
@@ -135,15 +135,15 @@ export class SafeMoneriumClient extends MoneriumClient {
         data: txData,
         operation: OperationType.DelegateCall
       }
-      const safeTransaction = await this.#safeSdk.createTransaction({
+      const safeTransaction = await this.#protocolKit.createTransaction({
         transactions: [safeTransactionData]
       })
 
-      const safeTxHash = await this.#safeSdk.getTransactionHash(safeTransaction)
+      const safeTxHash = await this.#protocolKit.getTransactionHash(safeTransaction)
 
-      const senderSignature = await this.#safeSdk.signHash(safeTxHash)
+      const senderSignature = await this.#protocolKit.signHash(safeTxHash)
 
-      const chainId = await this.#safeSdk.getChainId()
+      const chainId = await this.#protocolKit.getChainId()
 
       const apiKit = new SafeApiKit({ chainId })
 
@@ -168,7 +168,7 @@ export class SafeMoneriumClient extends MoneriumClient {
    * @returns The Chain Id
    */
   async getChainId(): Promise<number> {
-    return Number(await this.#safeSdk.getChainId())
+    return Number(await this.#protocolKit.getChainId())
   }
 
   /**
@@ -176,7 +176,7 @@ export class SafeMoneriumClient extends MoneriumClient {
    * @returns The Chain
    */
   async getChain(): Promise<Chain> {
-    const chainId = await this.#safeSdk.getChainId()
+    const chainId = await this.#protocolKit.getChainId()
 
     return getMoneriumChain(Number(chainId))
   }
@@ -186,7 +186,7 @@ export class SafeMoneriumClient extends MoneriumClient {
    * @returns The Network
    */
   async getNetwork(): Promise<Networks> {
-    const chainId = await this.#safeSdk.getChainId()
+    const chainId = await this.#protocolKit.getChainId()
 
     return getMoneriumNetwork(Number(chainId))
   }

--- a/packages/onramp-kit/src/packs/monerium/types.ts
+++ b/packages/onramp-kit/src/packs/monerium/types.ts
@@ -8,7 +8,7 @@ export interface MoneriumProviderConfig {
 }
 
 export interface MoneriumInitOptions {
-  safeSdk: Safe
+  protocolKit: Safe
 }
 
 export interface SafeMoneriumOrder {


### PR DESCRIPTION
## What it solves
Rename the old safeSdk name to protocolKit so it follows the new naming convention.