### PR TITLE
chore: bump monerium sdk to 2.11.0 for Sepolia support

### DIFF
--- a/packages/onramp-kit/example/client/package.json
+++ b/packages/onramp-kit/example/client/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@monerium/sdk": "^2.9.0",
+    "@monerium/sdk": "^2.11.0",
     "@mui/material": "^5.14.17",
     "@safe-global/auth-kit": "file:../../../auth-kit",
     "@safe-global/onramp-kit": "file:../../",

--- a/packages/onramp-kit/example/client/yarn.lock
+++ b/packages/onramp-kit/example/client/yarn.lock
@@ -808,10 +808,10 @@
     semver "^7.5.4"
     superstruct "^1.0.3"
 
-"@monerium/sdk@^2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@monerium/sdk/-/sdk-2.9.0.tgz#ec7296623853acd0b7477b1b088f8c8fae42f197"
-  integrity sha512-6tr1fWau5tca2xjgIB/7NLJQFoVLcRvGQh6gqzgPJZCS9kRIVlupGk1MaejFdGWOmoEqJSFVUzi0TGhEJK+VcA==
+"@monerium/sdk@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@monerium/sdk/-/sdk-2.11.0.tgz#d926609bcbd9c2c87a3b3c755c71da35c47f0cd8"
+  integrity sha512-GyNKnlpLu+jsp7cV/FsR4G993Y5zix0cCQu5c574M24wGzw7aK+uWEphRK9/DKCwR590Y9IXmnYcxQMLp4ahag==
   dependencies:
     crypto-js "^4.2.0"
 

--- a/packages/onramp-kit/package.json
+++ b/packages/onramp-kit/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@monerium/sdk": "^2.9.0",
+    "@monerium/sdk": "^2.11.0",
     "@safe-global/api-kit": "^2.1.0",
     "@safe-global/protocol-kit": "^3.0.0",
     "@safe-global/safe-core-sdk-types": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,10 +1261,10 @@
     semver "^7.5.4"
     superstruct "^1.0.3"
 
-"@monerium/sdk@^2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@monerium/sdk/-/sdk-2.9.0.tgz#ec7296623853acd0b7477b1b088f8c8fae42f197"
-  integrity sha512-6tr1fWau5tca2xjgIB/7NLJQFoVLcRvGQh6gqzgPJZCS9kRIVlupGk1MaejFdGWOmoEqJSFVUzi0TGhEJK+VcA==
+"@monerium/sdk@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@monerium/sdk/-/sdk-2.11.0.tgz#d926609bcbd9c2c87a3b3c755c71da35c47f0cd8"
+  integrity sha512-GyNKnlpLu+jsp7cV/FsR4G993Y5zix0cCQu5c574M24wGzw7aK+uWEphRK9/DKCwR590Y9IXmnYcxQMLp4ahag==
   dependencies:
     crypto-js "^4.2.0"
 


### PR DESCRIPTION
DO NOT MERGE
Wasn't able to properly test since the onramp kit seems to still trying to use Goerli.
Tests are failing, because they are trying to use Goerli.

## What it solves

Version 2.11.0 of `@monerium/sdk` supports Sepolia.



## How this PR fixes it
