### PR TITLE
feat: add short name for Lisk Sepolia Testnet

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -101,6 +101,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 2358n, shortName: 'kroma-sepolia' },
   { chainId: 3737n, shortName: 'csb' },
   { chainId: 4002n, shortName: 'tftm' },
+  { chainId: 4202n, shortName: 'lisksep' },
   { chainId: 4337n, shortName: 'beam' },
   { chainId: 4460n, shortName: 'orderlyl2' },
   { chainId: 4689n, shortName: 'iotex-mainnet' },


### PR DESCRIPTION
## What it solves
Adds short name for Lisk Sepolia Testnet:

https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-4202.json
