### PR TITLE
feat(protocol-kit): add short name for IoTeX Network Testnet

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -104,6 +104,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 4337n, shortName: 'beam' },
   { chainId: 4460n, shortName: 'orderlyl2' },
   { chainId: 4689n, shortName: 'iotex-mainnet' },
+  { chainId: 4690n, shortName: 'iotex-testnet' },
   { chainId: 4918n, shortName: 'txvm' },
   { chainId: 4919n, shortName: 'xvm' },
   { chainId: 5000n, shortName: 'mantle' },


### PR DESCRIPTION
## What it solves
Adds short name for IoTeX Network Testnet:

https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-4690.json