### PR TITLE
feat(protocol-kit): Migrate v1.0.0 to Abitype

### DIFF
--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -67,7 +67,7 @@
     "@types/semver": "^7.5.6",
     "@types/web3": "1.0.20",
     "@types/yargs": "^17.0.32",
-    "abitype": "^0.10.2",
+    "abitype": "^0.10.3",
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^16.3.1",

--- a/packages/protocol-kit/scripts/generateTypechainFiles.ts
+++ b/packages/protocol-kit/scripts/generateTypechainFiles.ts
@@ -25,7 +25,6 @@ const safeContracts_V1_3_0 = [
   `${safeContractsPath}/v1.3.0/create_call.json`,
   `${safeContractsPath}/v1.3.0/simulate_tx_accessor.json`
 ].join(' ')
-const safeContracts_V1_0_0 = [`${safeContractsPath}/v1.0.0/gnosis_safe.json`].join(' ')
 
 // Won't be included in dist/ folder
 const safeContractsTestV1_4_1Path =
@@ -79,7 +78,7 @@ function moveTypechainFiles(inDir: string, outDir: string): void {
   })
 }
 
-// Contracts v1.1.1 + v1.2.0 are migrated to Abitype already, so they're not included in here
+// Contracts v1.0.0 + v1.1.1 + v1.2.0 are migrated to Abitype already, so they're not included in here
 function generateTypes(typechainTarget: string) {
   // Src
   generateTypechainFiles(
@@ -92,11 +91,6 @@ function generateTypes(typechainTarget: string) {
     `${outDirSrc}${typechainTarget}/v1.3.0`,
     safeContracts_V1_3_0
   )
-  generateTypechainFiles(
-    typechainTarget,
-    `${outDirSrc}${typechainTarget}/v1.0.0`,
-    safeContracts_V1_0_0
-  )
   moveTypechainFiles(
     `${typeChainDirectorySrcPath}${typechainTarget}/v1.4.1`,
     `${typeChainDirectoryBuildPath}${typechainTarget}/v1.4.1`
@@ -104,10 +98,6 @@ function generateTypes(typechainTarget: string) {
   moveTypechainFiles(
     `${typeChainDirectorySrcPath}${typechainTarget}/v1.3.0`,
     `${typeChainDirectoryBuildPath}${typechainTarget}/v1.3.0`
-  )
-  moveTypechainFiles(
-    `${typeChainDirectorySrcPath}${typechainTarget}/v1.0.0`,
-    `${typeChainDirectoryBuildPath}${typechainTarget}/v1.0.0`
   )
 
   // Tests

--- a/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
+++ b/packages/protocol-kit/src/adapters/ethers/EthersAdapter.ts
@@ -109,11 +109,9 @@ class EthersAdapter implements EthAdapter {
     if (!contractAddress) {
       throw new Error('Invalid SafeProxy contract address')
     }
-    const signerOrProvider = this.#signer || this.#provider
     return getSafeContractInstance(
       safeVersion,
       contractAddress,
-      signerOrProvider,
       this,
       customContractAbi,
       isL1SafeSingleton

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/SafeContractEthers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/SafeContractEthers.ts
@@ -3,7 +3,6 @@ import {
   EthersTransactionResult
 } from '@safe-global/protocol-kit/adapters/ethers/types'
 import { toTxResult } from '@safe-global/protocol-kit/adapters/ethers/utils'
-import { Gnosis_safe as Safe_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.0.0/Gnosis_safe'
 import {
   SafeContract,
   SafeSetupConfig,
@@ -12,8 +11,9 @@ import {
   SafeVersion
 } from '@safe-global/safe-core-sdk-types'
 
+// TODO remove class when Typechain is removed
 abstract class SafeContractEthers implements SafeContract {
-  constructor(public contract: Safe_V1_0_0) {}
+  constructor(public contract: any) {}
 
   abstract setup(
     setupConfig: SafeSetupConfig,

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
@@ -1,66 +1,345 @@
+import SafeBaseContractEthers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/SafeBaseContractEthers'
+import EthersAdapter from '@safe-global/protocol-kit/adapters/ethers/EthersAdapter'
 import {
   EthersTransactionOptions,
   EthersTransactionResult
 } from '@safe-global/protocol-kit/adapters/ethers/types'
-import { sameString, toTxResult } from '@safe-global/protocol-kit/adapters/ethers/utils'
-import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/adapters/ethers/utils/constants'
-import { Gnosis_safe as Safe } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.0.0/Gnosis_safe'
-import { SafeSetupConfig } from '@safe-global/safe-core-sdk-types'
-import SafeContractEthers from '../SafeContractEthers'
+import SafeContract_v1_0_0_Contract, {
+  SafeContract_v1_0_0_Abi
+} from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.0.0/SafeContract_v1_0_0'
+import { toTxResult } from '@safe-global/protocol-kit/adapters/ethers/utils'
+import safe_1_0_0_ContractArtifacts from '@safe-global/protocol-kit/contracts/AbiType/assets/Safe/v1.0.0/gnosis_safe'
+import {
+  EncodeSafeFunction,
+  EstimateGasSafeFunction
+} from '@safe-global/protocol-kit/contracts/AbiType/Safe/SafeBaseContract'
+import { sameString } from '@safe-global/protocol-kit/utils'
+import { SafeTransaction, SafeTransactionData, SafeVersion } from '@safe-global/safe-core-sdk-types'
 
-class SafeContract_V1_0_0_Ethers extends SafeContractEthers {
-  constructor(public contract: Safe) {
-    super(contract)
+/**
+ * SafeContract_v1_0_0_Ethers is the implementation specific to the Safe contract version 1.0.0.
+ *
+ * This class specializes in handling interactions with the Safe contract version 1.0.0 using Ethers.js v6.
+ *
+ * @extends SafeBaseContractEthers<SafeContract_v1_0_0_Abi> - Inherits from SafeBaseContractEthers with ABI specific to Safe contract version 1.0.0.
+ * @implements SafeContract_v1_0_0_Contract - Implements the interface specific to Safe contract version 1.0.0.
+ */
+class SafeContract_v1_0_0_Ethers
+  extends SafeBaseContractEthers<SafeContract_v1_0_0_Abi>
+  implements SafeContract_v1_0_0_Contract
+{
+  safeVersion: SafeVersion
+
+  /**
+   * Constructs an instance of SafeContract_v1_0_0_Ethers
+   *
+   * @param chainId - The chain ID where the contract resides.
+   * @param ethersAdapter - An instance of EthersAdapter.
+   * @param isL1SafeSingleton - A flag indicating if the contract is a L1 Safe Singleton.
+   * @param customContractAddress - Optional custom address for the contract. If not provided, the address is derived from the Safe deployments based on the chainId and safeVersion.
+   * @param customContractAbi - Optional custom ABI for the contract. If not provided, the default ABI for version 1.0.0 is used.
+   */
+  constructor(
+    chainId: bigint,
+    ethersAdapter: EthersAdapter,
+    isL1SafeSingleton = false,
+    customContractAddress?: string,
+    customContractAbi?: SafeContract_v1_0_0_Abi
+  ) {
+    const safeVersion = '1.0.0'
+    const defaultAbi = safe_1_0_0_ContractArtifacts.abi
+
+    super(
+      chainId,
+      ethersAdapter,
+      defaultAbi,
+      safeVersion,
+      isL1SafeSingleton,
+      customContractAddress,
+      customContractAbi
+    )
+
+    this.safeVersion = safeVersion
   }
 
-  async setup(
-    setupConfig: SafeSetupConfig,
+  /* ----- Specific v1.0.0 properties -----  */
+  async DOMAIN_SEPARATOR_TYPEHASH(): Promise<[string]> {
+    return [await this.contract.DOMAIN_SEPARATOR_TYPEHASH()]
+  }
+
+  async SENTINEL_MODULES(): Promise<[string]> {
+    return [await this.contract.SENTINEL_MODULES()]
+  }
+
+  async SENTINEL_OWNERS(): Promise<[string]> {
+    return [await this.contract.SENTINEL_OWNERS()]
+  }
+
+  async SAFE_MSG_TYPEHASH(): Promise<[string]> {
+    return [await this.contract.SAFE_MSG_TYPEHASH()]
+  }
+
+  async SAFE_TX_TYPEHASH(): Promise<[string]> {
+    return [await this.contract.SAFE_TX_TYPEHASH()]
+  }
+  /* ----- End of specific v1.0.0 properties -----  */
+
+  async NAME(): Promise<[string]> {
+    return [await this.contract.NAME()]
+  }
+
+  async VERSION(): Promise<[SafeVersion]> {
+    return [await this.contract.VERSION()]
+  }
+
+  async approvedHashes([owner, txHash]: readonly [string, string]): Promise<[bigint]> {
+    return [await this.contract.approvedHashes(owner, txHash)]
+  }
+
+  async domainSeparator(): Promise<[string]> {
+    return [await this.contract.domainSeparator()]
+  }
+
+  async getModules(): Promise<[string[]]> {
+    return [await this.contract.getModules()]
+  }
+
+  async getOwners(): Promise<[string[]]> {
+    return [await this.contract.getOwners()]
+  }
+
+  async getThreshold(): Promise<[bigint]> {
+    return [await this.contract.getThreshold()]
+  }
+
+  async isOwner(args: readonly [address: string]): Promise<[boolean]> {
+    return [await this.contract.isOwner(...args)]
+  }
+
+  async nonce(): Promise<[bigint]> {
+    return [await this.contract.nonce()]
+  }
+
+  async signedMessages(args: readonly [messageHash: string]): Promise<[bigint]> {
+    return [await this.contract.signedMessages(...args)]
+  }
+
+  async getMessageHash(args: readonly [message: string]): Promise<[string]> {
+    return [await this.contract.getMessageHash(...args)]
+  }
+
+  async encodeTransactionData(
+    args: readonly [
+      to: string,
+      value: bigint,
+      data: string,
+      operation: number,
+      safeTxGas: bigint,
+      baseGas: bigint,
+      gasPrice: bigint,
+      gasToken: string,
+      refundReceiver: string,
+      _nonce: bigint
+    ]
+  ): Promise<[string]> {
+    return [await this.contract.encodeTransactionData(...args)]
+  }
+
+  async getTransactionHash(
+    args: readonly [
+      to: string,
+      value: bigint,
+      data: string,
+      operation: number,
+      safeTxGas: bigint,
+      baseGas: bigint,
+      gasPrice: bigint,
+      gasToken: string,
+      refundReceiver: string,
+      _nonce: bigint
+    ]
+  ): Promise<[string]> {
+    return [await this.contract.getTransactionHash(...args)]
+  }
+
+  encode: EncodeSafeFunction<SafeContract_v1_0_0_Abi> = (functionToEncode, args) => {
+    return this.contract.interface.encodeFunctionData(functionToEncode, args)
+  }
+
+  estimateGas: EstimateGasSafeFunction<SafeContract_v1_0_0_Abi, EthersTransactionOptions> = (
+    functionToEstimate,
+    args,
+    options = {}
+  ) => {
+    return this.contract.getFunction(functionToEstimate).estimateGas(...args, options)
+  }
+
+  // Custom method (not defined in the Safe Contract)
+  async approveHash(
+    hash: string,
     options?: EthersTransactionOptions
   ): Promise<EthersTransactionResult> {
-    const {
-      owners,
-      threshold,
-      to = ZERO_ADDRESS,
-      data = EMPTY_DATA,
-      paymentToken = ZERO_ADDRESS,
-      payment = 0,
-      paymentReceiver = ZERO_ADDRESS
-    } = setupConfig
+    const gasLimit = options?.gasLimit || (await this.estimateGas('approveHash', [hash], options))
+    const txResponse = await this.contract.approveHash(hash, { ...options, gasLimit })
 
-    if (options && !options.gasLimit) {
-      options.gasLimit = await this.estimateGas(
-        'setup',
-        [owners, threshold, to, data, paymentToken, payment, paymentReceiver],
-        {
-          ...options
-        }
-      )
-    }
-    const txResponse = await this.contract.setup(
-      owners,
-      threshold,
-      to,
-      data,
-      paymentToken,
-      payment,
-      paymentReceiver,
-      { ...options }
+    return toTxResult(txResponse, options)
+  }
+
+  // Custom method (not defined in the Safe Contract)
+  getAddress(): Promise<string> {
+    return this.contract.getAddress()
+  }
+
+  // Custom method (not defined in the Safe Contract)
+  async execTransaction(
+    safeTransaction: SafeTransaction,
+    options?: EthersTransactionOptions
+  ): Promise<EthersTransactionResult> {
+    const gasLimit =
+      options?.gasLimit ||
+      (await this.estimateGas(
+        'execTransaction',
+        [
+          safeTransaction.data.to,
+          BigInt(safeTransaction.data.value),
+          safeTransaction.data.data,
+          safeTransaction.data.operation,
+          BigInt(safeTransaction.data.safeTxGas),
+          BigInt(safeTransaction.data.baseGas),
+          BigInt(safeTransaction.data.gasPrice),
+          safeTransaction.data.gasToken,
+          safeTransaction.data.refundReceiver,
+          safeTransaction.encodedSignatures()
+        ],
+        options
+      ))
+
+    const txResponse = await this.contract.execTransaction(
+      safeTransaction.data.to,
+      safeTransaction.data.value,
+      safeTransaction.data.data,
+      safeTransaction.data.operation,
+      safeTransaction.data.safeTxGas,
+      safeTransaction.data.baseGas,
+      safeTransaction.data.gasPrice,
+      safeTransaction.data.gasToken,
+      safeTransaction.data.refundReceiver,
+      safeTransaction.encodedSignatures(),
+      { ...options, gasLimit }
     )
 
     return toTxResult(txResponse, options)
   }
 
-  async getModules(): Promise<string[]> {
-    return this.contract.getModules()
-  }
-
+  // Custom method (not defined in the Safe Contract)
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
-    const modules = await this.getModules()
+    const [modules] = await this.getModules()
     const isModuleEnabled = modules.some((enabledModuleAddress: string) =>
       sameString(enabledModuleAddress, moduleAddress)
     )
     return isModuleEnabled
   }
+
+  // Custom method (not defined in the Safe Contract)
+  async isValidTransaction(
+    safeTransaction: SafeTransaction,
+    options: EthersTransactionOptions = {}
+  ): Promise<boolean> {
+    try {
+      const gasLimit =
+        options?.gasLimit ||
+        (await this.estimateGas(
+          'execTransaction',
+          [
+            safeTransaction.data.to,
+            BigInt(safeTransaction.data.value),
+            safeTransaction.data.data,
+            safeTransaction.data.operation,
+            BigInt(safeTransaction.data.safeTxGas),
+            BigInt(safeTransaction.data.baseGas),
+            BigInt(safeTransaction.data.gasPrice),
+            safeTransaction.data.gasToken,
+            safeTransaction.data.refundReceiver,
+            safeTransaction.encodedSignatures()
+          ],
+          options
+        ))
+
+      return await this.contract.execTransaction.staticCall(
+        safeTransaction.data.to,
+        BigInt(safeTransaction.data.value),
+        safeTransaction.data.data,
+        safeTransaction.data.operation,
+        BigInt(safeTransaction.data.safeTxGas),
+        BigInt(safeTransaction.data.baseGas),
+        BigInt(safeTransaction.data.gasPrice),
+        safeTransaction.data.gasToken,
+        safeTransaction.data.refundReceiver,
+        safeTransaction.encodedSignatures(),
+        { ...options, gasLimit }
+      )
+    } catch (error) {
+      return false
+    }
+  }
+
+  // TODO: Remove this mapper after remove Typechain
+  mapToTypechainContract(): any {
+    return {
+      contract: this.contract,
+
+      setup: (): any => {
+        // setup function is labelled as `external` on the contract code, but not present on type SafeContract_v1_0_0_Contract
+        return
+      },
+
+      getModules: async () => (await this.getModules())[0],
+
+      isModuleEnabled: this.isModuleEnabled.bind(this),
+
+      getVersion: async () => (await this.VERSION())[0],
+
+      getAddress: this.getAddress.bind(this),
+
+      getNonce: async () => Number((await this.nonce())[0]),
+
+      getThreshold: async () => Number((await this.getThreshold())[0]),
+
+      getOwners: async () => (await this.getOwners())[0],
+
+      isOwner: async (address: string) => (await this.isOwner([address]))[0],
+
+      getTransactionHash: async (safeTransactionData: SafeTransactionData) => {
+        return (
+          await this.getTransactionHash([
+            safeTransactionData.to,
+            BigInt(safeTransactionData.value),
+            safeTransactionData.data,
+            safeTransactionData.operation,
+            BigInt(safeTransactionData.safeTxGas),
+            BigInt(safeTransactionData.baseGas),
+            BigInt(safeTransactionData.gasPrice),
+            safeTransactionData.gasToken,
+            safeTransactionData.refundReceiver,
+            BigInt(safeTransactionData.nonce)
+          ])
+        )[0]
+      },
+
+      approvedHashes: async (ownerAddress: string, hash: string) =>
+        (await this.approvedHashes([ownerAddress, hash]))[0],
+
+      approveHash: this.approveHash.bind(this),
+
+      isValidTransaction: this.isValidTransaction.bind(this),
+
+      execTransaction: this.execTransaction.bind(this),
+
+      encode: this.encode.bind(this),
+
+      estimateGas: this.estimateGas.bind(this)
+    }
+  }
 }
 
-export default SafeContract_V1_0_0_Ethers
+export default SafeContract_v1_0_0_Ethers

--- a/packages/protocol-kit/src/adapters/ethers/contracts/contractInstancesEthers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/contractInstancesEthers.ts
@@ -1,6 +1,5 @@
 import { AbstractSigner, Provider } from 'ethers'
 import { AbiItem } from 'web3-utils'
-import { Gnosis_safe__factory as SafeSingleton_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.0.0/factories/Gnosis_safe__factory'
 import { Compatibility_fallback_handler__factory as CompatibilityFallbackHandler_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.3.0/factories/Compatibility_fallback_handler__factory'
 import { Create_call__factory as CreateCall_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.3.0/factories/Create_call__factory'
 import { Simulate_tx_accessor__factory as SimulateTxAccessor_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.3.0/factories/Simulate_tx_accessor__factory'
@@ -17,20 +16,21 @@ import MultiSendContract_V1_3_0_Ethers from './MultiSend/v1.3.0/MultiSendContrac
 import MultiSendContract_V1_4_1_Ethers from './MultiSend/v1.4.1/MultiSendContract_V1_4_1_Ethers'
 import MultiSendCallOnlyContract_V1_3_0_Ethers from './MultiSend/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Ethers'
 import MultiSendCallOnlyContract_V1_4_1_Ethers from './MultiSend/v1.4.1/MultiSendCallOnlyContract_V1_4_1_Ethers'
-import SafeContract_V1_0_0_Ethers from './Safe/v1.0.0/SafeContract_V1_0_0_Ethers'
 import SignMessageLibContract_V1_3_0_Ethers from './SignMessageLib/v1.3.0/SignMessageLibContract_V1_3_0_Ethers'
 import SignMessageLibContract_V1_4_1_Ethers from './SignMessageLib/v1.4.1/SignMessageLibContract_V1_4_1_Ethers'
 import SimulateTxAccessorContract_V1_3_0_Ethers from './SimulateTxAccessor/v1.3.0/SimulateTxAccessorContract_V1_3_0_Ethers'
 import SimulateTxAccessorContract_V1_4_1_Ethers from './SimulateTxAccessor/v1.4.1/SimulateTxAccessorContract_V1_4_1_Ethers'
+import SafeContract_v1_0_0_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_v1_0_0_Ethers'
 import SafeContract_v1_1_1_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/v1.1.1/SafeContract_v1_1_1_Ethers'
 import SafeContract_v1_2_0_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/v1.2.0/SafeContract_v1_2_0_Ethers'
 import SafeContract_v1_3_0_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/v1.3.0/SafeContract_v1_3_0_Ethers'
+import SafeContract_v1_4_1_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/v1.4.1/SafeContract_v1_4_1_Ethers'
 import SafeProxyFactoryContract_v1_0_0_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/SafeProxyFactory/v1.0.0/SafeProxyFactoryContract_v1_0_0_Ethers'
 import SafeProxyFactoryContract_v1_1_1_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/SafeProxyFactory/v1.1.1/SafeProxyFactoryContract_v1_1_1_Ethers'
 import SafeProxyFactoryContract_v1_3_0_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/SafeProxyFactory/v1.3.0/SafeProxyFactoryContract_v1_3_0_Ethers'
 import SafeProxyFactoryContract_v1_4_1_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/SafeProxyFactory/v1.4.1/SafeProxyFactoryContract_v1_4_1_Ethers'
-import SafeContract_v1_4_1_Ethers from '@safe-global/protocol-kit/adapters/ethers/contracts/Safe/v1.4.1/SafeContract_v1_4_1_Ethers'
 import EthersAdapter from '../EthersAdapter'
+import { SafeContract_v1_0_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.0.0/SafeContract_v1_0_0'
 import { SafeContract_v1_1_1_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.1.1/SafeContract_v1_1_1'
 import { SafeContract_v1_2_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.2.0/SafeContract_v1_2_0'
 import { SafeContract_v1_3_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.3.0/SafeContract_v1_3_0'
@@ -50,11 +50,11 @@ import { SafeProxyFactoryContract_v1_4_1_Abi } from '@safe-global/protocol-kit/c
 export async function getSafeContractInstance(
   safeVersion: SafeVersion,
   contractAddress: string,
-  signerOrProvider: AbstractSigner | Provider,
   ethersAdapter: EthersAdapter,
   customContractAbi?: AbiItem | AbiItem[] | undefined,
   isL1SafeSingleton?: boolean
-): Promise<SafeContract_V1_0_0_Ethers> {
+  // TODO <any> return type used until Typechain is removed
+): Promise<any> {
   const chainId = await ethersAdapter.getChainId()
   let safeContract
   switch (safeVersion) {
@@ -100,10 +100,19 @@ export async function getSafeContractInstance(
         // TODO: Remove this unknown after remove Typechain
         customContractAbi as unknown as SafeContract_v1_1_1_Abi
       )
+      // TODO: Remove this mapper after remove typechain
       return safeContract.mapToTypechainContract()
     case '1.0.0':
-      safeContract = SafeSingleton_V1_0_0.connect(contractAddress, signerOrProvider)
-      return new SafeContract_V1_0_0_Ethers(safeContract)
+      safeContract = new SafeContract_v1_0_0_Ethers(
+        chainId,
+        ethersAdapter,
+        isL1SafeSingleton,
+        contractAddress,
+        // TODO: Remove this unknown after remove Typechain
+        customContractAbi as unknown as SafeContract_v1_0_0_Abi
+      )
+      // TODO: Remove this mapper after remove typechain
+      return safeContract.mapToTypechainContract()
     default:
       throw new Error('Invalid Safe version')
   }

--- a/packages/protocol-kit/src/adapters/web3/Web3Adapter.ts
+++ b/packages/protocol-kit/src/adapters/web3/Web3Adapter.ts
@@ -99,13 +99,9 @@ class Web3Adapter implements EthAdapter {
     if (!contractAddress) {
       throw new Error('Invalid SafeProxy contract address')
     }
-    const safeSingletonContract = this.getContract(
-      contractAddress,
-      customContractAbi ?? (singletonDeployment?.abi as AbiItem[])
-    )
+
     return getSafeContractInstance(
       safeVersion,
-      safeSingletonContract,
       contractAddress,
       this,
       customContractAbi,

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/SafeContractWeb3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/SafeContractWeb3.ts
@@ -3,7 +3,6 @@ import {
   Web3TransactionResult
 } from '@safe-global/protocol-kit/adapters/web3/types'
 import { toTxResult } from '@safe-global/protocol-kit/adapters/web3/utils'
-import { Gnosis_safe as Safe_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Gnosis_safe'
 import {
   SafeContract,
   SafeSetupConfig,
@@ -12,8 +11,9 @@ import {
   SafeVersion
 } from '@safe-global/safe-core-sdk-types'
 
+// TODO remove class when Typechain is removed
 abstract class SafeContractWeb3 implements SafeContract {
-  constructor(public contract: Safe_V1_0_0) {}
+  constructor(public contract: any) {}
 
   abstract setup(
     setupConfig: SafeSetupConfig,

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
@@ -1,59 +1,356 @@
+import SafeBaseContractWeb3 from '@safe-global/protocol-kit/adapters/web3/contracts/Safe/SafeBaseContractWeb3'
 import {
+  DeepWriteable,
   Web3TransactionOptions,
   Web3TransactionResult
 } from '@safe-global/protocol-kit/adapters/web3/types'
-import { sameString, toTxResult } from '@safe-global/protocol-kit/adapters/web3/utils'
-import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/adapters/web3/utils/constants'
-import { Gnosis_safe as Safe } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Gnosis_safe'
-import { SafeSetupConfig } from '@safe-global/safe-core-sdk-types'
-import SafeContractWeb3 from '../SafeContractWeb3'
+import { toTxResult } from '@safe-global/protocol-kit/adapters/web3/utils'
+import Web3Adapter from '@safe-global/protocol-kit/adapters/web3/Web3Adapter'
+import safe_1_0_0_ContractArtifacts from '@safe-global/protocol-kit/contracts/AbiType/assets/Safe/v1.0.0/gnosis_safe'
+import {
+  EncodeSafeFunction,
+  EstimateGasSafeFunction
+} from '@safe-global/protocol-kit/contracts/AbiType/Safe/SafeBaseContract'
+import SafeContract_v1_0_0_Contract, {
+  SafeContract_v1_0_0_Abi as SafeContract_v1_0_0_Abi_Readonly
+} from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.0.0/SafeContract_v1_0_0'
+import { sameString } from '@safe-global/protocol-kit/utils'
+import { SafeTransaction, SafeTransactionData, SafeVersion } from '@safe-global/safe-core-sdk-types'
 
-class SafeContract_V1_0_0_Web3 extends SafeContractWeb3 {
-  constructor(public contract: Safe) {
-    super(contract)
+// Remove all nested `readonly` modifiers from the ABI type
+type SafeContract_v1_0_0_Abi = DeepWriteable<SafeContract_v1_0_0_Abi_Readonly>
+
+/**
+ * SafeContract_v1_0_0_Web3 is the implementation specific to the Safe contract version 1.0.0.
+ *
+ * This class specializes in handling interactions with the Safe contract version 1.0.0 using Web3.js.
+ *
+ * @extends SafeBaseContractWeb3<SafeContract_v1_0_0_Abi> - Inherits from SafeBaseContractWeb3 with ABI specific to Safe contract version 1.0.0.
+ * @implements SafeContract_v1_0_0_Contract - Implements the interface specific to Safe contract version 1.0.0.
+ */
+class SafeContract_v1_0_0_Web3
+  extends SafeBaseContractWeb3<DeepWriteable<SafeContract_v1_0_0_Abi>>
+  implements SafeContract_v1_0_0_Contract
+{
+  safeVersion: SafeVersion
+
+  /**
+   * Constructs an instance of SafeContract_v1_0_0_Web3
+   *
+   * @param chainId - The chain ID where the contract resides.
+   * @param web3Adapter - An instance of Web3Adapter.
+   * @param isL1SafeSingleton - A flag indicating if the contract is a L1 Safe Singleton.
+   * @param customContractAddress - Optional custom address for the contract. If not provided, the address is derived from the Safe deployments based on the chainId and safeVersion.
+   * @param customContractAbi - Optional custom ABI for the contract. If not provided, the default ABI for version 1.0.0 is used.
+   */
+  constructor(
+    chainId: bigint,
+    web3Adapter: Web3Adapter,
+    isL1SafeSingleton = false,
+    customContractAddress?: string,
+    customContractAbi?: SafeContract_v1_0_0_Abi_Readonly
+  ) {
+    const safeVersion = '1.0.0'
+    const defaultAbi = safe_1_0_0_ContractArtifacts.abi as DeepWriteable<SafeContract_v1_0_0_Abi>
+
+    super(
+      chainId,
+      web3Adapter,
+      defaultAbi,
+      safeVersion,
+      isL1SafeSingleton,
+      customContractAddress,
+      customContractAbi as DeepWriteable<SafeContract_v1_0_0_Abi>
+    )
+
+    this.safeVersion = safeVersion
   }
 
-  async setup(
-    setupConfig: SafeSetupConfig,
+  /* ----- Specific v1.0.0 properties -----  */
+  async DOMAIN_SEPARATOR_TYPEHASH(): Promise<[string]> {
+    return [await this.contract.methods.DOMAIN_SEPARATOR_TYPEHASH().call()]
+  }
+
+  async SENTINEL_MODULES(): Promise<[string]> {
+    return [await this.contract.methods.SENTINEL_MODULES().call()]
+  }
+
+  async SENTINEL_OWNERS(): Promise<[string]> {
+    return [await this.contract.methods.SENTINEL_OWNERS().call()]
+  }
+
+  async SAFE_MSG_TYPEHASH(): Promise<[string]> {
+    return [await this.contract.methods.SAFE_MSG_TYPEHASH().call()]
+  }
+
+  async SAFE_TX_TYPEHASH(): Promise<[string]> {
+    return [await this.contract.methods.SAFE_TX_TYPEHASH().call()]
+  }
+  /* ----- End of specific v1.0.0 properties -----  */
+
+  async NAME(): Promise<[string]> {
+    return [await this.contract.methods.NAME().call()]
+  }
+
+  async VERSION(): Promise<[SafeVersion]> {
+    return [await this.contract.methods.VERSION().call()]
+  }
+
+  async approvedHashes(args: readonly [owner: string, txHash: string]): Promise<[bigint]> {
+    return [await this.contract.methods.approvedHashes(...args).call()]
+  }
+
+  async domainSeparator(): Promise<[string]> {
+    return [await this.contract.methods.domainSeparator().call()]
+  }
+
+  async getModules(): Promise<[string[]]> {
+    return [await this.contract.methods.getModules().call()]
+  }
+
+  async getOwners(): Promise<readonly [string[]]> {
+    return [await this.contract.methods.getOwners().call()]
+  }
+
+  async getThreshold(): Promise<[bigint]> {
+    return [await this.contract.methods.getThreshold().call()]
+  }
+
+  async isOwner(args: readonly [address: string]): Promise<[boolean]> {
+    return [await this.contract.methods.isOwner(...args).call()]
+  }
+
+  async nonce(): Promise<[bigint]> {
+    return [await this.contract.methods.nonce().call()]
+  }
+
+  async signedMessages(args: readonly [messageHash: string]): Promise<[bigint]> {
+    return [await this.contract.methods.signedMessages(...args).call()]
+  }
+
+  async getMessageHash(args: readonly [message: string]): Promise<[string]> {
+    return [await this.contract.methods.getMessageHash(...args).call()]
+  }
+
+  async encodeTransactionData(
+    args: readonly [
+      to: string,
+      value: bigint,
+      data: string,
+      operation: number,
+      safeTxGas: bigint,
+      baseGas: bigint,
+      gasPrice: bigint,
+      gasToken: string,
+      refundReceiver: string,
+      _nonce: bigint
+    ]
+  ): Promise<[string]> {
+    return [await this.contract.methods.encodeTransactionData(...args).call()]
+  }
+
+  async getTransactionHash(
+    args: readonly [
+      to: string,
+      value: bigint,
+      data: string,
+      operation: number,
+      safeTxGas: bigint,
+      baseGas: bigint,
+      gasPrice: bigint,
+      gasToken: string,
+      refundReceiver: string,
+      _nonce: bigint
+    ]
+  ): Promise<[string]> {
+    return [await this.contract.methods.getTransactionHash(...args).call()]
+  }
+
+  encode: EncodeSafeFunction<SafeContract_v1_0_0_Abi_Readonly> = (functionToEncode, args) => {
+    return this.contract.methods[functionToEncode](...args).encodeABI()
+  }
+
+  estimateGas: EstimateGasSafeFunction<SafeContract_v1_0_0_Abi_Readonly, Web3TransactionOptions> = (
+    functionToEstimate,
+    args,
+    options = {}
+  ) => {
+    return this.contract.methods[functionToEstimate](...args)
+      .estimateGas(options)
+      .then(BigInt)
+  }
+
+  // Custom method (not defined in the Safe Contract)
+  getAddress(): Promise<string> {
+    return Promise.resolve(this.contract.options.address)
+  }
+
+  // Custom method (not defined in the Safe Contract)
+  async execTransaction(
+    safeTransaction: SafeTransaction,
     options?: Web3TransactionOptions
   ): Promise<Web3TransactionResult> {
-    const {
-      owners,
-      threshold,
-      to = ZERO_ADDRESS,
-      data = EMPTY_DATA,
-      paymentToken = ZERO_ADDRESS,
-      payment = 0,
-      paymentReceiver = ZERO_ADDRESS
-    } = setupConfig
-
     if (options && !options.gas) {
-      options.gas = await this.estimateGas(
-        'setup',
-        [owners, threshold, to, data, paymentToken, payment, paymentReceiver],
-        {
-          ...options
-        }
-      )
+      options.gas = (
+        await this.estimateGas(
+          'execTransaction',
+          [
+            safeTransaction.data.to,
+            BigInt(safeTransaction.data.value),
+            safeTransaction.data.data,
+            safeTransaction.data.operation,
+            BigInt(safeTransaction.data.safeTxGas),
+            BigInt(safeTransaction.data.baseGas),
+            BigInt(safeTransaction.data.gasPrice),
+            safeTransaction.data.gasToken,
+            safeTransaction.data.refundReceiver,
+            safeTransaction.encodedSignatures()
+          ],
+          options
+        )
+      ).toString()
     }
     const txResponse = this.contract.methods
-      .setup(owners, threshold, to, data, paymentToken, payment, paymentReceiver)
+      .execTransaction(
+        safeTransaction.data.to,
+        BigInt(safeTransaction.data.value),
+        safeTransaction.data.data,
+        safeTransaction.data.operation,
+        BigInt(safeTransaction.data.safeTxGas),
+        BigInt(safeTransaction.data.baseGas),
+        BigInt(safeTransaction.data.gasPrice),
+        safeTransaction.data.gasToken,
+        safeTransaction.data.refundReceiver,
+        safeTransaction.encodedSignatures()
+      )
       .send(options)
 
     return toTxResult(txResponse, options)
   }
 
-  async getModules(): Promise<string[]> {
-    return this.contract.methods.getModules().call()
-  }
-
+  // Custom method (not defined in the Safe Contract)
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
-    const modules = await this.getModules()
+    const [modules] = await this.getModules()
     const isModuleEnabled = modules.some((enabledModuleAddress: string) =>
       sameString(enabledModuleAddress, moduleAddress)
     )
     return isModuleEnabled
   }
+
+  // Custom method (not defined in the Safe Contract)
+  async isValidTransaction(
+    safeTransaction: SafeTransaction,
+    options?: Web3TransactionOptions
+  ): Promise<boolean> {
+    let isTxValid = false
+    try {
+      if (options && !options.gas) {
+        options.gas = (
+          await this.estimateGas(
+            'execTransaction',
+            [
+              safeTransaction.data.to,
+              BigInt(safeTransaction.data.value),
+              safeTransaction.data.data,
+              safeTransaction.data.operation,
+              BigInt(safeTransaction.data.safeTxGas),
+              BigInt(safeTransaction.data.baseGas),
+              BigInt(safeTransaction.data.gasPrice),
+              safeTransaction.data.gasToken,
+              safeTransaction.data.refundReceiver,
+              safeTransaction.encodedSignatures()
+            ],
+            options
+          )
+        ).toString()
+      }
+      isTxValid = await this.contract.methods
+        .execTransaction(
+          safeTransaction.data.to,
+          BigInt(safeTransaction.data.value),
+          safeTransaction.data.data,
+          safeTransaction.data.operation,
+          BigInt(safeTransaction.data.safeTxGas),
+          BigInt(safeTransaction.data.baseGas),
+          BigInt(safeTransaction.data.gasPrice),
+          safeTransaction.data.gasToken,
+          safeTransaction.data.refundReceiver,
+          safeTransaction.encodedSignatures()
+        )
+        .call(options)
+    } catch {}
+    return isTxValid
+  }
+
+  // Custom method (not defined in the Safe Contract)
+  async approveHash(
+    hash: string,
+    options?: Web3TransactionOptions
+  ): Promise<Web3TransactionResult> {
+    if (options && !options.gas) {
+      options.gas = (await this.estimateGas('approveHash', [hash], { ...options })).toString()
+    }
+    const txResponse = this.contract.methods.approveHash(hash).send(options)
+    return toTxResult(txResponse, options)
+  }
+
+  // TODO: Remove this mapper after remove Typechain
+  mapToTypechainContract(): any {
+    return {
+      contract: this.contract,
+
+      setup: (): any => {
+        // setup function is labelled as `external` on the contract code, but not present on type SafeContract_v1_0_0_Contract
+        return
+      },
+
+      getModules: async () => (await this.getModules())[0],
+
+      isModuleEnabled: this.isModuleEnabled.bind(this),
+
+      getVersion: async () => (await this.VERSION())[0],
+
+      getAddress: this.getAddress.bind(this),
+
+      getNonce: async () => Number((await this.nonce())[0]),
+
+      getThreshold: async () => Number((await this.getThreshold())[0]),
+
+      getOwners: async () => (await this.getOwners())[0],
+
+      isOwner: async (address: string) => (await this.isOwner([address]))[0],
+
+      getTransactionHash: async (safeTransactionData: SafeTransactionData) => {
+        return (
+          await this.getTransactionHash([
+            safeTransactionData.to,
+            BigInt(safeTransactionData.value),
+            safeTransactionData.data,
+            safeTransactionData.operation,
+            BigInt(safeTransactionData.safeTxGas),
+            BigInt(safeTransactionData.baseGas),
+            BigInt(safeTransactionData.gasPrice),
+            safeTransactionData.gasToken,
+            safeTransactionData.refundReceiver,
+            BigInt(safeTransactionData.nonce)
+          ])
+        )[0]
+      },
+
+      approvedHashes: async (ownerAddress: string, hash: string) =>
+        (await this.approvedHashes([ownerAddress, hash]))[0],
+
+      approveHash: this.approveHash.bind(this),
+
+      isValidTransaction: this.isValidTransaction.bind(this),
+
+      execTransaction: this.execTransaction.bind(this),
+
+      encode: this.encode.bind(this),
+
+      estimateGas: this.estimateGas.bind(this)
+    }
+  }
 }
 
-export default SafeContract_V1_0_0_Web3
+export default SafeContract_v1_0_0_Web3

--- a/packages/protocol-kit/src/adapters/web3/contracts/contractInstancesWeb3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/contractInstancesWeb3.ts
@@ -1,4 +1,5 @@
 import { AbiItem } from 'web3-utils'
+import SafeContract_v1_0_0_Web3 from '@safe-global/protocol-kit/adapters/web3/contracts/Safe/v1.0.0/SafeContract_v1_0_0_Web3'
 import SafeContract_v1_1_1_Web3 from '@safe-global/protocol-kit/adapters/web3/contracts/Safe/v1.1.1/SafeContract_v1_1_1_Web3'
 import SafeContract_v1_2_0_Web3 from '@safe-global/protocol-kit/adapters/web3/contracts/Safe/v1.2.0/SafeContract_v1_2_0_Web3'
 import SafeContract_v1_3_0_Web3 from '@safe-global/protocol-kit/adapters/web3/contracts/Safe/v1.3.0/SafeContract_v1_3_0_Web3'
@@ -8,6 +9,7 @@ import SafeProxyFactoryContract_v1_1_1_Web3 from '@safe-global/protocol-kit/adap
 import SafeProxyFactoryContract_v1_3_0_Web3 from '@safe-global/protocol-kit/adapters/web3/contracts/SafeProxyFactory/v1.3.0/SafeProxyFactoryContract_v1_3_0_Web3'
 import SafeProxyFactoryContract_v1_4_1_Web3 from '@safe-global/protocol-kit/adapters/web3/contracts/SafeProxyFactory/v1.4.1/SafeProxyFactoryContract_v1_4_1_Web3'
 import Web3Adapter from '@safe-global/protocol-kit/adapters/web3/Web3Adapter'
+import { SafeContract_v1_0_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.0.0/SafeContract_v1_0_0'
 import { SafeContract_v1_1_1_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.1.1/SafeContract_v1_1_1'
 import { SafeContract_v1_2_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.2.0/SafeContract_v1_2_0'
 import { SafeContract_v1_3_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/Safe/v1.3.0/SafeContract_v1_3_0'
@@ -16,7 +18,6 @@ import { SafeProxyFactoryContract_v1_0_0_Abi } from '@safe-global/protocol-kit/c
 import { SafeProxyFactoryContract_v1_1_1_Abi } from '@safe-global/protocol-kit/contracts/AbiType/SafeProxyFactory/v1.1.1/SafeProxyFactoryContract_v1_1_1'
 import { SafeProxyFactoryContract_v1_3_0_Abi } from '@safe-global/protocol-kit/contracts/AbiType/SafeProxyFactory/v1.3.0/SafeProxyFactoryContract_v1_3_0'
 import { SafeProxyFactoryContract_v1_4_1_Abi } from '@safe-global/protocol-kit/contracts/AbiType/SafeProxyFactory/v1.4.1/SafeProxyFactoryContract_v1_4_1'
-import { Gnosis_safe as SafeSingleton_V1_0_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Gnosis_safe'
 import { Compatibility_fallback_handler as CompatibilityFallbackHandler_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Compatibility_fallback_handler'
 import { Create_call as CreateCall_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Create_call'
 import { Simulate_tx_accessor as SimulateTxAccessor_V1_3_0 } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.3.0/Simulate_tx_accessor'
@@ -33,7 +34,6 @@ import MultiSendContract_V1_3_0_Web3 from './MultiSend/v1.3.0/MultiSendContract_
 import MultiSendContract_V1_4_1_Web3 from './MultiSend/v1.4.1/MultiSendContract_V1_4_1_Web3'
 import MultiSendCallOnlyContract_V1_3_0_Web3 from './MultiSend/v1.3.0/MultiSendCallOnlyContract_V1_3_0_Web3'
 import MultiSendCallOnlyContract_V1_4_1_Web3 from './MultiSend/v1.4.1/MultiSendCallOnlyContract_V1_4_1_Web3'
-import SafeContract_V1_0_0_Web3 from './Safe/v1.0.0/SafeContract_V1_0_0_Web3'
 import SignMessageLibContract_v1_3_0_Web3 from './SignMessageLib/v1.3.0/SignMessageLibContract_V1_3_0_Web3'
 import SignMessageLibContract_v1_4_1_Web3 from './SignMessageLib/v1.4.1/SignMessageLibContract_V1_4_1_Web3'
 import SimulateTxAccessorContract_V1_3_0_Web3 from './SimulateTxAccessor/v1.3.0/SimulateTxAccessorContract_V1_3_0_Web3'
@@ -59,12 +59,12 @@ type SignMessageLibContract_v1_4_1_Abi = DeepWriteable<SignMessageLibContract_v1
 
 export async function getSafeContractInstance(
   safeVersion: SafeVersion,
-  safeSingletonContract: SafeSingleton_V1_0_0,
   contractAddress: string,
   web3Adapter: Web3Adapter,
   customContractAbi?: AbiItem | AbiItem[] | undefined,
   isL1SafeSingleton?: boolean
-): Promise<SafeContract_V1_0_0_Web3> {
+  // TODO <any> return type used until Typechain is removed
+): Promise<any> {
   const chainId = await web3Adapter.getChainId()
   let safeContract
   switch (safeVersion) {
@@ -113,7 +113,16 @@ export async function getSafeContractInstance(
       // TODO: Remove this mapper after remove typechain
       return safeContract.mapToTypechainContract()
     case '1.0.0':
-      return new SafeContract_V1_0_0_Web3(safeSingletonContract as SafeSingleton_V1_0_0)
+      safeContract = new SafeContract_v1_0_0_Web3(
+        chainId,
+        web3Adapter,
+        isL1SafeSingleton,
+        contractAddress,
+        // TODO: Remove this unknown after remove Typechain
+        customContractAbi as unknown as SafeContract_v1_0_0_Abi
+      )
+      // TODO: Remove this mapper after remove typechain
+      return safeContract.mapToTypechainContract()
     default:
       throw new Error('Invalid Safe version')
   }

--- a/packages/protocol-kit/src/contracts/AbiType/Safe/v1.0.0/SafeContract_v1_0_0.ts
+++ b/packages/protocol-kit/src/contracts/AbiType/Safe/v1.0.0/SafeContract_v1_0_0.ts
@@ -1,0 +1,39 @@
+import { narrow } from 'abitype'
+import safe_1_0_0_ContractArtifacts from '@safe-global/protocol-kit/contracts/AbiType/assets/Safe/v1.0.0/gnosis_safe'
+import SafeBaseContract, {
+  SafeContractReadFunctions,
+  SafeContractWriteFunctions
+} from '../SafeBaseContract'
+
+const safeContract_v1_0_0_AbiTypes = narrow(safe_1_0_0_ContractArtifacts.abi)
+
+/**
+ * Represents the ABI of the Safe contract version 1.0.0.
+ *
+ * @type {SafeContract_v1_0_0_Abi}
+ */
+export type SafeContract_v1_0_0_Abi = typeof safeContract_v1_0_0_AbiTypes
+
+/**
+ * Extracts the names of read-only functions (view or pure) specific to the Safe contract version 1.0.0.
+ *
+ * @type {Safe_v1_0_0_Read_Functions}
+ */
+export type Safe_v1_0_0_Read_Functions = SafeContractReadFunctions<SafeContract_v1_0_0_Abi>
+
+/**
+ * Extracts the names of write functions (nonpayable or payable) specific to the Safe contract version 1.0.0.
+ *
+ * @type {Safe_v1_0_0_Write_Functions}
+ */
+export type Safe_v1_0_0_Write_Functions = SafeContractWriteFunctions<SafeContract_v1_0_0_Abi>
+
+/**
+ * Represents the contract type for a Safe contract version 1.0.0, defining read and write methods.
+ * Utilizes the generic SafeBaseContract with the ABI specific to version 1.0.0.
+ *
+ * @type {SafeContract_v1_0_0_Contract}
+ */
+type SafeContract_v1_0_0_Contract = SafeBaseContract<SafeContract_v1_0_0_Abi>
+
+export default SafeContract_v1_0_0_Contract

--- a/packages/protocol-kit/src/contracts/AbiType/assets/Safe/v1.0.0/gnosis_safe.ts
+++ b/packages/protocol-kit/src/contracts/AbiType/assets/Safe/v1.0.0/gnosis_safe.ts
@@ -1,0 +1,418 @@
+// Source: https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.0.0/gnosis_safe.json
+export default {
+  defaultAddress: '0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A',
+  released: true,
+  contractName: 'GnosisSafe',
+  version: '1.0.0',
+  networkAddresses: {
+    '1': '0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A',
+    '4': '0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A',
+    '5': '0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A',
+    '42': '0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A',
+    '100': '0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A'
+  },
+  abi: [
+    {
+      constant: false,
+      inputs: [
+        { name: 'owner', type: 'address' },
+        { name: '_threshold', type: 'uint256' }
+      ],
+      name: 'addOwnerWithThreshold',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'DOMAIN_SEPARATOR_TYPEHASH',
+      outputs: [{ name: '', type: 'bytes32' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [{ name: 'owner', type: 'address' }],
+      name: 'isOwner',
+      outputs: [{ name: '', type: 'bool' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'operation', type: 'uint8' }
+      ],
+      name: 'execTransactionFromModule',
+      outputs: [{ name: 'success', type: 'bool' }],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [{ name: '', type: 'bytes32' }],
+      name: 'signedMessages',
+      outputs: [{ name: '', type: 'uint256' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [{ name: 'module', type: 'address' }],
+      name: 'enableModule',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [{ name: '_threshold', type: 'uint256' }],
+      name: 'changeThreshold',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [
+        { name: '', type: 'address' },
+        { name: '', type: 'bytes32' }
+      ],
+      name: 'approvedHashes',
+      outputs: [{ name: '', type: 'uint256' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [{ name: '_masterCopy', type: 'address' }],
+      name: 'changeMasterCopy',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'SENTINEL_MODULES',
+      outputs: [{ name: '', type: 'address' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'SENTINEL_OWNERS',
+      outputs: [{ name: '', type: 'address' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'getOwners',
+      outputs: [{ name: '', type: 'address[]' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'NAME',
+      outputs: [{ name: '', type: 'string' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'nonce',
+      outputs: [{ name: '', type: 'uint256' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'getModules',
+      outputs: [{ name: '', type: 'address[]' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'SAFE_MSG_TYPEHASH',
+      outputs: [{ name: '', type: 'bytes32' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'SAFE_TX_TYPEHASH',
+      outputs: [{ name: '', type: 'bytes32' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: 'prevModule', type: 'address' },
+        { name: 'module', type: 'address' }
+      ],
+      name: 'disableModule',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: 'prevOwner', type: 'address' },
+        { name: 'oldOwner', type: 'address' },
+        { name: 'newOwner', type: 'address' }
+      ],
+      name: 'swapOwner',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'getThreshold',
+      outputs: [{ name: '', type: 'uint256' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'domainSeparator',
+      outputs: [{ name: '', type: 'bytes32' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: 'prevOwner', type: 'address' },
+        { name: 'owner', type: 'address' },
+        { name: '_threshold', type: 'uint256' }
+      ],
+      name: 'removeOwner',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'VERSION',
+      outputs: [{ name: '', type: 'string' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    { payable: true, stateMutability: 'payable', type: 'fallback' },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'txHash', type: 'bytes32' }],
+      name: 'ExecutionFailed',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'owner', type: 'address' }],
+      name: 'AddedOwner',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'owner', type: 'address' }],
+      name: 'RemovedOwner',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'threshold', type: 'uint256' }],
+      name: 'ChangedThreshold',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'module', type: 'address' }],
+      name: 'EnabledModule',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'module', type: 'address' }],
+      name: 'DisabledModule',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [{ indexed: false, name: 'newContract', type: 'address' }],
+      name: 'ContractCreation',
+      type: 'event'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: '_owners', type: 'address[]' },
+        { name: '_threshold', type: 'uint256' },
+        { name: 'to', type: 'address' },
+        { name: 'data', type: 'bytes' },
+        { name: 'paymentToken', type: 'address' },
+        { name: 'payment', type: 'uint256' },
+        { name: 'paymentReceiver', type: 'address' }
+      ],
+      name: 'setup',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'operation', type: 'uint8' },
+        { name: 'safeTxGas', type: 'uint256' },
+        { name: 'baseGas', type: 'uint256' },
+        { name: 'gasPrice', type: 'uint256' },
+        { name: 'gasToken', type: 'address' },
+        { name: 'refundReceiver', type: 'address' },
+        { name: 'signatures', type: 'bytes' }
+      ],
+      name: 'execTransaction',
+      outputs: [{ name: 'success', type: 'bool' }],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'operation', type: 'uint8' }
+      ],
+      name: 'requiredTxGas',
+      outputs: [{ name: '', type: 'uint256' }],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [{ name: 'hashToApprove', type: 'bytes32' }],
+      name: 'approveHash',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [{ name: '_data', type: 'bytes' }],
+      name: 'signMessage',
+      outputs: [],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: false,
+      inputs: [
+        { name: '_data', type: 'bytes' },
+        { name: '_signature', type: 'bytes' }
+      ],
+      name: 'isValidSignature',
+      outputs: [{ name: '', type: 'bytes4' }],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [{ name: 'message', type: 'bytes' }],
+      name: 'getMessageHash',
+      outputs: [{ name: '', type: 'bytes32' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'operation', type: 'uint8' },
+        { name: 'safeTxGas', type: 'uint256' },
+        { name: 'baseGas', type: 'uint256' },
+        { name: 'gasPrice', type: 'uint256' },
+        { name: 'gasToken', type: 'address' },
+        { name: 'refundReceiver', type: 'address' },
+        { name: '_nonce', type: 'uint256' }
+      ],
+      name: 'encodeTransactionData',
+      outputs: [{ name: '', type: 'bytes' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'data', type: 'bytes' },
+        { name: 'operation', type: 'uint8' },
+        { name: 'safeTxGas', type: 'uint256' },
+        { name: 'baseGas', type: 'uint256' },
+        { name: 'gasPrice', type: 'uint256' },
+        { name: 'gasToken', type: 'address' },
+        { name: 'refundReceiver', type: 'address' },
+        { name: '_nonce', type: 'uint256' }
+      ],
+      name: 'getTransactionHash',
+      outputs: [{ name: '', type: 'bytes32' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    }
+  ]
+} as const

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,10 +2689,10 @@ abitype@^0.1.6:
   resolved "https://registry.npmjs.org/abitype/-/abitype-0.1.8.tgz"
   integrity sha512-2pde0KepTzdfu19ZrzYTYVIWo69+6UbBCY4B1RDiwWgo2XZtFSJhF6C+XThuRXbbZ823J0Rw1Y5cP0NXYVcCdQ==
 
-abitype@^0.10.2:
-  version "0.10.2"
-  resolved "https://registry.npmjs.org/abitype/-/abitype-0.10.2.tgz"
-  integrity sha512-1XndI+RKFWK4+TXCNv1683MRyX5NGmlHXCvqzjOqhSS3PQrxT2QYRZq1bMPPRNjn89B3eVaM2w7y3jVj/OIUzA==
+abitype@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.10.3.tgz#27ce7a7cdb9a80ccd732a3f3cf1ce6ff05266fce"
+  integrity sha512-tRN+7XIa7J9xugdbRzFv/95ka5ivR/sRe01eiWvM0HWWjHuigSZEACgKa0sj4wGuekTDtghCx+5Izk/cOi78pQ==
 
 abort-controller@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What it solves
Migrates Safe contract 1.0.0 with ethers + web3.js adapter from Typechain to Abitype.

## How this PR fixes it
In correspondance to the previous PR #604.