### PR TITLE
check if the Safe Account is 4337 compatible

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -148,6 +148,33 @@ export class Safe4337Pack extends RelayKitBasePack<{
         ethAdapter: ethersAdapter,
         safeAddress: options.safeAddress
       })
+
+      const safeVersion = await protocolKit.getContractVersion()
+      const isSafeVersion4337Compatible = safeVersion === DEFAULT_SAFE_VERSION
+
+      if (!isSafeVersion4337Compatible) {
+        throw new Error(
+          `Incompatibility detected: The current Safe Account version (${safeVersion}) is not supported. EIP-4337 requires version ${DEFAULT_SAFE_VERSION}.`
+        )
+      }
+
+      const safeModules = (await protocolKit.getModules()) as string[]
+      const is4337ModulePresent = safeModules.some((module) => module === safe4337ModuleAddress)
+
+      if (!is4337ModulePresent) {
+        throw new Error(
+          `Incompatibility detected: The EIP-4337 module is not attached to the Safe Account. Attach this module (address: ${safe4337ModuleAddress}) to ensure compatibility.`
+        )
+      }
+
+      const safeFallbackhandler = await protocolKit.getFallbackHandler()
+      const is433FallbackhandlerPresent = safeFallbackhandler === safe4337ModuleAddress
+
+      if (!is433FallbackhandlerPresent) {
+        throw new Error(
+          `Incompatibility detected: The EIP-4337 fallbackhandler is not attached to the Safe Account. Attach this fallbackhandler (address: ${safe4337ModuleAddress}) to ensure compatibility.`
+        )
+      }
     } else {
       // New Safe will be created based on the provided configuration when bundling a new UserOperation
       if (!options.owners || !options.threshold) {

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -164,7 +164,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
       if (!is4337ModulePresent) {
         throw new Error(
-          `Incompatibility detected: The EIP-4337 module is not attached to the Safe Account. Attach this module (address: ${safe4337ModuleAddress}) to ensure compatibility.`
+          `Incompatibility detected: The EIP-4337 module is not enabled in the provided Safe Account. Enable this module (address: ${safe4337ModuleAddress}) to add compatibility.`
         )
       }
 

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -169,9 +169,9 @@ export class Safe4337Pack extends RelayKitBasePack<{
       }
 
       const safeFallbackhandler = await protocolKit.getFallbackHandler()
-      const is433FallbackhandlerPresent = safeFallbackhandler === safe4337ModuleAddress
+      const is4337FallbackhandlerPresent = safeFallbackhandler === safe4337ModuleAddress
 
-      if (!is433FallbackhandlerPresent) {
+      if (!is4337FallbackhandlerPresent) {
         throw new Error(
           `Incompatibility detected: The EIP-4337 fallbackhandler is not attached to the Safe Account. Attach this fallbackhandler (address: ${safe4337ModuleAddress}) to ensure compatibility.`
         )

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+import semverSatisfies from 'semver/functions/satisfies'
 import Safe, {
   EthSafeSignature,
   EthersAdapter,
@@ -150,7 +151,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
       })
 
       const safeVersion = await protocolKit.getContractVersion()
-      const isSafeVersion4337Compatible = safeVersion === DEFAULT_SAFE_VERSION
+      const isSafeVersion4337Compatible = semverSatisfies(safeVersion, '>=1.4.1')
 
       if (!isSafeVersion4337Compatible) {
         throw new Error(

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -155,7 +155,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
       if (!isSafeVersion4337Compatible) {
         throw new Error(
-          `Incompatibility detected: The current Safe Account version (${safeVersion}) is not supported. EIP-4337 requires version ${DEFAULT_SAFE_VERSION}.`
+          `Incompatibility detected: The current Safe Account version (${safeVersion}) is not supported. EIP-4337 requires the Safe to use at least v1.4.1.`
         )
       }
 

--- a/playground/relay-kit/usdc-transfer-4337-counterfactual.ts
+++ b/playground/relay-kit/usdc-transfer-4337-counterfactual.ts
@@ -8,7 +8,7 @@ const PRIVATE_KEY = ''
 const PIMLICO_API_KEY = ''
 
 // RPC URL
-const RPC_URL = 'https://eth-sepolia.public.blastapi.io' // SEPOLIA
+const RPC_URL = 'https://rpc.ankr.com/eth_sepolia' // SEPOLIA
 // const RPC_URL = 'https://rpc.gnosischain.com/' // GNOSIS
 
 // CHAIN

--- a/playground/relay-kit/usdc-transfer-4337-erc20-counterfactual.ts
+++ b/playground/relay-kit/usdc-transfer-4337-erc20-counterfactual.ts
@@ -12,7 +12,7 @@ const CHAIN_NAME = 'sepolia'
 // const CHAIN_NAME = 'gnosis'
 
 // RPC URL
-const RPC_URL = 'https://eth-sepolia.public.blastapi.io' // SEPOLIA
+const RPC_URL = 'https://rpc.ankr.com/eth_sepolia' // SEPOLIA
 // const RPC_URL = 'https://rpc.gnosischain.com/' // GNOSIS
 
 // Bundler URL

--- a/playground/relay-kit/usdc-transfer-4337-erc20.ts
+++ b/playground/relay-kit/usdc-transfer-4337-erc20.ts
@@ -15,7 +15,7 @@ const CHAIN_NAME = 'sepolia'
 // const CHAIN_NAME = 'gnosis'
 
 // RPC URL
-const RPC_URL = 'https://eth-sepolia.public.blastapi.io' // SEPOLIA
+const RPC_URL = 'https://rpc.ankr.com/eth_sepolia' // SEPOLIA
 // const RPC_URL = 'https://rpc.gnosischain.com/' // GNOSIS
 
 // Bundler URL

--- a/playground/relay-kit/usdc-transfer-4337-sponsored-counterfactual.ts
+++ b/playground/relay-kit/usdc-transfer-4337-sponsored-counterfactual.ts
@@ -15,13 +15,13 @@ const CHAIN_NAME = 'sepolia'
 // const CHAIN_NAME = 'gnosis'
 
 // RPC URL
-const RPC_URL = 'https://eth-sepolia.public.blastapi.io' // SEPOLIA
+const RPC_URL = 'https://rpc.ankr.com/eth_sepolia' // SEPOLIA
 // const RPC_URL = 'https://rpc.gnosischain.com/' // GNOSIS
 
 // Bundler URL
 const BUNDLER_URL = `https://api.pimlico.io/v1/${CHAIN_NAME}/rpc?apikey=${PIMLICO_API_KEY}` // PIMLICO
 
-// Bundler URL
+// Paymaster URL
 const PAYMASTER_URL = `https://api.pimlico.io/v2/${CHAIN_NAME}/rpc?apikey=${PIMLICO_API_KEY}` // PIMLICO
 
 // PAYMASTER ADDRESS

--- a/playground/relay-kit/usdc-transfer-4337-sponsored.ts
+++ b/playground/relay-kit/usdc-transfer-4337-sponsored.ts
@@ -18,13 +18,13 @@ const CHAIN_NAME = 'sepolia'
 // const CHAIN_NAME = 'gnosis'
 
 // RPC URL
-const RPC_URL = 'https://eth-sepolia.public.blastapi.io' // SEPOLIA
+const RPC_URL = 'https://rpc.ankr.com/eth_sepolia' // SEPOLIA
 // const RPC_URL = 'https://rpc.gnosischain.com/' // GNOSIS
 
 // Bundler URL
 const BUNDLER_URL = `https://api.pimlico.io/v1/${CHAIN_NAME}/rpc?apikey=${PIMLICO_API_KEY}` // PIMLICO
 
-// Bundler URL
+// Paymaster URL
 const PAYMASTER_URL = `https://api.pimlico.io/v2/${CHAIN_NAME}/rpc?apikey=${PIMLICO_API_KEY}` // PIMLICO
 
 // PAYMASTER ADDRESS

--- a/playground/relay-kit/usdc-transfer-4337.ts
+++ b/playground/relay-kit/usdc-transfer-4337.ts
@@ -14,7 +14,7 @@ const SAFE_ADDRESS = ''
 const BUNDLER_URL = `https://api.pimlico.io/v1/sepolia/rpc?apikey=${PIMLICO_API_KEY}` // PIMLICO
 
 // RPC URL
-const RPC_URL = 'https://eth-sepolia.public.blastapi.io'
+const RPC_URL = 'https://rpc.ankr.com/eth_sepolia'
 
 // USDC CONTRACT ADDRESS IN SEPOLIA
 // faucet: https://faucet.circle.com/


### PR DESCRIPTION
## What it solves
Resolves #720 

## How this PR fixes it

- The Safe uses v1.4.1 version.
- Safe has the 4337 module enabled.
- Safe has the 4337 fallback handler enabled.


## How to test this PR 

```typescript
  // 1) Initialize pack with the Safe Address
  const safe4337Pack = await Safe4337Pack.init({
    ethersAdapter,
    rpcUrl: RPC_URL,
    bundlerUrl: BUNDLER_URL,
    options: {
      safeAddress
    }
  })

```

You can use this Safes in `Sepolia` to test this checks:

- [`0x9534Bc54EB95975DaF2Dbc74ff945f0DB9810043`](https://app.safe.global/settings/setup?safe=sep:0x9534Bc54EB95975DaF2Dbc74ff945f0DB9810043): Safe with `1.3.0` version, this version is not compatible with 4337.
- [`0xfC82a1e4A045a44527e8b45FC70332C8F66fc32B`](https://app.safe.global/settings/setup?safe=sep:0xfC82a1e4A045a44527e8b45FC70332C8F66fc32B): Safe with `1.4.1` version but no 4337 Module attached.
- [`0xA6FDc4e18404E1715D1bC51B07266c91393C6622`](https://app.safe.global/settings/modules?safe=sep:0xA6FDc4e18404E1715D1bC51B07266c91393C6622): Safe with `1.4.1` version and 4337 Module attached but no 4337 fallback handler attached.
- [`0xB4510553D7ecD3F2A3170ce2cD16A21853D07b9C`](https://app.safe.global/settings/setup?safe=sep:0xB4510553D7ecD3F2A3170ce2cD16A21853D07b9C): Safe 4337 Compatible (`1.4.1` version, 4337 Module and 4337 fallback handler attached)





