### PR TITLE
Fix: migrate api kit tests to sepolia

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: germartinez,rmeissner,Uxio0,dasanra,luarx,DaniSomoza,yagopv,JagoFigueroa,bot*
+          allowlist: germartinez,rmeissner,Uxio0,dasanra,luarx,DaniSomoza,yagopv,JagoFigueroa,leonardotc,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: germartinez,rmeissner,Uxio0,dasanra,luarx,DaniSomoza,yagopv,JagoFigueroa,leonardotc,bot*
+          allowlist: germartinez,rmeissner,Uxio0,dasanra,luarx,DaniSomoza,yagopv,JagoFigueroa,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/packages/api-kit/tests/e2e/addMessage.test.ts
+++ b/packages/api-kit/tests/e2e/addMessage.test.ts
@@ -20,12 +20,12 @@ const generateRandomUUID = (): string => {
 }
 
 const generateMessage = () => `${generateRandomUUID()}: I am the owner of the safe`
-const safeAddress = '0x3296b3DD454B7c3912F7F477787B503918C50082'
+const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
 
 describe('addMessage', () => {
   before(async () => {
     ;({ safeApiKit, ethAdapter } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
 
     protocolKit = await Safe.create({

--- a/packages/api-kit/tests/e2e/addMessageSignature.test.ts
+++ b/packages/api-kit/tests/e2e/addMessageSignature.test.ts
@@ -27,17 +27,16 @@ const generateRandomUUID = (): string => {
 }
 
 const generateMessage = () => `${generateRandomUUID()}: I am the owner of the safe`
-const safeAddress = '0x3296b3DD454B7c3912F7F477787B503918C50082'
-const signerSafeAddress = '0x83aB93f078A8fbbe6a677b1C488819e0ae981128'
+const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
+const signerSafeAddress = '0xDa8dd250065F19f7A29564396D7F13230b9fC5A3'
 
 describe('addMessageSignature', () => {
   before(async () => {
     ;({ safeApiKit: safeApiKit1, ethAdapter: ethAdapter1 } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
-      'https://safe-transaction-goerli.staging.5afe.dev/api'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
     ;({ ethAdapter: ethAdapter2 } = await getServiceClient(
-      '0x6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1'
+      '0xb88ad5789871315d0dab6fc5961d6714f24f35a6393f13a6f426dfecfc00ab44'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/addSafeDelegate.test.ts
+++ b/packages/api-kit/tests/e2e/addSafeDelegate.test.ts
@@ -13,12 +13,12 @@ let signer: Signer
 describe('addSafeDelegate', () => {
   before(async () => {
     ;({ safeApiKit, signer } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
   it('should fail if Label is empty', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       delegateAddress,
@@ -46,7 +46,7 @@ describe('addSafeDelegate', () => {
   })
 
   it('should fail if Safe delegator address is empty', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = ''
     const delegateConfig: AddSafeDelegateProps = {
       delegateAddress,
@@ -60,8 +60,8 @@ describe('addSafeDelegate', () => {
   })
 
   it('should fail if Safe address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'.toLowerCase()
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'.toLowerCase()
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       safeAddress,
@@ -76,8 +76,8 @@ describe('addSafeDelegate', () => {
   })
 
   it('should fail if Safe delegate address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'.toLowerCase()
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'.toLowerCase()
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       safeAddress,
@@ -92,8 +92,8 @@ describe('addSafeDelegate', () => {
   })
 
   it('should fail if Safe delegator address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = (await signer.getAddress()).toLowerCase()
     const delegateConfig: AddSafeDelegateProps = {
       safeAddress,
@@ -109,7 +109,7 @@ describe('addSafeDelegate', () => {
 
   it('should fail if Safe does not exist', async () => {
     const safeAddress = '0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e'
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       safeAddress,
@@ -127,8 +127,8 @@ describe('addSafeDelegate', () => {
     const { safeApiKit, signer } = await getServiceClient(
       '0xb0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773'
     )
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       safeAddress,
@@ -145,8 +145,8 @@ describe('addSafeDelegate', () => {
   })
 
   it('should add a new delegate', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       safeAddress,
@@ -169,7 +169,7 @@ describe('addSafeDelegate', () => {
   })
 
   it('should add a new delegate without specifying a Safe', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: AddSafeDelegateProps = {
       delegateAddress,
@@ -196,9 +196,9 @@ describe('addSafeDelegate', () => {
   })
 
   it('should add a new delegate EIP-3770', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const eip3770DelegateAddress = `${config.EIP_3770_PREFIX}:${delegateAddress}`
     const delegatorAddress = await signer.getAddress()
     const eip3770DelegatorAddress = `${config.EIP_3770_PREFIX}:${delegatorAddress}`

--- a/packages/api-kit/tests/e2e/confirmTransaction.test.ts
+++ b/packages/api-kit/tests/e2e/confirmTransaction.test.ts
@@ -17,18 +17,16 @@ let protocolKit: Safe
 let ethAdapter1: EthAdapter
 let ethAdapter2: EthAdapter
 
-const safeAddress = '0x3296b3DD454B7c3912F7F477787B503918C50082'
-const signerSafeAddress = '0x83aB93f078A8fbbe6a677b1C488819e0ae981128'
+const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
+const signerSafeAddress = '0xDa8dd250065F19f7A29564396D7F13230b9fC5A3'
 
 describe('proposeTransaction', () => {
   before(async () => {
     ;({ safeApiKit: safeApiKit1, ethAdapter: ethAdapter1 } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
-      'https://safe-transaction-goerli.staging.5afe.dev/api'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
     ;({ ethAdapter: ethAdapter2 } = await getServiceClient(
-      '0x6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1',
-      'https://safe-transaction-goerli.staging.5afe.dev/api'
+      '0xb88ad5789871315d0dab6fc5961d6714f24f35a6393f13a6f426dfecfc00ab44'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/decodeData.test.ts
+++ b/packages/api-kit/tests/e2e/decodeData.test.ts
@@ -10,7 +10,7 @@ let safeApiKit: SafeApiKit
 describe('decodeData', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getIncomingTransactions.test.ts
+++ b/packages/api-kit/tests/e2e/getIncomingTransactions.test.ts
@@ -11,7 +11,7 @@ let safeApiKit: SafeApiKit
 describe('getIncomingTransactions', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -23,7 +23,7 @@ describe('getIncomingTransactions', () => {
   })
 
   it('should fail if Safe address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'.toLowerCase()
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'.toLowerCase()
     await chai
       .expect(safeApiKit.getIncomingTransactions(safeAddress))
       .to.be.rejectedWith('Checksum address validation failed')
@@ -37,21 +37,21 @@ describe('getIncomingTransactions', () => {
   })
 
   it('should return the list of incoming transactions', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205' // Safe with incoming transactions
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78' // Safe with incoming transactions
     const transferListResponse = await safeApiKit.getIncomingTransactions(safeAddress)
-    chai.expect(transferListResponse.count).to.be.equal(5)
-    chai.expect(transferListResponse.results.length).to.be.equal(5)
+    chai.expect(transferListResponse.count).to.be.equal(6)
+    chai.expect(transferListResponse.results.length).to.be.equal(6)
     transferListResponse.results.map((transaction) => {
       chai.expect(transaction.to).to.be.equal(safeAddress)
     })
   })
 
   it('should return the list of incoming transactions EIP-3770', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205' // Safe with incoming transactions
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78' // Safe with incoming transactions
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
     const transferListResponse = await safeApiKit.getIncomingTransactions(eip3770SafeAddress)
-    chai.expect(transferListResponse.count).to.be.equal(5)
-    chai.expect(transferListResponse.results.length).to.be.equal(5)
+    chai.expect(transferListResponse.count).to.be.equal(6)
+    chai.expect(transferListResponse.results.length).to.be.equal(6)
     transferListResponse.results.map((transaction) => {
       chai.expect(transaction.to).to.be.equal(safeAddress)
     })

--- a/packages/api-kit/tests/e2e/getMessage.test.ts
+++ b/packages/api-kit/tests/e2e/getMessage.test.ts
@@ -6,12 +6,12 @@ import { getServiceClient } from '../utils/setupServiceClient'
 chai.use(chaiAsPromised)
 
 let safeApiKit: SafeApiKit
-const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
 
 describe('getMessages', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getMessages.test.ts
+++ b/packages/api-kit/tests/e2e/getMessages.test.ts
@@ -6,12 +6,12 @@ import { getServiceClient } from '../utils/setupServiceClient'
 chai.use(chaiAsPromised)
 
 let safeApiKit: SafeApiKit
-const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
 
 describe('getMessages', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getMultisigTransactions.test.ts
+++ b/packages/api-kit/tests/e2e/getMultisigTransactions.test.ts
@@ -11,7 +11,7 @@ let safeApiKit: SafeApiKit
 describe('getMultisigTransactions', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -23,7 +23,7 @@ describe('getMultisigTransactions', () => {
   })
 
   it('should fail if Safe address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'.toLowerCase()
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'.toLowerCase()
     await chai
       .expect(safeApiKit.getMultisigTransactions(safeAddress))
       .to.be.rejectedWith('Checksum address validation failed')
@@ -38,23 +38,23 @@ describe('getMultisigTransactions', () => {
   })
 
   it('should return the list of multisig transactions', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205' // Safe with multisig transactions
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78' // Safe with multisig transactions
     const safeMultisigTransactionListResponse =
       await safeApiKit.getMultisigTransactions(safeAddress)
-    chai.expect(safeMultisigTransactionListResponse.count).to.be.equal(12)
-    chai.expect(safeMultisigTransactionListResponse.results.length).to.be.equal(12)
+    chai.expect(safeMultisigTransactionListResponse.count).to.be.equal(18)
+    chai.expect(safeMultisigTransactionListResponse.results.length).to.be.equal(18)
     safeMultisigTransactionListResponse.results.map((transaction) => {
       chai.expect(transaction.safe).to.be.equal(safeAddress)
     })
   })
 
   it('should return the list of multisig transactions EIP-3770', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205' // Safe with multisig transactions
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78' // Safe with multisig transactions
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
     const safeMultisigTransactionListResponse =
       await safeApiKit.getMultisigTransactions(eip3770SafeAddress)
-    chai.expect(safeMultisigTransactionListResponse.count).to.be.equal(12)
-    chai.expect(safeMultisigTransactionListResponse.results.length).to.be.equal(12)
+    chai.expect(safeMultisigTransactionListResponse.count).to.be.equal(18)
+    chai.expect(safeMultisigTransactionListResponse.results.length).to.be.equal(18)
     safeMultisigTransactionListResponse.results.map((transaction) => {
       chai.expect(transaction.safe).to.be.equal(safeAddress)
     })

--- a/packages/api-kit/tests/e2e/getNextNonce.test.ts
+++ b/packages/api-kit/tests/e2e/getNextNonce.test.ts
@@ -10,7 +10,7 @@ let safeApiKit: SafeApiKit
 describe('getNextNonce', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -22,20 +22,20 @@ describe('getNextNonce', () => {
   })
 
   it('should return the next Safe nonce when there are pending transactions', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const nextNonce = await safeApiKit.getNextNonce(safeAddress)
-    chai.expect(nextNonce).to.be.equal(9)
+    chai.expect(nextNonce).to.be.equal(11)
   })
 
   it('should return the next Safe nonce when there are pending transactions EIP-3770', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
     const nextNonce = await safeApiKit.getNextNonce(eip3770SafeAddress)
-    chai.expect(nextNonce).to.be.equal(9)
+    chai.expect(nextNonce).to.be.equal(11)
   })
 
   it('should return the next Safe nonce when there are no pending transactions', async () => {
-    const safeAddress = '0x72c346260a4887F0231af41178C1c818Ce34543f'
+    const safeAddress = '0xDa8dd250065F19f7A29564396D7F13230b9fC5A3'
     const nextNonce = await safeApiKit.getNextNonce(safeAddress)
     chai.expect(nextNonce).to.be.equal(5)
   })

--- a/packages/api-kit/tests/e2e/getPendingTransactions.test.ts
+++ b/packages/api-kit/tests/e2e/getPendingTransactions.test.ts
@@ -11,7 +11,7 @@ let safeApiKit: SafeApiKit
 describe('getPendingTransactions', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -23,31 +23,31 @@ describe('getPendingTransactions', () => {
   })
 
   it('should fail if safeAddress is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'.toLowerCase()
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'.toLowerCase()
     await chai
       .expect(safeApiKit.getPendingTransactions(safeAddress))
       .to.be.rejectedWith('Checksum address validation failed')
   })
 
   it('should return an empty list if there are no pending transactions', async () => {
-    const safeAddress = '0x72c346260a4887F0231af41178C1c818Ce34543f' // Safe without pending transaction
+    const safeAddress = '0xDa8dd250065F19f7A29564396D7F13230b9fC5A3' // Safe without pending transaction
     const transactionList = await safeApiKit.getPendingTransactions(safeAddress)
     chai.expect(transactionList.count).to.be.equal(0)
     chai.expect(transactionList.results.length).to.be.equal(0)
   })
 
   it('should return the the transaction list', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205' // Safe with pending transaction
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78' // Safe with pending transaction
     const transactionList = await safeApiKit.getPendingTransactions(safeAddress)
-    chai.expect(transactionList.count).to.be.equal(1)
-    chai.expect(transactionList.results.length).to.be.equal(1)
+    chai.expect(transactionList.count).to.be.equal(3)
+    chai.expect(transactionList.results.length).to.be.equal(3)
   })
 
   it('should return the the transaction list EIP-3770', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205' // Safe with pending transaction
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78' // Safe with pending transaction
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
     const transactionList = await safeApiKit.getPendingTransactions(eip3770SafeAddress)
-    chai.expect(transactionList.count).to.be.equal(1)
-    chai.expect(transactionList.results.length).to.be.equal(1)
+    chai.expect(transactionList.count).to.be.equal(3)
+    chai.expect(transactionList.results.length).to.be.equal(3)
   })
 })

--- a/packages/api-kit/tests/e2e/getSafeDelegates.test.ts
+++ b/packages/api-kit/tests/e2e/getSafeDelegates.test.ts
@@ -13,7 +13,7 @@ let signer: Signer
 describe('getSafeDelegates', () => {
   before(async () => {
     ;({ safeApiKit, signer } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -25,7 +25,7 @@ describe('getSafeDelegates', () => {
   })
 
   it('should fail if Safe address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'.toLowerCase()
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'.toLowerCase()
     await chai
       .expect(safeApiKit.getSafeDelegates({ safeAddress }))
       .to.be.rejectedWith('Enter a valid checksummed Ethereum Address')
@@ -39,10 +39,10 @@ describe('getSafeDelegates', () => {
   })
 
   it('should return an array of delegates', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig1: DeleteSafeDelegateProps = {
-      delegateAddress: '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0',
+      delegateAddress: '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B',
       delegatorAddress,
       signer
     }
@@ -86,11 +86,11 @@ describe('getSafeDelegates', () => {
   })
 
   it('should return an array of delegates EIP-3770', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
     const delegatorAddress = await signer.getAddress()
     const delegateConfig1: DeleteSafeDelegateProps = {
-      delegateAddress: `${config.EIP_3770_PREFIX}:0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0`,
+      delegateAddress: `${config.EIP_3770_PREFIX}:0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B`,
       delegatorAddress,
       signer
     }
@@ -115,7 +115,7 @@ describe('getSafeDelegates', () => {
     const { results } = safeDelegateListResponse
     const sortedResults = results.sort((a, b) => (a.delegate > b.delegate ? -1 : 1))
     chai.expect(sortedResults.length).to.be.eq(2)
-    chai.expect(sortedResults[0].delegate).to.be.eq('0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0')
+    chai.expect(sortedResults[0].delegate).to.be.eq('0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B')
     chai.expect(sortedResults[0].delegator).to.be.eq(await delegateConfig1.signer.getAddress())
     chai.expect(sortedResults[0].label).to.be.eq('Label1')
     chai.expect(sortedResults[1].delegate).to.be.eq('0x22d491Bde2303f2f43325b2108D26f1eAbA1e32b')

--- a/packages/api-kit/tests/e2e/getSafeInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getSafeInfo.test.ts
@@ -11,7 +11,7 @@ let safeApiKit: SafeApiKit
 describe('getSafeInfo', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -23,14 +23,14 @@ describe('getSafeInfo', () => {
   })
 
   it('should fail if Safe address is not checksummed', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'.toLowerCase()
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'.toLowerCase()
     await chai
       .expect(safeApiKit.getSafeInfo(safeAddress))
       .to.be.rejectedWith('Checksum address validation failed')
   })
 
   it('should return the Safe info if the address is correct', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const safeInfoResponse = await safeApiKit.getSafeInfo(safeAddress)
     chai.expect(safeInfoResponse.address).to.be.equal(safeAddress)
     chai.expect(safeInfoResponse.nonce).to.be.a('number')
@@ -38,7 +38,7 @@ describe('getSafeInfo', () => {
   })
 
   it('should return the Safe info if EIP-3770 address is correct', async () => {
-    const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+    const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
     const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
     const safeInfoResponse = await safeApiKit.getSafeInfo(eip3770SafeAddress)
     chai.expect(safeInfoResponse.address).to.be.equal(safeAddress)

--- a/packages/api-kit/tests/e2e/getSafesByModule.test.ts
+++ b/packages/api-kit/tests/e2e/getSafesByModule.test.ts
@@ -12,7 +12,7 @@ const goerliSpendingLimitModule = '0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134'
 describe('getSafesByModule', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getSafesByOwner.test.ts
+++ b/packages/api-kit/tests/e2e/getSafesByOwner.test.ts
@@ -11,7 +11,7 @@ let safeApiKit: SafeApiKit
 describe('getSafesByOwner', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getServiceInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceInfo.test.ts
@@ -7,7 +7,7 @@ let safeApiKit: SafeApiKit
 describe('getServiceInfo', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
@@ -16,10 +16,10 @@ describe('getServiceSingletonsInfo', () => {
     const singletonsResponse = await safeApiKit.getServiceSingletonsInfo()
     chai.expect(singletonsResponse.length).to.be.greaterThan(1)
     singletonsResponse.map((singleton) => {
-      if (semverSatisfies(singleton.version, '<=1.3.0')) {
+      if (semverSatisfies(singleton.version, '<1.3.0')) {
         chai.expect(singleton.deployer).to.be.equal('Gnosis')
       }
-      if (semverSatisfies(singleton.version, '>1.3.0')) {
+      if (semverSatisfies(singleton.version, '>=1.3.0')) {
         chai.expect(singleton.deployer).to.be.equal('Safe')
       }
     })

--- a/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
@@ -1,5 +1,6 @@
 import chai from 'chai'
 import SafeApiKit from '@safe-global/api-kit/index'
+import semverSatisfies from 'semver/functions/satisfies'
 import { getServiceClient } from '../utils/setupServiceClient'
 
 let safeApiKit: SafeApiKit
@@ -15,7 +16,12 @@ describe('getServiceSingletonsInfo', () => {
     const singletonsResponse = await safeApiKit.getServiceSingletonsInfo()
     chai.expect(singletonsResponse.length).to.be.greaterThan(1)
     singletonsResponse.map((singleton) => {
-      chai.expect(singleton.deployer).to.be.equal('Safe')
+      if (semverSatisfies(singleton.version, '<=1.3.0')) {
+        chai.expect(singleton.deployer).to.be.equal('Gnosis')
+      }
+      if (semverSatisfies(singleton.version, '>1.3.0')) {
+        chai.expect(singleton.deployer).to.be.equal('Safe')
+      }
     })
   })
 })

--- a/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
+++ b/packages/api-kit/tests/e2e/getServiceSingletonsInfo.test.ts
@@ -1,6 +1,5 @@
 import chai from 'chai'
 import SafeApiKit from '@safe-global/api-kit/index'
-import semverSatisfies from 'semver/functions/satisfies'
 import { getServiceClient } from '../utils/setupServiceClient'
 
 let safeApiKit: SafeApiKit
@@ -8,7 +7,7 @@ let safeApiKit: SafeApiKit
 describe('getServiceSingletonsInfo', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -16,12 +15,7 @@ describe('getServiceSingletonsInfo', () => {
     const singletonsResponse = await safeApiKit.getServiceSingletonsInfo()
     chai.expect(singletonsResponse.length).to.be.greaterThan(1)
     singletonsResponse.map((singleton) => {
-      if (semverSatisfies(singleton.version, '<=1.3.0')) {
-        chai.expect(singleton.deployer).to.be.equal('Gnosis')
-      }
-      if (semverSatisfies(singleton.version, '>1.3.0')) {
-        chai.expect(singleton.deployer).to.be.equal('Safe')
-      }
+      chai.expect(singleton.deployer).to.be.equal('Safe')
     })
   })
 })

--- a/packages/api-kit/tests/e2e/getToken.test.ts
+++ b/packages/api-kit/tests/e2e/getToken.test.ts
@@ -11,7 +11,7 @@ let safeApiKit: SafeApiKit
 describe('getToken', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getToken.test.ts
+++ b/packages/api-kit/tests/e2e/getToken.test.ts
@@ -21,22 +21,22 @@ describe('getToken', () => {
   })
 
   it('should fail if token address is not checksummed', async () => {
-    const tokenAddress = '0x210EC22dD6b1c174E5cA1A261DD9791e0755cc6D'.toLowerCase()
+    const tokenAddress = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'.toLowerCase()
     await chai
       .expect(safeApiKit.getToken(tokenAddress))
       .to.be.rejectedWith('Invalid ethereum address')
   })
 
   it('should return the token info', async () => {
-    const tokenAddress = '0x210EC22dD6b1c174E5cA1A261DD9791e0755cc6D'
+    const tokenAddress = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
     const tokenInfoResponse = await safeApiKit.getToken(tokenAddress)
-    chai.expect(tokenInfoResponse.address).to.be.equal('0x210EC22dD6b1c174E5cA1A261DD9791e0755cc6D')
+    chai.expect(tokenInfoResponse.address).to.be.equal('0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14')
   })
 
   it('should return the token info EIP-3770', async () => {
-    const tokenAddress = '0x210EC22dD6b1c174E5cA1A261DD9791e0755cc6D'
+    const tokenAddress = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
     const eip3770TokenAddress = `${config.EIP_3770_PREFIX}:${tokenAddress}`
     const tokenInfoResponse = await safeApiKit.getToken(eip3770TokenAddress)
-    chai.expect(tokenInfoResponse.address).to.be.equal('0x210EC22dD6b1c174E5cA1A261DD9791e0755cc6D')
+    chai.expect(tokenInfoResponse.address).to.be.equal('0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14')
   })
 })

--- a/packages/api-kit/tests/e2e/getTokenList.test.ts
+++ b/packages/api-kit/tests/e2e/getTokenList.test.ts
@@ -7,7 +7,7 @@ let safeApiKit: SafeApiKit
 describe('getTokenList', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 

--- a/packages/api-kit/tests/e2e/getTransaction.test.ts
+++ b/packages/api-kit/tests/e2e/getTransaction.test.ts
@@ -10,7 +10,7 @@ let safeApiKit: SafeApiKit
 describe('getTransaction', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -27,7 +27,7 @@ describe('getTransaction', () => {
   })
 
   it('should return the transaction with the given safeTxHash', async () => {
-    const safeTxHash = '0xc58b604550610302477087256063d1ba195fbec20b2fd27648fec55242074592'
+    const safeTxHash = '0x317834aea988fd3cfa54fd8b2be2c96b4fd70a14d8c9470a7110576b01e6480a'
     const transaction = await safeApiKit.getTransaction(safeTxHash)
     chai.expect(transaction.safeTxHash).to.be.equal(safeTxHash)
   })

--- a/packages/api-kit/tests/e2e/getTransactionConfirmations.test.ts
+++ b/packages/api-kit/tests/e2e/getTransactionConfirmations.test.ts
@@ -10,7 +10,7 @@ let safeApiKit: SafeApiKit
 describe('getTransactionConfirmations', () => {
   before(async () => {
     ;({ safeApiKit } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -29,7 +29,7 @@ describe('getTransactionConfirmations', () => {
   })
 
   it('should return the transaction with the given safeTxHash', async () => {
-    const safeTxHash = '0xc58b604550610302477087256063d1ba195fbec20b2fd27648fec55242074592'
+    const safeTxHash = '0x317834aea988fd3cfa54fd8b2be2c96b4fd70a14d8c9470a7110576b01e6480a'
     const transactionConfirmations = await safeApiKit.getTransactionConfirmations(safeTxHash)
     chai.expect(transactionConfirmations.count).to.be.equal(2)
     chai.expect(transactionConfirmations.results.length).to.be.equal(2)

--- a/packages/api-kit/tests/e2e/removeSafeDelegate.test.ts
+++ b/packages/api-kit/tests/e2e/removeSafeDelegate.test.ts
@@ -13,7 +13,7 @@ let signer: Signer
 describe('removeSafeDelegate', () => {
   before(async () => {
     ;({ safeApiKit, signer } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
   })
 
@@ -31,7 +31,7 @@ describe('removeSafeDelegate', () => {
   })
 
   it('should fail if Safe delegator address is empty', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = ''
     const delegateConfig: DeleteSafeDelegateProps = {
       delegateAddress,
@@ -44,7 +44,7 @@ describe('removeSafeDelegate', () => {
   })
 
   it('should fail if Safe delegate address is not checksummed', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'.toLowerCase()
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'.toLowerCase()
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: DeleteSafeDelegateProps = {
       delegateAddress,
@@ -57,7 +57,7 @@ describe('removeSafeDelegate', () => {
   })
 
   it('should fail if Safe delegator address is not checksummed', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = (await signer.getAddress()).toLowerCase()
     const delegateConfig: DeleteSafeDelegateProps = {
       delegateAddress,
@@ -81,7 +81,7 @@ describe('removeSafeDelegate', () => {
   })
 
   it('should remove a delegate', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const delegatorAddress = await signer.getAddress()
     const delegateConfig: DeleteSafeDelegateProps = {
       delegateAddress,
@@ -103,7 +103,7 @@ describe('removeSafeDelegate', () => {
   })
 
   it('should remove a delegate EIP-3770', async () => {
-    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const delegateAddress = '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B'
     const eip3770DelegateAddress = `${config.EIP_3770_PREFIX}:${delegateAddress}`
     const delegatorAddress = await signer.getAddress()
     const eip3770DelegatorAddress = `${config.EIP_3770_PREFIX}:${delegatorAddress}`

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -347,7 +347,6 @@ describe('Endpoint tests', () => {
       })
     })
 
-    // FIXME when tests are migrated to Sepolia
     it('proposeTransaction', async () => {
       const safeTransactionData = {
         to: safeAddress,
@@ -397,7 +396,6 @@ describe('Endpoint tests', () => {
       })
     })
 
-    // FIXME when tests are migrated to Sepolia
     it('proposeTransaction EIP-3770', async () => {
       const safeTransactionData = {
         to: safeAddress,

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -18,19 +18,19 @@ import { getServiceClient } from '../utils/setupServiceClient'
 chai.use(chaiAsPromised)
 chai.use(sinonChai)
 
-const safeAddress = '0x9D1E7371852a9baF631Ea115b9815deb97cC3205'
+const safeAddress = '0xF8ef84392f7542576F6b9d1b140334144930Ac78'
 const eip3770SafeAddress = `${config.EIP_3770_PREFIX}:${safeAddress}`
 const randomAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
 const eip3770RandomAddress = `${config.EIP_3770_PREFIX}:${randomAddress}`
 const delegateAddress = '0x22d491Bde2303f2f43325b2108D26f1eAbA1e32b'
 const eip3770DelegateAddress = `${config.EIP_3770_PREFIX}:${delegateAddress}`
-const tokenAddress = '0x210EC22dD6b1c174E5cA1A261DD9791e0755cc6D'
+const tokenAddress = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
 const eip3770TokenAddress = `${config.EIP_3770_PREFIX}:${tokenAddress}`
-const safeTxHash = '0xede78ed72e9a8afd2b7a21f35c86f56cba5fffb2fff0838e253b7a41d19ceb48'
+const safeTxHash = '0x317834aea988fd3cfa54fd8b2be2c96b4fd70a14d8c9470a7110576b01e6480a'
 const txServiceBaseUrl = 'https://safe-transaction-sepolia.safe.global/api'
 const provider = getDefaultProvider(config.JSON_RPC)
 const signer = new Wallet(
-  '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
+  '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676',
   provider
 )
 let ethAdapter: EthAdapter
@@ -41,7 +41,7 @@ let eip3770DelegatorAddress: string
 describe('Endpoint tests', () => {
   before(async () => {
     ;({ safeApiKit, ethAdapter } = await getServiceClient(
-      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
+      '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676'
     ))
     delegatorAddress = await signer.getAddress()
     eip3770DelegatorAddress = `${config.EIP_3770_PREFIX}:${delegatorAddress}`
@@ -348,7 +348,7 @@ describe('Endpoint tests', () => {
     })
 
     // FIXME when tests are migrated to Sepolia
-    it.skip('proposeTransaction', async () => {
+    it('proposeTransaction', async () => {
       const safeTransactionData = {
         to: safeAddress,
         data: '0x',
@@ -398,7 +398,7 @@ describe('Endpoint tests', () => {
     })
 
     // FIXME when tests are migrated to Sepolia
-    it.skip('proposeTransaction EIP-3770', async () => {
+    it('proposeTransaction EIP-3770', async () => {
       const safeTransactionData = {
         to: safeAddress,
         data: '0x',
@@ -654,7 +654,7 @@ describe('Endpoint tests', () => {
 
     it('should can instantiate the SafeApiKit with a custom endpoint', async () => {
       ;({ safeApiKit } = await getServiceClient(
-        '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
+        '0x83a415ca62e11f5fa5567e98450d0f82ae19ff36ef876c10a8d448c788a53676',
         txServiceUrl
       ))
 


### PR DESCRIPTION
## What it solves
Resolves #687

## How this PR fixes it
Enable the previously failing tests and uses applicable data to Sepolia