### PR TITLE
Playground-create-execute-transaction

### DIFF
--- a/playground/config/run.ts
+++ b/playground/config/run.ts
@@ -3,6 +3,7 @@ import { execSync } from 'child_process'
 const playInput = process.argv[2]
 
 const playgroundProtocolKitPaths = {
+  'create-execute-transaction': 'protocol-kit/create-execute-transaction',
   'deploy-safe': 'protocol-kit/deploy-safe',
   'generate-safe-address': 'protocol-kit/generate-safe-address',
   eip1271: 'protocol-kit/eip1271'

--- a/playground/protocol-kit/create-execute-transaction.ts
+++ b/playground/protocol-kit/create-execute-transaction.ts
@@ -1,0 +1,94 @@
+import { ethers } from 'ethers'
+import * as dotenv from 'dotenv'
+import Safe, { EthersAdapter, SigningMethod } from '@safe-global/protocol-kit'
+import { OperationType, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
+
+dotenv.config()
+
+const { SIGNER_ADDRESS_PRIVATE_KEY } = process.env
+
+// This file can be used to play around with the Safe Core SDK
+// The script creates, signs and executes a transaction for an existing 1/1 Safe
+
+interface Config {
+  RPC_URL: string
+  /** Private key of a signer owning the Safe */
+  SIGNER_ADDRESS_PRIVATE_KEY: string
+  /** Address of a 1/1 Safe */
+  SAFE_ADDRESS: string
+}
+
+const config: Config = {
+  RPC_URL: 'https://rpc.ankr.com/eth_sepolia',
+  SIGNER_ADDRESS_PRIVATE_KEY: SIGNER_ADDRESS_PRIVATE_KEY!,
+  SAFE_ADDRESS: '<SAFE_ADDRESS>'
+}
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(config.RPC_URL)
+  const signer = new ethers.Wallet(config.SIGNER_ADDRESS_PRIVATE_KEY, provider)
+
+  // Create EthAdapter instance
+  const ethAdapter = new EthersAdapter({
+    ethers,
+    signerOrProvider: signer
+  })
+
+  // Create Safe instance
+  const safe = await Safe.create({
+    ethAdapter,
+    safeAddress: config.SAFE_ADDRESS
+  })
+
+  console.log('Creating transaction with Safe:')
+  console.log(' - Address: ', await safe.getAddress())
+  console.log(' - ChainID: ', await safe.getChainId())
+  console.log(' - Version: ', await safe.getContractVersion())
+  console.log(' - Threshold: ', await safe.getThreshold(), '\n')
+
+  // Create transaction
+  const safeTransactionData: SafeTransactionDataPartial = {
+    to: config.SAFE_ADDRESS,
+    value: '1000000000000000', // 0.001 ether
+    data: '0x',
+    operation: OperationType.Call
+  }
+
+  let safeTransaction
+  try {
+    safeTransaction = await safe.createTransaction({ transactions: [safeTransactionData] })
+  } catch (err) {
+    console.log('`createTransaction` failed:')
+    console.log(err)
+    return
+  }
+
+  console.log('Created the Safe transaction.')
+
+  let signedSafeTransaction
+  try {
+    // Sign the safeTransaction
+    signedSafeTransaction = await safe.signTransaction(safeTransaction, SigningMethod.ETH_SIGN)
+  } catch (err) {
+    console.log('`signTransaction` failed:')
+    console.log(err)
+    return
+  }
+
+  console.log('Signed the transaction.')
+
+  let result
+  try {
+    // Execute the signed transaction
+    result = await safe.executeTransaction(signedSafeTransaction)
+  } catch (err) {
+    console.log('`executeTransaction` failed:')
+    console.log(err)
+    return
+  }
+
+  console.log('Succesfully executed the transaction:')
+  console.log(' - Tx hash: ', result.hash)
+}
+
+main()


### PR DESCRIPTION
## What it solves
Adds a playground script to create, sign and execute a transaction with an existing 1/1 Safe.

The script was used to verify the behavior of `createTransaction` (#110) when being called with a non-executable transaction (insufficient funds in the Safe):

| Safe version | Behavior of `createTransaction` for non-executable Tx |
|--------------|-------------------------------------------------------|
| v1.0.0       | Throws: "insufficient funds"                          |
| v1.1.1       | Throws: "insufficient funds"                          |
| v1.2.0       | Throws: "insufficient funds"                          |
| v1.3.0       | Succeeds                                              |
| v1.4.1       | Succeeds                                              |