### PR TITLE
Feat/protocol kit/get modules paginated

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -368,6 +368,17 @@ class Safe {
   }
 
   /**
+   * Returns the list of addresses of all the enabled Safe modules. The list will start on the next position address in relation to offsetAddress.
+   *
+   * @param offsetAddress - The address to be "offsetted" from the list, should be SENTINEL_ADDRESS otherwise.
+   * @param pageSize - The size of the page. It will be the max length of the returning array.
+   * @returns The list of addresses of all the enabled Safe modules
+   */
+  async getModulesPaginated(start: string, pageSize: number = 10): Promise<string[]> {
+    return this.#moduleManager.getModulesPaginated(start, pageSize)
+  }
+
+  /**
    * Checks if a specific Safe module is enabled for the current Safe.
    *
    * @param moduleAddress - The desired module address

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -368,7 +368,7 @@ class Safe {
   }
 
   /**
-   * Returns the list of addresses of all the enabled Safe modules. The list will start on the next position address in relation to offsetAddress.
+   * Returns the list of addresses of all the enabled Safe modules. The list will start on the next position address in relation to start.
    *
    * @param offsetAddress - The address to be "offsetted" from the list, should be SENTINEL_ADDRESS otherwise.
    * @param pageSize - The size of the page. It will be the max length of the returning array.

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -370,8 +370,8 @@ class Safe {
   /**
    * Returns the list of addresses of all the enabled Safe modules. The list will start on the next position address in relation to start.
    *
-   * @param offsetAddress - The address to be "offsetted" from the list, should be SENTINEL_ADDRESS otherwise.
-   * @param pageSize - The size of the page. It will be the max length of the returning array.
+   * @param start - The address to be "offsetted" from the list, should be SENTINEL_ADDRESS otherwise.
+   * @param pageSize - The size of the page. It will be the max length of the returning array. Must be greater then 0.
    * @returns The list of addresses of all the enabled Safe modules
    */
   async getModulesPaginated(start: string, pageSize: number = 10): Promise<string[]> {

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/SafeContractEthers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/SafeContractEthers.ts
@@ -85,6 +85,8 @@ abstract class SafeContractEthers implements SafeContract {
 
   abstract getModules(): Promise<string[]>
 
+  abstract getModulesPaginated(start: string, pageSize: number): Promise<string[]>
+
   abstract isModuleEnabled(moduleAddress: string): Promise<boolean>
 
   async isValidTransaction(

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
@@ -60,8 +60,8 @@ class SafeContract_V1_0_0_Ethers extends SafeContractEthers {
     if (start === SENTINEL_ADDRESS) {
       return array.slice(0, pageSize)
     } else {
-      const ownerIndex = array.findIndex((module: string) => sameString(module, start))
-      return ownerIndex === -1 ? [] : array.slice(ownerIndex + 1, pageSize)
+      const moduleIndex = array.findIndex((module: string) => sameString(module, start))
+      return moduleIndex === -1 ? [] : array.slice(moduleIndex + 1, pageSize)
     }
   }
 

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
@@ -61,7 +61,7 @@ class SafeContract_V1_0_0_Ethers extends SafeContractEthers {
       return array.slice(0, pageSize)
     } else {
       const ownerIndex = array.findIndex((module: string) => sameString(module, start))
-      return ownerIndex === -1 ? [] : array.slice(ownerIndex, pageSize)
+      return ownerIndex === -1 ? [] : array.slice(ownerIndex + 1, pageSize)
     }
   }
 

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
@@ -56,6 +56,8 @@ class SafeContract_V1_0_0_Ethers extends SafeContractEthers {
   }
 
   async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    if (pageSize <= 0) throw new Error('Invalid page size for fetching paginated modules')
+
     const array = await this.getModules()
     if (start === SENTINEL_ADDRESS) {
       return array.slice(0, pageSize)

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Ethers.ts
@@ -7,6 +7,7 @@ import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/adapters/eth
 import { Gnosis_safe as Safe } from '@safe-global/protocol-kit/typechain/src/ethers-v6/v1.0.0/Gnosis_safe'
 import { SafeSetupConfig } from '@safe-global/safe-core-sdk-types'
 import SafeContractEthers from '../SafeContractEthers'
+import { SENTINEL_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
 
 class SafeContract_V1_0_0_Ethers extends SafeContractEthers {
   constructor(public contract: Safe) {
@@ -52,6 +53,16 @@ class SafeContract_V1_0_0_Ethers extends SafeContractEthers {
 
   async getModules(): Promise<string[]> {
     return this.contract.getModules()
+  }
+
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const array = await this.getModules()
+    if (start === SENTINEL_ADDRESS) {
+      return array.slice(0, pageSize)
+    } else {
+      const ownerIndex = array.findIndex((module: string) => sameString(module, start))
+      return ownerIndex === -1 ? [] : array.slice(ownerIndex, pageSize)
+    }
   }
 
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.1.1/SafeContract_V1_1_1_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.1.1/SafeContract_V1_1_1_Ethers.ts
@@ -56,6 +56,11 @@ class SafeContract_V1_1_1_Ethers extends SafeContractEthers {
     return this.contract.getModules()
   }
 
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.getModulesPaginated(start, pageSize)
+    return array
+  }
+
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
     const modules = await this.getModules()
     const isModuleEnabled = modules.some((enabledModuleAddress: string) =>

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.2.0/SafeContract_V1_2_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.2.0/SafeContract_V1_2_0_Ethers.ts
@@ -56,6 +56,11 @@ class SafeContract_V1_2_0_Ethers extends SafeContractEthers {
     return this.contract.getModules()
   }
 
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.getModulesPaginated(start, pageSize)
+    return array
+  }
+
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
     return this.contract.isModuleEnabled(moduleAddress)
   }

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.3.0/SafeContract_V1_3_0_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.3.0/SafeContract_V1_3_0_Ethers.ts
@@ -57,7 +57,11 @@ class SafeContract_V1_3_0_Ethers extends SafeContractEthers {
   }
 
   async getModules(): Promise<string[]> {
-    const { array } = await this.contract.getModulesPaginated(SENTINEL_ADDRESS, 10)
+    return await this.getModulesPaginated(SENTINEL_ADDRESS, 10)
+  }
+
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.getModulesPaginated(start, pageSize)
     return array
   }
 

--- a/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.4.1/SafeContract_V1_4_1_Ethers.ts
+++ b/packages/protocol-kit/src/adapters/ethers/contracts/Safe/v1.4.1/SafeContract_V1_4_1_Ethers.ts
@@ -57,7 +57,11 @@ class SafeContract_V1_4_1_Ethers extends SafeContractEthers {
   }
 
   async getModules(): Promise<string[]> {
-    const { array } = await this.contract.getModulesPaginated(SENTINEL_ADDRESS, 10)
+    return await this.getModulesPaginated(SENTINEL_ADDRESS, 10)
+  }
+
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.getModulesPaginated(start, pageSize)
     return array
   }
 

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/SafeContractWeb3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/SafeContractWeb3.ts
@@ -84,6 +84,8 @@ abstract class SafeContractWeb3 implements SafeContract {
 
   abstract getModules(): Promise<string[]>
 
+  abstract getModulesPaginated(start: string, pageSize: number): Promise<string[]>
+
   abstract isModuleEnabled(moduleAddress: string): Promise<boolean>
 
   async isValidTransaction(

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
@@ -57,7 +57,7 @@ class SafeContract_V1_0_0_Web3 extends SafeContractWeb3 {
       return array.slice(0, pageSize)
     } else {
       const ownerIndex = array.findIndex((module: string) => sameString(module, start))
-      return ownerIndex === -1 ? [] : array.slice(ownerIndex, pageSize)
+      return ownerIndex === -1 ? [] : array.slice(ownerIndex + 1, pageSize)
     }
   }
 

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
@@ -3,7 +3,11 @@ import {
   Web3TransactionResult
 } from '@safe-global/protocol-kit/adapters/web3/types'
 import { sameString, toTxResult } from '@safe-global/protocol-kit/adapters/web3/utils'
-import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/adapters/web3/utils/constants'
+import {
+  EMPTY_DATA,
+  ZERO_ADDRESS,
+  SENTINEL_ADDRESS
+} from '@safe-global/protocol-kit/adapters/web3/utils/constants'
 import { Gnosis_safe as Safe } from '@safe-global/protocol-kit/typechain/src/web3-v1/v1.0.0/Gnosis_safe'
 import { SafeSetupConfig } from '@safe-global/safe-core-sdk-types'
 import SafeContractWeb3 from '../SafeContractWeb3'
@@ -45,6 +49,16 @@ class SafeContract_V1_0_0_Web3 extends SafeContractWeb3 {
 
   async getModules(): Promise<string[]> {
     return this.contract.methods.getModules().call()
+  }
+
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const array = await this.getModules()
+    if (start === SENTINEL_ADDRESS) {
+      return array.slice(0, pageSize)
+    } else {
+      const ownerIndex = array.findIndex((module: string) => sameString(module, start))
+      return ownerIndex === -1 ? [] : array.slice(ownerIndex, pageSize)
+    }
   }
 
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
@@ -52,6 +52,8 @@ class SafeContract_V1_0_0_Web3 extends SafeContractWeb3 {
   }
 
   async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    if (pageSize <= 0) throw new Error('Invalid page size for fetching paginated modules')
+
     const array = await this.getModules()
     if (start === SENTINEL_ADDRESS) {
       return array.slice(0, pageSize)

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.0.0/SafeContract_V1_0_0_Web3.ts
@@ -56,8 +56,8 @@ class SafeContract_V1_0_0_Web3 extends SafeContractWeb3 {
     if (start === SENTINEL_ADDRESS) {
       return array.slice(0, pageSize)
     } else {
-      const ownerIndex = array.findIndex((module: string) => sameString(module, start))
-      return ownerIndex === -1 ? [] : array.slice(ownerIndex + 1, pageSize)
+      const moduleIndex = array.findIndex((module: string) => sameString(module, start))
+      return moduleIndex === -1 ? [] : array.slice(moduleIndex + 1, pageSize)
     }
   }
 

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.1.1/SafeContract_V1_1_1_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.1.1/SafeContract_V1_1_1_Web3.ts
@@ -48,6 +48,11 @@ class SafeContract_V1_1_1_Web3 extends SafeContractWeb3 {
     return this.contract.methods.getModules().call()
   }
 
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.methods.getModulesPaginated(start, pageSize).call()
+    return array
+  }
+
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
     const modules = await this.getModules()
     const isModuleEnabled = modules.some((enabledModuleAddress: string) =>

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.2.0/SafeContract_V1_2_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.2.0/SafeContract_V1_2_0_Web3.ts
@@ -48,6 +48,11 @@ class SafeContract_V1_2_0_Web3 extends SafeContractWeb3 {
     return this.contract.methods.getModules().call()
   }
 
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.methods.getModulesPaginated(start, pageSize).call()
+    return array
+  }
+
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
     return this.contract.methods.isModuleEnabled(moduleAddress).call()
   }

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.3.0/SafeContract_V1_3_0_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.3.0/SafeContract_V1_3_0_Web3.ts
@@ -49,7 +49,11 @@ class SafeContract_V1_3_0_Web3 extends SafeContractWeb3 {
   }
 
   async getModules(): Promise<string[]> {
-    const { array } = await this.contract.methods.getModulesPaginated(SENTINEL_ADDRESS, 10).call()
+    return await this.getModulesPaginated(SENTINEL_ADDRESS, 10)
+  }
+
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.methods.getModulesPaginated(start, pageSize).call()
     return array
   }
 

--- a/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.4.1/SafeContract_V1_4_1_Web3.ts
+++ b/packages/protocol-kit/src/adapters/web3/contracts/Safe/v1.4.1/SafeContract_V1_4_1_Web3.ts
@@ -49,7 +49,11 @@ class SafeContract_V1_4_1_Web3 extends SafeContractWeb3 {
   }
 
   async getModules(): Promise<string[]> {
-    const { array } = await this.contract.methods.getModulesPaginated(SENTINEL_ADDRESS, 10).call()
+    return await this.getModulesPaginated(SENTINEL_ADDRESS, 10)
+  }
+
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    const { array } = await this.contract.methods.getModulesPaginated(start, pageSize).call()
     return array
   }
 

--- a/packages/protocol-kit/src/managers/moduleManager.ts
+++ b/packages/protocol-kit/src/managers/moduleManager.ts
@@ -42,6 +42,13 @@ class ModuleManager {
     return this.#safeContract.getModules()
   }
 
+  async getModulesPaginated(start: string, pageSize: number): Promise<string[]> {
+    if (!this.#safeContract) {
+      throw new Error('Safe is not deployed')
+    }
+    return this.#safeContract.getModulesPaginated(start, pageSize)
+  }
+
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {
     if (!this.#safeContract) {
       throw new Error('Safe is not deployed')

--- a/packages/protocol-kit/tests/e2e/moduleManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/moduleManager.test.ts
@@ -75,6 +75,93 @@ describe('Safe modules manager', () => {
     })
   })
 
+  describe('getModulesPaginated', async () => {
+    it('should fail if the Safe is not deployed', async () => {
+      const { predictedSafe, accounts, contractNetworks } = await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeSdk = await Safe.create({
+        ethAdapter,
+        predictedSafe,
+        contractNetworks
+      })
+      chai
+        .expect(safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10))
+        .to.be.rejectedWith('Safe is not deployed')
+    })
+
+    it('should return the enabled modules', async () => {
+      const { safe, accounts, dailyLimitModule, contractNetworks } = await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeAddress = await safe.getAddress()
+      const safeSdk = await Safe.create({
+        ethAdapter,
+        safeAddress,
+        contractNetworks
+      })
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(0)
+      const tx = await safeSdk.createEnableModuleTx(await dailyLimitModule.getAddress())
+      const txResponse = await safeSdk.executeTransaction(tx)
+      await waitSafeTxReceipt(txResponse)
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(1)
+    })
+
+    it('should contrain the returned modules by pageSize', async () => {
+      const { safe, accounts, dailyLimitModule, contractNetworks, socialRecoveryModule } =
+        await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeAddress = await safe.getAddress()
+      const dailyLimitsAddress = await await dailyLimitModule.getAddress()
+      const socialRecoveryAddress = await await socialRecoveryModule.getAddress()
+      const safeSdk = await Safe.create({
+        ethAdapter,
+        safeAddress,
+        contractNetworks
+      })
+
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(0)
+      const txDailyLimits = await safeSdk.createEnableModuleTx(dailyLimitsAddress)
+      const dailyLimitsResponse = await safeSdk.executeTransaction(txDailyLimits)
+      await waitSafeTxReceipt(dailyLimitsResponse)
+      const txSocialRecovery = await safeSdk.createEnableModuleTx(socialRecoveryAddress)
+      const soecialRecoveryResponse = await safeSdk.executeTransaction(txSocialRecovery)
+      await waitSafeTxReceipt(soecialRecoveryResponse)
+
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(2)
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 1)).length).to.be.eq(1)
+    })
+
+    it('should offset the returned modules', async () => {
+      const { safe, accounts, dailyLimitModule, contractNetworks, socialRecoveryModule } =
+        await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeAddress = await safe.getAddress()
+      const dailyLimitsAddress = await await dailyLimitModule.getAddress()
+      const socialRecoveryAddress = await await socialRecoveryModule.getAddress()
+      const safeSdk = await Safe.create({
+        ethAdapter,
+        safeAddress,
+        contractNetworks
+      })
+
+      const txDailyLimits = await safeSdk.createEnableModuleTx(dailyLimitsAddress)
+      const dailyLimitsResponse = await safeSdk.executeTransaction(txDailyLimits)
+      await waitSafeTxReceipt(dailyLimitsResponse)
+      const txSocialRecovery = await safeSdk.createEnableModuleTx(socialRecoveryAddress)
+      const soecialRecoveryResponse = await safeSdk.executeTransaction(txSocialRecovery)
+      await waitSafeTxReceipt(soecialRecoveryResponse)
+
+      const [firstModule, secondModule] = await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)
+
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(2)
+      chai.expect((await safeSdk.getModulesPaginated(firstModule, 10)).length).to.be.eq(1)
+      chai.expect((await safeSdk.getModulesPaginated(secondModule, 10)).length).to.be.eq(0)
+    })
+  })
+
   describe('isModuleEnabled', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, accounts, dailyLimitModule, contractNetworks } = await setupTests()

--- a/packages/protocol-kit/tests/e2e/moduleManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/moduleManager.test.ts
@@ -107,7 +107,7 @@ describe('Safe modules manager', () => {
       chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(1)
     })
 
-    it('should contrain the returned modules by pageSize', async () => {
+    it('should constraint returned modules by pageSize', async () => {
       const { safe, accounts, dailyLimitModule, contractNetworks, socialRecoveryModule } =
         await setupTests()
       const [account1] = accounts
@@ -130,6 +130,7 @@ describe('Safe modules manager', () => {
       await waitSafeTxReceipt(soecialRecoveryResponse)
 
       chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(2)
+      chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 1)).length).to.be.eq(1)
       chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 1)).length).to.be.eq(1)
     })
 
@@ -159,6 +160,21 @@ describe('Safe modules manager', () => {
       chai.expect((await safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 10)).length).to.be.eq(2)
       chai.expect((await safeSdk.getModulesPaginated(firstModule, 10)).length).to.be.eq(1)
       chai.expect((await safeSdk.getModulesPaginated(secondModule, 10)).length).to.be.eq(0)
+    })
+
+    it('should fail if pageSize is invalid', async () => {
+      const { predictedSafe, accounts, contractNetworks } = await setupTests()
+      const [account1] = accounts
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeSdk = await Safe.create({
+        ethAdapter,
+        predictedSafe,
+        contractNetworks
+      })
+
+      chai
+        .expect(safeSdk.getModulesPaginated(SENTINEL_ADDRESS, 0))
+        .to.be.rejectedWith('Invalid page size for fetching paginated modules')
     })
   })
 

--- a/packages/safe-core-sdk-types/src/contracts/SafeContract.ts
+++ b/packages/safe-core-sdk-types/src/contracts/SafeContract.ts
@@ -19,6 +19,7 @@ export interface SafeContract {
   approvedHashes(ownerAddress: string, hash: string): Promise<bigint>
   approveHash(hash: string, options?: TransactionOptions): Promise<TransactionResult>
   getModules(): Promise<string[]>
+  getModulesPaginated(start: string, pageSize: number): Promise<string[]>
   isModuleEnabled(moduleAddress: string): Promise<boolean>
   isValidTransaction(
     safeTransaction: SafeTransaction,


### PR DESCRIPTION
## What it solves
Resolves #607
`getModules` returns a fixed number of Modules that would potentialy truncate the output list of addresses.

## How this PR fixes it
Add `getModulesPaginated` from smart contract to versions that support it.
Add a function that uses `getModules` in the background for those contract versions that don't support it.