### PR TITLE
replace `callsOnly` by`onlyCalls` in README

### DIFF
--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -567,14 +567,14 @@ const options: SafeTransactionOptionalProps = {
 const safeTransaction = await safeSdk.createTransaction({ transactions, options })
 ```
 
-In addition, the optional `callsOnly` parameter, which is `false` by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
+In addition, the optional `onlyCalls` parameter, which is `false` by default, allows to force the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
 
 ```js
-const callsOnly = true
+const onlyCalls = true
 const safeTransaction = await safeSdk.createTransaction({
   transactions,
   options,
-  callsOnly
+  onlyCalls
 })
 ```
 


### PR DESCRIPTION
## What it solves

There is a mistake in the README of the Safe protocol-kit where the args for `createTransaction` specifies a `callsOnly` param - while it should be`onlyCalls`.

You can see the [types](https://github.com/safe-global/safe-core-sdk/blob/0bc0515d4265ef099085644791d4fa1fe4e1cf55/packages/protocol-kit/src/types/index.ts#L136) here 

## How this PR fixes it

This PR corrects the error in the README.

Also related : https://github.com/safe-global/safe-docs/pull/459