### PR TITLE
fix: `abitype` is not a dev dependency

### DIFF
--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -58,7 +58,6 @@
     "@types/semver": "^7.5.6",
     "@types/web3": "1.0.20",
     "@types/yargs": "^17.0.32",
-    "abitype": "^1.0.2",
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^16.3.1",
@@ -77,6 +76,7 @@
     "@safe-global/safe-deployments": "^1.34.0",
     "ethereumjs-util": "^7.1.5",
     "ethers": "^6.7.1",
-    "semver": "^7.5.4"
+    "semver": "^7.5.4",
+    "abitype": "^1.0.2"
   }
 }

--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -29,7 +29,6 @@
   ],
   "homepage": "https://github.com/safe-global/safe-core-sdk#readme",
   "dependencies": {
-    "@safe-global/safe-deployments": "^1.34.0",
     "abitype": "^1.0.2"
   }
 }

--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -29,9 +29,7 @@
   ],
   "homepage": "https://github.com/safe-global/safe-core-sdk#readme",
   "dependencies": {
-    "@safe-global/safe-deployments": "^1.34.0"
-  },
-  "devDependencies": {
+    "@safe-global/safe-deployments": "^1.34.0",
     "abitype": "^1.0.2"
   }
 }


### PR DESCRIPTION
## What it solves

This PR moves `abitype` to the `dependencies` in the `package.json` files

