### PR TITLE
feat: Rename methods

### DIFF
--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -57,9 +57,9 @@ const safeService = new SafeApiKit({
 ```js
 import Safe, { SafeFactory } from '@safe-global/protocol-kit'
 
-const safeFactory = await SafeFactory.create({ provider, signer })
+const safeFactory = await SafeFactory.init({ provider, signer })
 
-const safeSdk = await Safe.create({ provider, signer, safeAddress })
+const safeSdk = await Safe.init({ provider, signer, safeAddress })
 ```
 
 There are two versions of the Safe contracts: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that does not trigger events in order to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
@@ -67,9 +67,9 @@ There are two versions of the Safe contracts: [Safe.sol](https://github.com/safe
 By default `Safe.sol` will be only used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the property `isL1SafeSingleton` to force the use of the `Safe.sol` contract.
 
 ```js
-const safeFactory = await SafeFactory.create({ provider, signer, isL1SafeSingleton: true })
+const safeFactory = await SafeFactory.init({ provider, signer, isL1SafeSingleton: true })
 
-const safeSdk = await Safe.create({ provider, signer, safeAddress, isL1SafeSingleton: true })
+const safeSdk = await Safe.init({ provider, signer, safeAddress, isL1SafeSingleton: true })
 ```
 
 If the Safe contracts are not deployed to your current network, the property `contractNetworks` will be required to point to the addresses of the Safe contracts previously deployed by you.
@@ -100,16 +100,16 @@ const contractNetworks: ContractNetworksConfig = {
   }
 }
 
-const safeFactory = await SafeFactory.create({ provider, signer, contractNetworks })
+const safeFactory = await SafeFactory.init({ provider, signer, contractNetworks })
 
-const safeSdk = await Safe.create({ provider, signer, safeAddress, contractNetworks })
+const safeSdk = await Safe.init({ provider, signer, safeAddress, contractNetworks })
 ```
 
 The `SafeFactory` constructor also accepts the property `safeVersion` to specify the Safe contract version that will be deployed. This string can take the values `1.0.0`, `1.1.1`, `1.2.0`, `1.3.0` or `1.4.1`. If not specified, the `DEFAULT_SAFE_VERSION` value will be used.
 
 ```js
 const safeVersion = 'X.Y.Z'
-const safeFactory = await SafeFactory.create({ provider, signer, safeVersion })
+const safeFactory = await SafeFactory.init({ provider, signer, safeVersion })
 ```
 
 ## <a name="deploy-safe">3. Deploy a new Safe</a>

--- a/packages/account-abstraction-kit/src/AccountAbstraction.test.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.test.ts
@@ -40,8 +40,8 @@ describe('AccountAbstraction', () => {
           safeAccountConfig: { owners: ['0xSignerAddress'], threshold: 1 }
         })
       )
-      expect(SafeMock.create).toHaveBeenCalledTimes(1)
-      expect(SafeMock.create).toHaveBeenCalledWith(
+      expect(SafeMock.init).toHaveBeenCalledTimes(1)
+      expect(SafeMock.init).toHaveBeenCalledWith(
         expect.objectContaining({
           safeAddress: predictSafeAddress
         })
@@ -60,8 +60,8 @@ describe('AccountAbstraction', () => {
           safeAccountConfig: { owners: ['0xSignerAddress'], threshold: 1 }
         })
       )
-      expect(SafeMock.create).toHaveBeenCalledTimes(1)
-      expect(SafeMock.create).toHaveBeenCalledWith(
+      expect(SafeMock.init).toHaveBeenCalledTimes(1)
+      expect(SafeMock.init).toHaveBeenCalledWith(
         expect.objectContaining({
           predictedSafe: { safeAccountConfig: { owners: ['0xSignerAddress'], threshold: 1 } }
         })
@@ -75,7 +75,7 @@ describe('AccountAbstraction', () => {
         `There's no signer available with the provided config (provider, signer)`
       )
 
-      expect(SafeMock.create).not.toHaveBeenCalled()
+      expect(SafeMock.init).not.toHaveBeenCalled()
     })
   })
 
@@ -97,7 +97,7 @@ describe('AccountAbstraction', () => {
 
     beforeEach(async () => {
       jest.clearAllMocks()
-      SafeMock.create = () => Promise.resolve(safeInstanceMock as unknown as Safe)
+      SafeMock.init = () => Promise.resolve(safeInstanceMock as unknown as Safe)
       accountAbstraction = await initAccountAbstraction()
     })
 

--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -55,13 +55,13 @@ class AccountAbstraction {
     const isSafeDeployed = await safeProvider.isContractDeployed(safeAddress)
 
     if (isSafeDeployed) {
-      this.protocolKit = await Safe.create({
+      this.protocolKit = await Safe.init({
         provider: this.#provider,
         signer: this.#signer,
         safeAddress
       })
     } else {
-      this.protocolKit = await Safe.create({
+      this.protocolKit = await Safe.init({
         provider: this.#provider,
         signer: this.#signer,
         predictedSafe: { safeAccountConfig }

--- a/packages/api-kit/tests/utils/setupKits.ts
+++ b/packages/api-kit/tests/utils/setupKits.ts
@@ -53,7 +53,7 @@ export async function getProtocolKit({
   safeAddress: GetKitsOptions['safeAddress']
 }): Promise<Safe> {
   const provider = getEip1193Provider()
-  const protocolKit = await Safe.create({ provider, signer, safeAddress })
+  const protocolKit = await Safe.init({ provider, signer, safeAddress })
 
   return protocolKit
 }

--- a/packages/auth-kit/example/src/App.tsx
+++ b/packages/auth-kit/example/src/App.tsx
@@ -129,7 +129,7 @@ function App() {
     const safeAddress = safeAuthSignInResponse?.safes?.[index] || '0x'
 
     // Wrap Web3Auth provider with ethers
-    const protocolKit = await Safe.create({
+    const protocolKit = await Safe.init({
       provider: safeAuthPack?.getProvider() as Eip1193Provider,
       safeAddress
     })

--- a/packages/onramp-kit/example/client/src/components/monerium/Monerium.tsx
+++ b/packages/onramp-kit/example/client/src/components/monerium/Monerium.tsx
@@ -22,7 +22,7 @@ function Monerium() {
     ;(async () => {
       if (!authProvider || !selectedSafe) return
 
-      const protocolKit = await Safe.create({
+      const protocolKit = await Safe.init({
         provider: authProvider,
         safeAddress: selectedSafe,
         isL1SafeSingleton: true

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -111,7 +111,7 @@ class Safe {
    * @throws "MultiSend contract is not deployed on the current network"
    * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
-  async #initializeProtocolKit(config: SafeConfig): Promise<Safe> {
+  async #initializeProtocolKit(config: SafeConfig) {
     const { provider, signer, isL1SafeSingleton, contractNetworks } = config
 
     this.#safeProvider = new SafeProvider({

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -114,8 +114,6 @@ class Safe {
   async #initializeProtocolKit(config: SafeConfig): Promise<Safe> {
     const { provider, signer, isL1SafeSingleton, contractNetworks } = config
 
-    const safeSdk = new Safe()
-
     this.#safeProvider = new SafeProvider({
       provider,
       signer
@@ -150,8 +148,6 @@ class Safe {
       this.#safeProvider,
       this.#contractManager.safeContract
     )
-
-    return safeSdk
   }
 
   /**

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -122,7 +122,7 @@ class Safe {
     })
     if (isSafeConfigWithPredictedSafe(config)) {
       this.#predictedSafe = config.predictedSafe
-      this.#contractManager = await ContractManager.create(
+      this.#contractManager = await ContractManager.init(
         {
           provider,
           predictedSafe: this.#predictedSafe,
@@ -132,7 +132,7 @@ class Safe {
         this.#safeProvider
       )
     } else {
-      this.#contractManager = await ContractManager.create(
+      this.#contractManager = await ContractManager.init(
         {
           provider,
           safeAddress: config.safeAddress,

--- a/packages/protocol-kit/src/SafeFactory.ts
+++ b/packages/protocol-kit/src/SafeFactory.ts
@@ -35,7 +35,7 @@ class SafeFactory {
   #signer?: SafeFactoryConfig['signer']
   #safeProvider!: SafeProvider
 
-  static async create({
+  static async init({
     provider,
     signer,
     safeVersion = DEFAULT_SAFE_VERSION,
@@ -43,7 +43,7 @@ class SafeFactory {
     contractNetworks
   }: SafeFactoryConfig): Promise<SafeFactory> {
     const safeFactorySdk = new SafeFactory()
-    await safeFactorySdk.init({
+    await safeFactorySdk.#initializeSafeFactory({
       provider,
       signer,
       safeVersion,
@@ -53,7 +53,7 @@ class SafeFactory {
     return safeFactorySdk
   }
 
-  private async init({
+  async #initializeSafeFactory({
     provider,
     signer,
     safeVersion,
@@ -157,7 +157,7 @@ class SafeFactory {
     if (!isContractDeployed) {
       throw new Error('SafeProxy contract is not deployed on the current network')
     }
-    const safe = await Safe.create({
+    const safe = await Safe.init({
       provider: this.#provider,
       signer: this.#signer,
       safeAddress,

--- a/packages/protocol-kit/src/SafeFactory.ts
+++ b/packages/protocol-kit/src/SafeFactory.ts
@@ -59,7 +59,7 @@ class SafeFactory {
     safeVersion,
     isL1SafeSingleton,
     contractNetworks
-  }: SafeFactoryInitConfig): Promise<void> {
+  }: SafeFactoryInitConfig) {
     this.#provider = provider
     this.#signer = signer
     this.#safeProvider = new SafeProvider({ provider, signer })

--- a/packages/protocol-kit/src/SafeProvider.ts
+++ b/packages/protocol-kit/src/SafeProvider.ts
@@ -34,6 +34,26 @@ import {
   SocketTransport
 } from '@safe-global/protocol-kit/types'
 
+export function http(transportUrl: string): Provider {
+  return new JsonRpcProvider(transportUrl)
+}
+
+export function socket(transportUrl: string): Provider {
+  return new JsonRpcProvider(transportUrl)
+}
+
+export function eip1193(provider: Eip1193Provider): Provider {
+  return new BrowserProvider(provider)
+}
+
+export function privateKey(privateKey: string): string {
+  return privateKey
+}
+
+export function providerAddress(address: string): string {
+  return address
+}
+
 class SafeProvider {
   #externalProvider: BrowserProvider | JsonRpcProvider
   signer?: string

--- a/packages/protocol-kit/src/SafeProvider.ts
+++ b/packages/protocol-kit/src/SafeProvider.ts
@@ -34,26 +34,6 @@ import {
   SocketTransport
 } from '@safe-global/protocol-kit/types'
 
-export function http(transportUrl: string): Provider {
-  return new JsonRpcProvider(transportUrl)
-}
-
-export function socket(transportUrl: string): Provider {
-  return new JsonRpcProvider(transportUrl)
-}
-
-export function eip1193(provider: Eip1193Provider): Provider {
-  return new BrowserProvider(provider)
-}
-
-export function privateKey(privateKey: string): string {
-  return privateKey
-}
-
-export function providerAddress(address: string): string {
-  return address
-}
-
 class SafeProvider {
   #externalProvider: BrowserProvider | JsonRpcProvider
   signer?: string

--- a/packages/protocol-kit/src/managers/contractManager.ts
+++ b/packages/protocol-kit/src/managers/contractManager.ts
@@ -28,7 +28,7 @@ class ContractManager {
     return contractManager
   }
 
-  async #initializeContractManager(config: SafeConfig, safeProvider: SafeProvider): Promise<void> {
+  async #initializeContractManager(config: SafeConfig, safeProvider: SafeProvider) {
     const { isL1SafeSingleton, contractNetworks, predictedSafe, safeAddress } = config
 
     const chainId = await safeProvider.getChainId()

--- a/packages/protocol-kit/src/managers/contractManager.ts
+++ b/packages/protocol-kit/src/managers/contractManager.ts
@@ -22,13 +22,13 @@ class ContractManager {
   #multiSendContract!: MultiSendContractImplementationType
   #multiSendCallOnlyContract!: MultiSendCallOnlyContractImplementationType
 
-  static async create(config: SafeConfig, safeProvider: SafeProvider): Promise<ContractManager> {
+  static async init(config: SafeConfig, safeProvider: SafeProvider): Promise<ContractManager> {
     const contractManager = new ContractManager()
-    await contractManager.init(config, safeProvider)
+    await contractManager.#initializeContractManager(config, safeProvider)
     return contractManager
   }
 
-  async init(config: SafeConfig, safeProvider: SafeProvider): Promise<void> {
+  async #initializeContractManager(config: SafeConfig, safeProvider: SafeProvider): Promise<void> {
     const { isL1SafeSingleton, contractNetworks, predictedSafe, safeAddress } = config
 
     const chainId = await safeProvider.getChainId()

--- a/packages/protocol-kit/tests/e2e/contractManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/contractManager.test.ts
@@ -50,7 +50,7 @@ describe('Safe contracts manager', () => {
         }
       }
       chai.expect(
-        await Safe.create({
+        await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -63,7 +63,7 @@ describe('Safe contracts manager', () => {
       const safeAddress = await safe.getAddress()
       await chai
         .expect(
-          Safe.create({
+          Safe.init({
             provider,
             safeAddress
           })
@@ -75,7 +75,7 @@ describe('Safe contracts manager', () => {
       const { contractNetworks, provider } = await setupTests()
       await chai
         .expect(
-          Safe.create({
+          Safe.init({
             provider,
             safeAddress: ZERO_ADDRESS,
             contractNetworks
@@ -110,7 +110,7 @@ describe('Safe contracts manager', () => {
       const safeAddress = await safe.getAddress()
       await chai
         .expect(
-          Safe.create({
+          Safe.init({
             provider,
             safeAddress,
             contractNetworks: customContractNetworks
@@ -122,7 +122,7 @@ describe('Safe contracts manager', () => {
     it('should set the MultiSend contract available on the current network', async () => {
       const { safe, chainId, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/core.test.ts
+++ b/packages/protocol-kit/tests/e2e/core.test.ts
@@ -45,7 +45,7 @@ describe('Safe Info', () => {
       async () => {
         const { predictedSafe, safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -65,7 +65,7 @@ describe('Safe Info', () => {
         const { predictedSafe, safe, accounts, contractNetworks, provider } = await setupTests()
         const [account1] = accounts
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -81,7 +81,7 @@ describe('Safe Info', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2, account3] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -116,7 +116,7 @@ describe('Safe Info', () => {
   describe('getContractVersion', async () => {
     it('should return the contract version of a Safe that is not deployed with a custom version configuration', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -131,7 +131,7 @@ describe('Safe Info', () => {
         ...predictedSafe,
         safeDeploymentConfig: {}
       }
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe: safeConfig,
         contractNetworks
@@ -143,7 +143,7 @@ describe('Safe Info', () => {
     it('should return the Safe contract version', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -158,7 +158,7 @@ describe('Safe Info', () => {
       'should fail to return the address of a Safe <v1.3.0 that is not deployed',
       async () => {
         const { predictedSafe, contractNetworks, provider } = await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -176,14 +176,14 @@ describe('Safe Info', () => {
       'should return the address of a Safe >=v1.3.0 that is not deployed',
       async () => {
         const { predictedSafe, contractNetworks, provider } = await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
         })
         const safeAddress = await safeSdk.getAddress()
 
-        const safeFactory = await SafeFactory.create({
+        const safeFactory = await SafeFactory.init({
           provider,
           safeVersion: safeVersionDeployed,
           contractNetworks
@@ -198,7 +198,7 @@ describe('Safe Info', () => {
     it('should return the address of a deployed Safe', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -212,7 +212,7 @@ describe('Safe Info', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: safeAddress,
         contractNetworks
@@ -226,7 +226,7 @@ describe('Safe Info', () => {
   describe('getNonce', async () => {
     it('should return the nonce of a Safe that is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -239,7 +239,7 @@ describe('Safe Info', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: safeAddress,
         contractNetworks
@@ -261,7 +261,7 @@ describe('Safe Info', () => {
   describe('getChainId', async () => {
     it('should return the chainId of a Safe that is not deployed', async () => {
       const { predictedSafe, chainId, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -272,7 +272,7 @@ describe('Safe Info', () => {
     it('should return the chainId of the current network', async () => {
       const { safe, chainId, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: safeAddress,
         contractNetworks
@@ -286,7 +286,7 @@ describe('Safe Info', () => {
       'should fail to return the balance of a Safe <v1.3.0 that is not deployed',
       async () => {
         const { predictedSafe, contractNetworks, provider } = await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -304,7 +304,7 @@ describe('Safe Info', () => {
       async () => {
         const { predictedSafe, accounts, contractNetworks, provider } = await setupTests()
         const [account1] = accounts
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -328,7 +328,7 @@ describe('Safe Info', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         signer: account1.address,
         safeAddress,

--- a/packages/protocol-kit/tests/e2e/createSafeDeploymentTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createSafeDeploymentTransaction.test.ts
@@ -46,7 +46,7 @@ describe('createSafeDeploymentTransaction', () => {
   itif(safeVersionDeployed == '1.4.1')('should return a Safe deployment transactions', async () => {
     const { contractNetworks, predictedSafe, provider } = await setupTests()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       predictedSafe,
       contractNetworks
@@ -67,7 +67,7 @@ describe('createSafeDeploymentTransaction', () => {
   itif(safeVersionDeployed == '1.3.0')('should return a Safe deployment transactions', async () => {
     const { contractNetworks, predictedSafe, provider } = await setupTests()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       predictedSafe,
       contractNetworks
@@ -88,7 +88,7 @@ describe('createSafeDeploymentTransaction', () => {
   itif(safeVersionDeployed == '1.2.0')('should return a Safe deployment transactions', async () => {
     const { contractNetworks, predictedSafe, provider } = await setupTests()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       predictedSafe,
       contractNetworks
@@ -109,7 +109,7 @@ describe('createSafeDeploymentTransaction', () => {
   itif(safeVersionDeployed == '1.1.1')('should return a Safe deployment transactions', async () => {
     const { contractNetworks, predictedSafe, provider } = await setupTests()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       predictedSafe,
       contractNetworks
@@ -130,7 +130,7 @@ describe('createSafeDeploymentTransaction', () => {
   itif(safeVersionDeployed == '1.0.0')('should return a Safe deployment transactions', async () => {
     const { contractNetworks, predictedSafe, provider } = await setupTests()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       predictedSafe,
       contractNetworks
@@ -151,7 +151,7 @@ describe('createSafeDeploymentTransaction', () => {
   it('should contain the initializer setup call in the deployment data to sets the threshold & owners of the deployed Safe', async () => {
     const { contractNetworks, predictedSafe, chainId, provider } = await setupTests()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       predictedSafe,
       contractNetworks
@@ -183,7 +183,7 @@ describe('createSafeDeploymentTransaction', () => {
       const { contractNetworks, predictedSafe, chainId, provider } = await setupTests()
 
       const safeProvider = new SafeProvider({ provider })
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -206,7 +206,7 @@ describe('createSafeDeploymentTransaction', () => {
       const { contractNetworks, predictedSafe, provider } = await setupTests()
 
       const safeProvider = new SafeProvider({ provider })
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -227,7 +227,7 @@ describe('createSafeDeploymentTransaction', () => {
 
       const customSaltNonce = '123456789'
 
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe: {
           ...predictedSafe,
@@ -257,7 +257,7 @@ describe('createSafeDeploymentTransaction', () => {
     const safe = await getSafeWithOwners([account1.address])
     const safeAddress = await safe.getAddress()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       safeAddress,
       contractNetworks

--- a/packages/protocol-kit/tests/e2e/createTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransaction.test.ts
@@ -61,7 +61,7 @@ describe('Transactions creation', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -88,7 +88,7 @@ describe('Transactions creation', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -116,7 +116,7 @@ describe('Transactions creation', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -145,7 +145,7 @@ describe('Transactions creation', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -172,7 +172,7 @@ describe('Transactions creation', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -201,7 +201,7 @@ describe('Transactions creation', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -228,7 +228,7 @@ describe('Transactions creation', () => {
     it('should create a single transaction with gasPrice=0', async () => {
       const { predictedSafe, accounts, contractNetworks, provider } = await setupTests()
       const [, account2] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -251,7 +251,7 @@ describe('Transactions creation', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -281,7 +281,7 @@ describe('Transactions creation', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -311,7 +311,7 @@ describe('Transactions creation', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -332,7 +332,7 @@ describe('Transactions creation', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -360,7 +360,7 @@ describe('Transactions creation', () => {
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -374,7 +374,7 @@ describe('Transactions creation', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -408,7 +408,7 @@ describe('Transactions creation', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -451,7 +451,7 @@ describe('Transactions creation', () => {
       async () => {
         const { safe, predictedSafe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks

--- a/packages/protocol-kit/tests/e2e/createTransactionBatch.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransactionBatch.test.ts
@@ -47,7 +47,7 @@ describe('createTransactionBatch', () => {
     const provider = getEip1193Provider()
     const safeAddress = await safe.getAddress()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       safeAddress,
       contractNetworks

--- a/packages/protocol-kit/tests/e2e/eip1271-contract-signatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/eip1271-contract-signatures.test.ts
@@ -80,7 +80,7 @@ describe('The EIP1271 implementation', () => {
         // Create adapters and the protocol kit instance
         const [account1, account2, account3, account4, account5] = accounts
 
-        let protocolKit = await Safe.create({
+        let protocolKit = await Safe.init({
           provider: provider,
           safeAddress,
           contractNetworks
@@ -232,7 +232,7 @@ describe('The EIP1271 implementation', () => {
         // Create adapters and the protocol kit instance
         const [account1, account2, account3, account4, account5] = accounts
 
-        let protocolKit = await Safe.create({
+        let protocolKit = await Safe.init({
           provider,
           safeAddress,
           contractNetworks

--- a/packages/protocol-kit/tests/e2e/eip1271.test.ts
+++ b/packages/protocol-kit/tests/e2e/eip1271.test.ts
@@ -66,14 +66,14 @@ describe('The EIP1271 implementation', () => {
       )
       const safeAddress = await safe.getAddress()
 
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
       })
 
       // Adapter and Safe instance for owner 2
-      const safeSdk2 = await Safe.create({
+      const safeSdk2 = await Safe.init({
         provider,
         signer: account2.address,
         safeAddress,
@@ -81,7 +81,7 @@ describe('The EIP1271 implementation', () => {
       })
 
       // Adapter and Safe instance for owner 3
-      const safeSdk3 = await Safe.create({
+      const safeSdk3 = await Safe.init({
         provider,
         signer: account1.address,
         safeAddress: signerSafeAddress,

--- a/packages/protocol-kit/tests/e2e/erc-20.test.ts
+++ b/packages/protocol-kit/tests/e2e/erc-20.test.ts
@@ -56,7 +56,7 @@ describe('ERC-20 utils', () => {
         // mock decimals() call
         callStub = sinon.stub(SafeProvider.prototype, 'call').returns(Promise.resolve('0x12'))
 
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -77,7 +77,7 @@ describe('ERC-20 utils', () => {
         // mock decimals() call
         callStub = sinon.stub(SafeProvider.prototype, 'call').returns(Promise.resolve('0x06'))
 
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -98,7 +98,7 @@ describe('ERC-20 utils', () => {
         // mock decimals() call
         callStub = sinon.stub(SafeProvider.prototype, 'call').returns(Promise.resolve('0x'))
 
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -118,7 +118,7 @@ describe('ERC-20 utils', () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
 
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -142,7 +142,7 @@ describe('ERC-20 utils', () => {
         // mock decimals() call
         callStub = sinon.stub(SafeProvider.prototype, 'call').returns(Promise.resolve('0x12'))
 
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -166,7 +166,7 @@ describe('ERC-20 utils', () => {
         // mock decimals() call
         callStub = sinon.stub(SafeProvider.prototype, 'call').returns(Promise.resolve('0x06'))
 
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks

--- a/packages/protocol-kit/tests/e2e/execution.test.ts
+++ b/packages/protocol-kit/tests/e2e/execution.test.ts
@@ -36,7 +36,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -72,7 +72,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -101,7 +101,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -124,7 +124,7 @@ describe('Transactions execution', () => {
       const [account1, account2, account3] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address, account3.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -153,7 +153,7 @@ describe('Transactions execution', () => {
       const [account1, account2, account3] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address, account3.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -174,7 +174,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -223,7 +223,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -249,7 +249,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -285,7 +285,7 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -338,7 +338,7 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -399,7 +399,7 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -466,7 +466,7 @@ describe('Transactions execution', () => {
           to: safeAddress,
           value: 1_000_000_000_000_000_000n // 1 ETH
         })
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -525,7 +525,7 @@ describe('Transactions execution', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [, account2, account3] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -566,7 +566,7 @@ describe('Transactions execution', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -596,7 +596,7 @@ describe('Transactions execution', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -630,7 +630,7 @@ describe('Transactions execution', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -666,7 +666,7 @@ describe('Transactions execution', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -699,7 +699,7 @@ describe('Transactions execution', () => {
         const [account1, account2] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk1 = await Safe.create({
+        const safeSdk1 = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -733,7 +733,7 @@ describe('Transactions execution', () => {
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -763,7 +763,7 @@ describe('Transactions execution', () => {
       const [account1, account2, account3] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address, account3.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -811,7 +811,7 @@ describe('Transactions execution', () => {
       const [account1, account2, account3] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address, account3.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/fallbackHandlerManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/fallbackHandlerManager.test.ts
@@ -53,7 +53,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -69,7 +69,7 @@ describe('Fallback handler manager', () => {
 
     itif(safeVersionDeployed >= '1.1.1')('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -80,7 +80,7 @@ describe('Fallback handler manager', () => {
     itif(safeVersionDeployed >= '1.1.1')('should return the enabled fallback handler', async () => {
       const { safe, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -106,7 +106,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { predictedSafe, contractNetworks, defaultCallbackHandler, provider } =
           await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -125,7 +125,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { predictedSafe, contractNetworks, defaultCallbackHandler, provider } =
           await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -140,7 +140,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { safe, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -157,7 +157,7 @@ describe('Fallback handler manager', () => {
     itif(safeVersionDeployed >= '1.1.1')('should fail if address is invalid', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -171,7 +171,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -184,7 +184,7 @@ describe('Fallback handler manager', () => {
     itif(safeVersionDeployed >= '1.1.1')('should fail if address is already enabled', async () => {
       const { safe, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -203,7 +203,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { safe, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -232,7 +232,7 @@ describe('Fallback handler manager', () => {
     itif(safeVersionDeployed >= '1.1.1')('should enable a fallback handler', async () => {
       const { safe, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -257,7 +257,7 @@ describe('Fallback handler manager', () => {
       'should fail if the Safe with version <v1.3.0 is not deployed',
       async () => {
         const { predictedSafe, contractNetworks, provider } = await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -276,7 +276,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { predictedSafe, contractNetworks, defaultCallbackHandler, provider } =
           await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -293,7 +293,7 @@ describe('Fallback handler manager', () => {
         const [account1] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -312,7 +312,7 @@ describe('Fallback handler manager', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -335,7 +335,7 @@ describe('Fallback handler manager', () => {
         const [account1] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -372,7 +372,7 @@ describe('Fallback handler manager', () => {
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/getEncodedTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/getEncodedTransaction.test.ts
@@ -30,7 +30,7 @@ describe('getEncodedTransaction', () => {
     const safe = await getSafeWithOwners([account1.address])
     const safeAddress = await safe.getAddress()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       safeAddress,
       contractNetworks
@@ -60,7 +60,7 @@ describe('getEncodedTransaction', () => {
     const safe = await getSafeWithOwners([account1.address])
     const safeAddress = await safe.getAddress()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       safeAddress,
       contractNetworks
@@ -90,7 +90,7 @@ describe('getEncodedTransaction', () => {
     const safe = await getSafeWithOwners([account1.address])
     const safeAddress = await safe.getAddress()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       safeAddress,
       contractNetworks

--- a/packages/protocol-kit/tests/e2e/guardManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/guardManager.test.ts
@@ -48,7 +48,7 @@ describe('Safe guard manager', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -64,7 +64,7 @@ describe('Safe guard manager', () => {
 
     itif(safeVersionDeployed >= '1.3.0')('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -77,7 +77,7 @@ describe('Safe guard manager', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -89,7 +89,7 @@ describe('Safe guard manager', () => {
     itif(safeVersionDeployed >= '1.3.0')('should return the enabled Safe guard', async () => {
       const { safe, contractNetworks, debugTransactionGuard, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -108,7 +108,7 @@ describe('Safe guard manager', () => {
       async () => {
         const { safe, contractNetworks, debugTransactionGuard, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -126,7 +126,7 @@ describe('Safe guard manager', () => {
       const { predictedSafe, debugTransactionGuard, contractNetworks, provider } =
         await setupTests()
 
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -138,7 +138,7 @@ describe('Safe guard manager', () => {
     itif(safeVersionDeployed >= '1.3.0')('should fail if address is invalid', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -153,7 +153,7 @@ describe('Safe guard manager', () => {
         const { safe, contractNetworks, provider } = await setupTests()
 
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -167,7 +167,7 @@ describe('Safe guard manager', () => {
       const { safe, contractNetworks, debugTransactionGuard, provider } = await setupTests()
 
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -185,7 +185,7 @@ describe('Safe guard manager', () => {
         const { safe, contractNetworks, debugTransactionGuard, provider } = await setupTests()
 
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -215,7 +215,7 @@ describe('Safe guard manager', () => {
       const { safe, contractNetworks, debugTransactionGuard, provider } = await setupTests()
 
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -236,7 +236,7 @@ describe('Safe guard manager', () => {
         const [account1] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -253,7 +253,7 @@ describe('Safe guard manager', () => {
     itif(safeVersionDeployed >= '1.3.0')('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
 
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -266,7 +266,7 @@ describe('Safe guard manager', () => {
       const { safe, contractNetworks, provider } = await setupTests()
 
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -282,7 +282,7 @@ describe('Safe guard manager', () => {
         const [account1] = accounts
         const safe = await getSafeWithOwners([account1.address])
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -314,7 +314,7 @@ describe('Safe guard manager', () => {
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/moduleManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/moduleManager.test.ts
@@ -55,7 +55,7 @@ describe('Safe modules manager', () => {
   describe('getModules', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -67,7 +67,7 @@ describe('Safe modules manager', () => {
       const { safe, dailyLimitModule, socialRecoveryModule, contractNetworks, provider } =
         await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -94,7 +94,7 @@ describe('Safe modules manager', () => {
   describe('getModulesPaginated', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -107,7 +107,7 @@ describe('Safe modules manager', () => {
     it('should return the enabled modules', async () => {
       const { safe, dailyLimitModule, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -140,7 +140,7 @@ describe('Safe modules manager', () => {
       const socialRecoveryAddress = await socialRecoveryModule.getAddress()
       const stateChannelAddress = await stateChannelModule.getAddress()
       const whiteListAddress = await whiteListModule.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -205,7 +205,7 @@ describe('Safe modules manager', () => {
       const socialRecoveryAddress = await socialRecoveryModule.getAddress()
       const stateChannelAddress = await stateChannelModule.getAddress()
       const whiteListAddress = await whiteListModule.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -246,7 +246,7 @@ describe('Safe modules manager', () => {
 
     it('should fail if pageSize is invalid', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -261,7 +261,7 @@ describe('Safe modules manager', () => {
   describe('isModuleEnabled', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, dailyLimitModule, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -273,7 +273,7 @@ describe('Safe modules manager', () => {
     it('should return true if a module is enabled', async () => {
       const { safe, dailyLimitModule, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -289,7 +289,7 @@ describe('Safe modules manager', () => {
   describe('createEnableModuleTx', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, dailyLimitModule, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -301,7 +301,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is invalid', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -313,7 +313,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is equal to sentinel', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -325,7 +325,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is equal to 0x address', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -337,7 +337,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is already enabled', async () => {
       const { safe, dailyLimitModule, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -352,7 +352,7 @@ describe('Safe modules manager', () => {
     it('should build the transaction with the optional props', async () => {
       const { safe, dailyLimitModule, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -377,7 +377,7 @@ describe('Safe modules manager', () => {
     it('should enable a Safe module', async () => {
       const { safe, dailyLimitModule, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -395,7 +395,7 @@ describe('Safe modules manager', () => {
   describe('createDisableModuleTx', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, dailyLimitModule, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -407,7 +407,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is invalid', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -419,7 +419,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is equal to sentinel', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -431,7 +431,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is equal to 0x address', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -443,7 +443,7 @@ describe('Safe modules manager', () => {
     it('should fail if address is not enabled', async () => {
       const { safe, dailyLimitModule, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -457,7 +457,7 @@ describe('Safe modules manager', () => {
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -492,7 +492,7 @@ describe('Safe modules manager', () => {
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -41,7 +41,7 @@ describe('Off-chain signatures', () => {
   describe('signHash', async () => {
     it('should sign a transaction hash with the current signer if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -54,7 +54,7 @@ describe('Off-chain signatures', () => {
     it('should sign a transaction hash with the current signer', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -76,13 +76,13 @@ describe('Off-chain signatures', () => {
       'should fail to sign a transaction if the Safe with version <v1.3.0 is using predicted config',
       async () => {
         const { safe, predictedSafe, contractNetworks, provider } = await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
         })
         const safeAddress = await safe.getAddress()
-        const safeSdkExistingSafe = await Safe.create({
+        const safeSdkExistingSafe = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -108,7 +108,7 @@ describe('Off-chain signatures', () => {
       'should sign a transaction with the current signer if the Safe with version >=v1.3.0 is using predicted config',
       async () => {
         const { safe, predictedSafe, contractNetworks, provider } = await setupTests()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           predictedSafe,
           contractNetworks
@@ -131,7 +131,7 @@ describe('Off-chain signatures', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const account3 = accounts[2]
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         signer: account3.address,
@@ -151,7 +151,7 @@ describe('Off-chain signatures', () => {
     it('should ignore duplicated signatures', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -175,7 +175,7 @@ describe('Off-chain signatures', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress: safeAddress,
           contractNetworks
@@ -197,7 +197,7 @@ describe('Off-chain signatures', () => {
       async () => {
         const { safe, contractNetworks, provider } = await setupTests()
         const safeAddress = await safe.getAddress()
-        const safeSdk = await Safe.create({
+        const safeSdk = await Safe.init({
           provider,
           safeAddress,
           contractNetworks
@@ -218,7 +218,7 @@ describe('Off-chain signatures', () => {
     it('should add the signature of the current signer using eth_signTypedData', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -238,7 +238,7 @@ describe('Off-chain signatures', () => {
     it('should add the signature of the current signer using eth_signTypedData_v3', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -258,7 +258,7 @@ describe('Off-chain signatures', () => {
     it('should add the signature of the current signer using eth_signTypedData_v4', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -278,7 +278,7 @@ describe('Off-chain signatures', () => {
     it('should add the signature of the current signer using eth_signTypedData_v4 by default', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -299,7 +299,7 @@ describe('Off-chain signatures', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/onChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainSignatures.test.ts
@@ -40,7 +40,7 @@ describe('On-chain signatures', () => {
   describe('approveTransactionHash', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -55,7 +55,7 @@ describe('On-chain signatures', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const account3 = accounts[2]
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         signer: account3.address,
         safeAddress,
@@ -77,7 +77,7 @@ describe('On-chain signatures', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -98,7 +98,7 @@ describe('On-chain signatures', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress,
         contractNetworks
@@ -123,7 +123,7 @@ describe('On-chain signatures', () => {
   describe('getOwnersWhoApprovedTx', async () => {
     it('should fail if Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -137,7 +137,7 @@ describe('On-chain signatures', () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [, account2] = accounts
       const safeAddress = await safe.getAddress()
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress: safeAddress,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/ownerManager.test.ts
+++ b/packages/protocol-kit/tests/e2e/ownerManager.test.ts
@@ -47,7 +47,7 @@ describe('Safe owners manager', () => {
   describe('getOwners', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -59,7 +59,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -75,7 +75,7 @@ describe('Safe owners manager', () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -87,7 +87,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -100,7 +100,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -114,7 +114,7 @@ describe('Safe owners manager', () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, accounts, contractNetworks, provider } = await setupTests()
       const [, account2] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -127,7 +127,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -140,7 +140,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -153,7 +153,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -166,7 +166,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -179,7 +179,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -198,7 +198,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -211,7 +211,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -237,7 +237,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -261,7 +261,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -288,7 +288,7 @@ describe('Safe owners manager', () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, accounts, contractNetworks, provider } = await setupTests()
       const [, account2] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -299,7 +299,7 @@ describe('Safe owners manager', () => {
 
     it('should fail if address is invalid', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -310,7 +310,7 @@ describe('Safe owners manager', () => {
 
     it('should fail if address is equal to sentinel', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -321,7 +321,7 @@ describe('Safe owners manager', () => {
 
     it('should fail if address is equal to 0x address', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -333,7 +333,7 @@ describe('Safe owners manager', () => {
     it('should fail if address is not an owner', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [, , , account4] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -345,7 +345,7 @@ describe('Safe owners manager', () => {
     it('should fail if the threshold is bigger than the number of owners', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -363,7 +363,7 @@ describe('Safe owners manager', () => {
     it('should fail if the threshold is not bigger than 0', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -375,7 +375,7 @@ describe('Safe owners manager', () => {
     it('should build the transaction with the optional props', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -400,7 +400,7 @@ describe('Safe owners manager', () => {
     it('should remove the first owner of a Safe and decrease the threshold', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2, account3] = accounts
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -433,7 +433,7 @@ describe('Safe owners manager', () => {
     it('should remove any owner of a Safe and decrease the threshold', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2, account3] = accounts
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -467,7 +467,7 @@ describe('Safe owners manager', () => {
     it('should remove an owner and update the threshold', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2, account3] = accounts
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -504,7 +504,7 @@ describe('Safe owners manager', () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -520,7 +520,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -536,7 +536,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -552,7 +552,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -568,7 +568,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -584,7 +584,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -600,7 +600,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -616,7 +616,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2, , account4] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -632,7 +632,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -648,7 +648,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -677,7 +677,7 @@ describe('Safe owners manager', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address])
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -699,7 +699,7 @@ describe('Safe owners manager', () => {
     it('should replace any owner of a Safe', async () => {
       const { safe, accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2, account3, account4] = accounts
-      const safeSdk1 = await Safe.create({
+      const safeSdk1 = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/safeFactory.test.ts
+++ b/packages/protocol-kit/tests/e2e/safeFactory.test.ts
@@ -49,9 +49,7 @@ describe('SafeProxyFactory', () => {
   describe('create', async () => {
     it('should fail if the current network is not a default network and no contractNetworks is provided', async () => {
       const { provider } = await setupTests()
-      chai
-        .expect(SafeFactory.create({ provider }))
-        .rejectedWith('Invalid SafeProxyFactory contract')
+      chai.expect(SafeFactory.init({ provider })).rejectedWith('Invalid SafeProxyFactory contract')
     })
 
     it('should fail if the contractNetworks provided are not deployed', async () => {
@@ -77,14 +75,14 @@ describe('SafeProxyFactory', () => {
         }
       }
       chai
-        .expect(SafeFactory.create({ provider, contractNetworks }))
+        .expect(SafeFactory.init({ provider, contractNetworks }))
         .rejectedWith('SafeProxyFactory contract is not deployed on the current network')
     })
 
     it('should instantiate the SafeProxyFactory', async () => {
       const { contractNetworks, provider } = await setupTests()
       const safeProvider = new SafeProvider({ provider })
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const networkId = await safeProvider.getChainId()
       chai
         .expect(await safeFactory.getAddress())
@@ -96,7 +94,7 @@ describe('SafeProxyFactory', () => {
     it('should return the connected SafeProvider', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1] = accounts
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       chai
         .expect(await safeFactory.getSafeProvider().getSignerAddress())
         .to.be.eq(await account1.signer.getAddress())
@@ -106,7 +104,7 @@ describe('SafeProxyFactory', () => {
   describe('getChainId', async () => {
     it('should return the chainId of the current network', async () => {
       const { chainId, contractNetworks, provider } = await setupTests()
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       chai.expect(await safeFactory.getChainId()).to.be.eq(chainId)
     })
   })
@@ -114,7 +112,7 @@ describe('SafeProxyFactory', () => {
   describe('predictSafeAddress', async () => {
     it('should fail if there are no owners', async () => {
       const { contractNetworks, provider } = await setupTests()
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const owners: string[] = []
       const threshold = 2
       const safeAccountConfig: SafeAccountConfig = { owners, threshold }
@@ -128,7 +126,7 @@ describe('SafeProxyFactory', () => {
     it('should fail if the threshold is lower than 0', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const owners = [account1.address, account2.address]
       const invalidThreshold = 0
       const safeAccountConfig: SafeAccountConfig = { owners, threshold: invalidThreshold }
@@ -142,7 +140,7 @@ describe('SafeProxyFactory', () => {
     it('should fail if the threshold is higher than the threshold', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const owners = [account1.address, account2.address]
       const invalidThreshold = 3
       const safeAccountConfig: SafeAccountConfig = { owners, threshold: invalidThreshold }
@@ -156,7 +154,7 @@ describe('SafeProxyFactory', () => {
     it('should fail if the saltNonce is lower than 0', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks
@@ -174,7 +172,7 @@ describe('SafeProxyFactory', () => {
     it('should predict a new Safe with saltNonce', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks
@@ -200,7 +198,7 @@ describe('SafeProxyFactory', () => {
       async () => {
         const { accounts, contractNetworks, provider } = await setupTests()
         const [account1, account2] = accounts
-        const safeFactory = await SafeFactory.create({
+        const safeFactory = await SafeFactory.init({
           provider,
           safeVersion: safeVersionDeployed,
           contractNetworks
@@ -228,7 +226,7 @@ describe('SafeProxyFactory', () => {
       async () => {
         const { accounts, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
         const [account1, account2] = accounts
-        const safeFactory = await SafeFactory.create({
+        const safeFactory = await SafeFactory.init({
           provider,
           safeVersion: safeVersionDeployed,
           contractNetworks
@@ -258,7 +256,7 @@ describe('SafeProxyFactory', () => {
   describe('deploySafe', async () => {
     it('should fail if there are no owners', async () => {
       const { contractNetworks, provider } = await setupTests()
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const owners: string[] = []
       const threshold = 2
       const safeAccountConfig: SafeAccountConfig = { owners, threshold }
@@ -271,7 +269,7 @@ describe('SafeProxyFactory', () => {
     it('should fail if the threshold is lower than 0', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const owners = [account1.address, account2.address]
       const threshold = 0
       const safeAccountConfig: SafeAccountConfig = { owners, threshold }
@@ -284,7 +282,7 @@ describe('SafeProxyFactory', () => {
     it('should fail if the threshold is higher than the threshold', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+      const safeFactory = await SafeFactory.init({ provider, contractNetworks })
       const owners = [account1.address, account2.address]
       const threshold = 3
       const safeAccountConfig: SafeAccountConfig = { owners, threshold }
@@ -297,7 +295,7 @@ describe('SafeProxyFactory', () => {
     it('should fail if the saltNonce is lower than 0', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks
@@ -317,7 +315,7 @@ describe('SafeProxyFactory', () => {
       async () => {
         const { accounts, contractNetworks, defaultCallbackHandler, provider } = await setupTests()
         const [account1, account2] = accounts
-        const safeFactory = await SafeFactory.create({
+        const safeFactory = await SafeFactory.init({
           provider,
           safeVersion: safeVersionDeployed,
           contractNetworks
@@ -345,7 +343,7 @@ describe('SafeProxyFactory', () => {
       async () => {
         const { accounts, contractNetworks, provider } = await setupTests()
         const [account1, account2] = accounts
-        const safeFactory = await SafeFactory.create({
+        const safeFactory = await SafeFactory.init({
           provider,
           safeVersion: safeVersionDeployed,
           contractNetworks
@@ -366,7 +364,7 @@ describe('SafeProxyFactory', () => {
     it('should deploy a new Safe without saltNonce', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks
@@ -385,7 +383,7 @@ describe('SafeProxyFactory', () => {
     it('should deploy a new Safe with saltNonce', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks
@@ -409,7 +407,7 @@ describe('SafeProxyFactory', () => {
       const callback = (txHash: string) => {
         callbackResult = txHash
       }
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks
@@ -430,7 +428,7 @@ describe('SafeProxyFactory', () => {
       async () => {
         const { accounts, contractNetworks, provider } = await setupTests()
         const [account1, account2] = accounts
-        const safeFactory = await SafeFactory.create({ provider, contractNetworks })
+        const safeFactory = await SafeFactory.init({ provider, contractNetworks })
         const owners = [account1.address, account2.address]
         const threshold = 2
         const safeAccountConfig: SafeAccountConfig = { owners, threshold }
@@ -444,7 +442,7 @@ describe('SafeProxyFactory', () => {
     it('should deploy a specific Safe version', async () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
-      const safeFactory = await SafeFactory.create({
+      const safeFactory = await SafeFactory.init({
         provider,
         safeVersion: safeVersionDeployed,
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/threshold.test.ts
+++ b/packages/protocol-kit/tests/e2e/threshold.test.ts
@@ -43,7 +43,7 @@ describe('Safe Threshold', () => {
   describe('getThreshold', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -53,7 +53,7 @@ describe('Safe Threshold', () => {
 
     it('should return the Safe threshold', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -65,7 +65,7 @@ describe('Safe Threshold', () => {
   describe('createChangeThresholdTx', async () => {
     it('should fail if the Safe is not deployed', async () => {
       const { predictedSafe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -78,7 +78,7 @@ describe('Safe Threshold', () => {
 
     it('should fail if the threshold is bigger than the number of owners', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -93,7 +93,7 @@ describe('Safe Threshold', () => {
 
     it('should fail if the threshold is not bigger than 0', async () => {
       const { safe, contractNetworks, provider } = await setupTests()
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -108,7 +108,7 @@ describe('Safe Threshold', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address], 1)
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks
@@ -136,7 +136,7 @@ describe('Safe Threshold', () => {
       const { accounts, contractNetworks, provider } = await setupTests()
       const [account1, account2] = accounts
       const safe = await getSafeWithOwners([account1.address, account2.address], 1)
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         safeAddress: await safe.getAddress(),
         contractNetworks

--- a/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
+++ b/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
@@ -26,7 +26,7 @@ async function deploySafe(
   contractNetworks: ContractNetworksConfig,
   signerAddress?: string
 ): Promise<Safe> {
-  const safeFactory = await SafeFactory.create({
+  const safeFactory = await SafeFactory.init({
     provider,
     signer: signerAddress,
     safeVersion: safeVersionDeployed,

--- a/packages/protocol-kit/tests/e2e/wrapSafeTransactionIntoDeploymentBatch.test.ts
+++ b/packages/protocol-kit/tests/e2e/wrapSafeTransactionIntoDeploymentBatch.test.ts
@@ -47,7 +47,7 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
     const safe = await getSafeWithOwners([account1.address])
     const safeAddress = await safe.getAddress()
 
-    const safeSdk = await Safe.create({
+    const safeSdk = await Safe.init({
       provider,
       safeAddress,
       contractNetworks
@@ -74,7 +74,7 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
       const { accounts, contractNetworks, predictedSafe, provider } = await setupTests()
       const [, account2] = accounts
 
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -108,7 +108,7 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
       const { accounts, contractNetworks, predictedSafe, provider } = await setupTests()
       const [, account2] = accounts
 
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks
@@ -142,7 +142,7 @@ describe('wrapSafeTransactionIntoDeploymentBatch', () => {
       const { accounts, contractNetworks, predictedSafe, provider } = await setupTests()
       const [, account2] = accounts
 
-      const safeSdk = await Safe.create({
+      const safeSdk = await Safe.init({
         provider,
         predictedSafe,
         contractNetworks

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -182,7 +182,7 @@ describe('Safe4337Pack', () => {
 
     it('should encode the enableModules transaction as deployment data', async () => {
       const encodeFunctionDataSpy = jest.spyOn(constants.INTERFACES, 'encodeFunctionData')
-      const safeCreateSpy = jest.spyOn(Safe, 'create')
+      const safeCreateSpy = jest.spyOn(Safe, 'init')
 
       const safe4337Pack = await createSafe4337Pack({
         options: {
@@ -218,7 +218,7 @@ describe('Safe4337Pack', () => {
 
     it('should encode the enablesModule transaction together with a specific token approval in a multiSend call when trying to use a paymaster', async () => {
       const encodeFunctionDataSpy = jest.spyOn(constants.INTERFACES, 'encodeFunctionData')
-      const safeCreateSpy = jest.spyOn(Safe, 'create')
+      const safeCreateSpy = jest.spyOn(Safe, 'init')
 
       const safe4337Pack = await createSafe4337Pack({
         options: {

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -142,7 +142,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
     // Existing Safe
     if ('safeAddress' in options) {
-      protocolKit = await Safe.create({
+      protocolKit = await Safe.init({
         provider,
         signer,
         safeAddress: options.safeAddress
@@ -220,7 +220,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
         deploymentData = batchData
       }
 
-      protocolKit = await Safe.create({
+      protocolKit = await Safe.init({
         provider,
         signer,
         predictedSafe: {

--- a/playground/api-kit/confirm-transaction.ts
+++ b/playground/api-kit/confirm-transaction.ts
@@ -21,7 +21,7 @@ const config: Config = {
 
 async function main() {
   // Create Safe instance
-  const protocolKit = await Safe.create({
+  const protocolKit = await Safe.init({
     provider: config.RPC_URL,
     signer: config.SIGNER_ADDRESS_PRIVATE_KEY,
     safeAddress: config.SAFE_ADDRESS

--- a/playground/api-kit/execute-transaction.ts
+++ b/playground/api-kit/execute-transaction.ts
@@ -21,7 +21,7 @@ const config: Config = {
 
 async function main() {
   // Create Safe instance
-  const protocolKit = await Safe.create({
+  const protocolKit = await Safe.init({
     provider: config.RPC_URL,
     signer: config.SIGNER_ADDRESS_PRIVATE_KEY,
     safeAddress: config.SAFE_ADDRESS

--- a/playground/api-kit/propose-transaction.ts
+++ b/playground/api-kit/propose-transaction.ts
@@ -20,7 +20,7 @@ const config: Config = {
 
 async function main() {
   // Create Safe instance
-  const protocolKit = await Safe.create({
+  const protocolKit = await Safe.init({
     provider: config.RPC_URL,
     signer: config.SIGNER_ADDRESS_PRIVATE_KEY,
     safeAddress: config.SAFE_ADDRESS

--- a/playground/protocol-kit/create-execute-transaction.ts
+++ b/playground/protocol-kit/create-execute-transaction.ts
@@ -25,7 +25,7 @@ const config: Config = {
 
 async function main() {
   // Create Safe instance
-  const safe = await Safe.create({
+  const safe = await Safe.init({
     provider: config.RPC_URL,
     signer: config.SIGNER_ADDRESS_PRIVATE_KEY,
     safeAddress: config.SAFE_ADDRESS

--- a/playground/protocol-kit/deploy-safe.ts
+++ b/playground/protocol-kit/deploy-safe.ts
@@ -31,7 +31,7 @@ async function main() {
   console.log('safe config: ', config.DEPLOY_SAFE)
 
   // Create SafeFactory instance
-  const safeFactory = await SafeFactory.create({
+  const safeFactory = await SafeFactory.init({
     provider: config.RPC_URL,
     signer: config.DEPLOYER_ADDRESS_PRIVATE_KEY,
     safeVersion

--- a/playground/protocol-kit/validate-signatures.ts
+++ b/playground/protocol-kit/validate-signatures.ts
@@ -26,7 +26,7 @@ const config: Config = {
 
 async function main() {
   // Create safeSdk instances
-  let protocolKit = await Safe.create({
+  let protocolKit = await Safe.init({
     provider: config.RPC_URL,
     signer: config.OWNER1_PRIVATE_KEY,
     safeAddress: config.SAFE_3_3_ADDRESS


### PR DESCRIPTION
## What it solves
We are renaming the `create` methods to `init` as this is confusing for the developers and they use to think that we deploy the Safe when using the `create`

[Related safe-docs PR](https://github.com/safe-global/safe-docs/pull/468)
