### PR TITLE
chore: add new chain 'aleph-zero-network' to network config

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -100,6 +100,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 2020n, shortName: 'pmint' },
   { chainId: 2021n, shortName: 'edg' },
   { chainId: 2221n, shortName: 'tkava' },
+  { chainId: 2039n, shortName: 'aleph-zero-testnet' },
   { chainId: 2222n, shortName: 'kava' },
   { chainId: 2358n, shortName: 'kroma-sepolia' },
   { chainId: 3737n, shortName: 'csb' },


### PR DESCRIPTION
## What it solves
Adds short name for Aleph Zero Testnet:
https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-2039.json

https://github.com/safe-global/safe-deployments/pull/496
1.3.0 release of safe-deployments
