### PR TITLE
fix(protocol-kit): move safe-core-sdk-types from devDependencies to dependencies

### DIFF
--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -53,7 +53,6 @@
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@openzeppelin/contracts": "^2.5.1",
     "@safe-global/safe-contracts-v1.4.1": "npm:@safe-global/safe-contracts@1.4.1",
-    "@safe-global/safe-core-sdk-types": "^5.0.0",
     "@types/chai": "^4.3.16",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.6",
@@ -74,6 +73,7 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.3.3",
+    "@safe-global/safe-core-sdk-types": "^5.0.0",
     "@safe-global/safe-deployments": "^1.36.0",
     "abitype": "^1.0.2",
     "ethereumjs-util": "^7.1.5",


### PR DESCRIPTION
## What it solves
Contract ABIs moved to `safe-core-sdk-types` so the protocol-kit now uses the types lib as a dependency and not only devDependency

## How this PR fixes it
Set `safe-core-sdk-types` as a dependency