### PR TITLE
feat(relay-kit): Remove `rpcUrl`

### DIFF
--- a/packages/api-kit/tests/e2e/addSafeOperation.test.ts
+++ b/packages/api-kit/tests/e2e/addSafeOperation.test.ts
@@ -8,7 +8,6 @@ import SafeApiKit from '@safe-global/api-kit'
 import { Safe4337Pack } from '@safe-global/relay-kit'
 import { generateTransferCallData } from '@safe-global/relay-kit/src/packs/safe-4337/testing-utils/helpers'
 import { RPC_4337_CALLS } from '@safe-global/relay-kit/packs/safe-4337/constants'
-import config from '../utils/config'
 import { getKits } from '../utils/setupKits'
 import { getAddSafeOperationProps } from '@safe-global/api-kit/utils/safeOperation'
 
@@ -67,7 +66,6 @@ describe('addSafeOperation', () => {
       provider: protocolKit.getSafeProvider().provider,
       signer: protocolKit.getSafeProvider().signer,
       options: { safeAddress: SAFE_ADDRESS },
-      rpcUrl: config.JSON_RPC,
       bundlerUrl: BUNDLER_URL,
       paymasterOptions: {
         paymasterTokenAddress: PAYMASTER_TOKEN_ADDRESS,

--- a/packages/relay-kit/src/packs/safe-4337/testing-utils/helpers.ts
+++ b/packages/relay-kit/src/packs/safe-4337/testing-utils/helpers.ts
@@ -28,7 +28,6 @@ export const createSafe4337Pack = async (
       safeAddress: ''
     },
     ...initOptions,
-    rpcUrl: fixtures.RPC_URL,
     bundlerUrl: fixtures.BUNDLER_URL
   })
 

--- a/packages/relay-kit/src/packs/safe-4337/types.ts
+++ b/packages/relay-kit/src/packs/safe-4337/types.ts
@@ -33,7 +33,6 @@ export type Safe4337InitOptions = {
   provider: SafeProviderConfig['provider']
   signer?: SafeProviderConfig['signer']
   bundlerUrl: string
-  rpcUrl: string
   safeModulesVersion?: string
   customContracts?: {
     entryPointAddress?: string
@@ -49,7 +48,6 @@ export type Safe4337Options = {
   bundlerUrl: string
   paymasterOptions?: PaymasterOptions
   bundlerClient: ethers.JsonRpcProvider
-  publicClient: ethers.JsonRpcProvider
   entryPointAddress: string
   safe4337ModuleAddress: string
 }

--- a/packages/relay-kit/src/packs/safe-4337/utils.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils.ts
@@ -29,20 +29,6 @@ export function getEip4337BundlerProvider(bundlerUrl: string): ethers.JsonRpcPro
 }
 
 /**
- * Gets the EIP-1193 provider from the bundler url.
- *
- * @param {string} rpcUrl The RPC URL.
- * @return {Provider} The EIP-1193 provider.
- */
-export function getEip1193Provider(rpcUrl: string): ethers.JsonRpcProvider {
-  const provider = new ethers.JsonRpcProvider(rpcUrl, undefined, {
-    batchMaxCount: 1
-  })
-
-  return provider
-}
-
-/**
  * Signs typed data.
  *
  * @param {SafeUserOperation} safeUserOperation - Safe user operation to sign.

--- a/playground/relay-kit/api-kit-interoperability.ts
+++ b/playground/relay-kit/api-kit-interoperability.ts
@@ -25,7 +25,6 @@ async function main() {
   let safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: OWNER_1_PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     options: {
       owners: [OWNER_1_PRIVATE_KEY, OWNER_2_PRIVATE_KEY],
@@ -57,7 +56,6 @@ async function main() {
     safe4337Pack = await Safe4337Pack.init({
       provider: RPC_URL,
       signer: OWNER_2_PRIVATE_KEY,
-      rpcUrl: RPC_URL,
       bundlerUrl: BUNDLER_URL,
       paymasterOptions: {
         isSponsored: true,

--- a/playground/relay-kit/usdc-transfer-4337-counterfactual.ts
+++ b/playground/relay-kit/usdc-transfer-4337-counterfactual.ts
@@ -31,7 +31,6 @@ async function main() {
   const safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     options: {
       owners: [OWNER_ADDRESS],

--- a/playground/relay-kit/usdc-transfer-4337-erc20-counterfactual.ts
+++ b/playground/relay-kit/usdc-transfer-4337-erc20-counterfactual.ts
@@ -34,7 +34,6 @@ async function main() {
   const safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     paymasterOptions: {
       paymasterTokenAddress: usdcTokenAddress,

--- a/playground/relay-kit/usdc-transfer-4337-erc20.ts
+++ b/playground/relay-kit/usdc-transfer-4337-erc20.ts
@@ -34,7 +34,6 @@ async function main() {
   const safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     paymasterOptions: {
       paymasterTokenAddress: usdcTokenAddress,

--- a/playground/relay-kit/usdc-transfer-4337-sponsored-counterfactual.ts
+++ b/playground/relay-kit/usdc-transfer-4337-sponsored-counterfactual.ts
@@ -40,7 +40,6 @@ async function main() {
   const safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     paymasterOptions: {
       isSponsored: true,

--- a/playground/relay-kit/usdc-transfer-4337-sponsored.ts
+++ b/playground/relay-kit/usdc-transfer-4337-sponsored.ts
@@ -40,7 +40,6 @@ async function main() {
   const safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     paymasterOptions: {
       isSponsored: true,

--- a/playground/relay-kit/usdc-transfer-4337.ts
+++ b/playground/relay-kit/usdc-transfer-4337.ts
@@ -26,7 +26,6 @@ async function main() {
   const safe4337Pack = await Safe4337Pack.init({
     provider: RPC_URL,
     signer: PRIVATE_KEY,
-    rpcUrl: RPC_URL,
     bundlerUrl: BUNDLER_URL,
     options: {
       safeAddress: SAFE_ADDRESS


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-core-sdk/issues/844

## How this PR fixes it
We are removing the `rpcUrl` prop as it is redundant, and the provider should be able to handle this functionality
