### PR TITLE
feat(relay-kit): add dummy signature as a passkey signature

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -61,7 +61,7 @@ const EQ_OR_GT_1_4_1 = '>=1.4.1'
   Deployment commit: https://github.com/safe-global/safe-modules/commit/3853f34f31837e0a0aee47a4452564278f8c62ba
 */
 // FIXME: use the production deployment packages instead of a hardcoded address
-export const SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS = '0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1'
+const SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS = '0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1'
 
 // FIXME: use the production deployment packages instead of a hardcoded address
 // Sepolia only
@@ -381,7 +381,13 @@ export class Safe4337Pack extends RelayKitBasePack<{
     const estimateUserOperationGas = await this.#bundlerClient.send(
       RPC_4337_CALLS.ESTIMATE_USER_OPERATION_GAS,
       [
-        userOperationToHexValues(addDummySignature(safeOperation.toUserOperation(), threshold)),
+        userOperationToHexValues(
+          addDummySignature(
+            safeOperation.toUserOperation(),
+            SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS,
+            threshold
+          )
+        ),
         this.#ENTRYPOINT_ADDRESS
       ]
     )
@@ -410,7 +416,11 @@ export class Safe4337Pack extends RelayKitBasePack<{
       }
 
       const paymasterEstimation = await feeEstimator?.getPaymasterEstimation?.({
-        userOperation: addDummySignature(safeOperation.toUserOperation(), threshold),
+        userOperation: addDummySignature(
+          safeOperation.toUserOperation(),
+          SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS,
+          threshold
+        ),
         paymasterUrl: this.#paymasterOptions.paymasterUrl,
         entryPoint: this.#ENTRYPOINT_ADDRESS,
         sponsorshipPolicyId: this.#paymasterOptions.sponsorshipPolicyId

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -61,7 +61,7 @@ const EQ_OR_GT_1_4_1 = '>=1.4.1'
   Deployment commit: https://github.com/safe-global/safe-modules/commit/3853f34f31837e0a0aee47a4452564278f8c62ba
 */
 // FIXME: use the production deployment packages instead of a hardcoded address
-const SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS = '0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1'
+export const SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS = '0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1'
 
 // FIXME: use the production deployment packages instead of a hardcoded address
 // Sepolia only
@@ -367,6 +367,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
     safeOperation,
     feeEstimator = new PimlicoFeeEstimator()
   }: EstimateFeeProps): Promise<EthSafeOperation> {
+    const threshold = await this.protocolKit.getThreshold()
     const setupEstimationData = await feeEstimator?.setupEstimation?.({
       bundlerUrl: this.#BUNDLER_URL,
       entryPoint: this.#ENTRYPOINT_ADDRESS,
@@ -380,9 +381,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
     const estimateUserOperationGas = await this.#bundlerClient.send(
       RPC_4337_CALLS.ESTIMATE_USER_OPERATION_GAS,
       [
-        userOperationToHexValues(
-          addDummySignature(safeOperation.toUserOperation(), await this.protocolKit.getOwners())
-        ),
+        userOperationToHexValues(addDummySignature(safeOperation.toUserOperation(), threshold)),
         this.#ENTRYPOINT_ADDRESS
       ]
     )
@@ -411,7 +410,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
       }
 
       const paymasterEstimation = await feeEstimator?.getPaymasterEstimation?.({
-        userOperation: safeOperation.toUserOperation(),
+        userOperation: addDummySignature(safeOperation.toUserOperation(), threshold),
         paymasterUrl: this.#paymasterOptions.paymasterUrl,
         entryPoint: this.#ENTRYPOINT_ADDRESS,
         sponsorshipPolicyId: this.#paymasterOptions.sponsorshipPolicyId
@@ -574,6 +573,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
     const safeProvider = this.protocolKit.getSafeProvider()
     const signerAddress = await safeProvider.getSignerAddress()
     const chainId = await safeProvider.getChainId()
+    const isPasskeySigner = await safeProvider.isPasskeySigner()
 
     if (!signerAddress) {
       throw new Error('There is no signer address available to sign the SafeOperation')
@@ -583,13 +583,11 @@ export class Safe4337Pack extends RelayKitBasePack<{
       (owner: string) => signerAddress && owner.toLowerCase() === signerAddress.toLowerCase()
     )
 
-    if (!addressIsOwner) {
+    if (!addressIsOwner && !isPasskeySigner) {
       throw new Error('UserOperations can only be signed by Safe owners')
     }
 
     let signature: SafeSignature
-
-    const isPasskeySigner = await safeProvider.isPasskeySigner()
 
     if (isPasskeySigner) {
       const safeOpHash = calculateSafeUserOperationHash(

--- a/packages/relay-kit/src/packs/safe-4337/utils.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils.ts
@@ -13,6 +13,7 @@ import {
 } from '@safe-global/protocol-kit'
 import { ethers } from 'ethers'
 import { EIP712_SAFE_OPERATION_TYPE, INTERFACES } from './constants'
+import { SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS } from './Safe4337Pack'
 
 /**
  * Gets the EIP-4337 bundler provider.
@@ -121,21 +122,48 @@ export function userOperationToHexValues(userOperation: UserOperation) {
 }
 
 /**
- * This method creates a dummy signature for the SafeOperation based the owners.
+ * Passkey Dummy client data JSON fields. This can be used for gas estimations, as it pads the fields enough
+ * to account for variations in WebAuthn implementations.
+ */
+export const DUMMY_CLIENT_DATA_FIELDS = [
+  `"origin":"http://safe.global"`,
+  `"padding":"This pads the clientDataJSON so that we can leave room for additional implementation specific fields for a more accurate 'preVerificationGas' estimate."`
+].join(',')
+
+/**
+ * Dummy authenticator data. This can be used for gas estimations, as it ensures that the correct
+ * authenticator flags are set.
+ */
+export const DUMMY_AUTHENTICATOR_DATA = new Uint8Array(37)
+// Authenticator data is the concatenation of:
+// - 32 byte SHA-256 hash of the relying party ID
+// - 1 byte for the user verification flag
+// - 4 bytes for the signature count
+// We fill it all with `0xfe` and set the appropriate user verification flag.
+DUMMY_AUTHENTICATOR_DATA.fill(0xfe)
+DUMMY_AUTHENTICATOR_DATA[32] = 0x04
+
+/**
+ * This method creates a dummy signature for the SafeOperation based on the Safe threshold. We assume that all owners are passkeys
  * This is useful for gas estimations
  * @param userOperation - The user operation
- * @param safeOwners - The safe owner addresses
- * @returns The user operation with the dummy signature
+ * @param threshold - The Safe threshold
+ * @returns The user operation with the dummy passkey signature
  */
-export function addDummySignature(
-  userOperation: UserOperation,
-  safeOwners: string[]
-): UserOperation {
+export function addDummySignature(userOperation: UserOperation, threshold: number): UserOperation {
   const signatures = []
 
-  for (const owner of safeOwners) {
-    const dummySignature = `0x000000000000000000000000${owner.slice(2)}000000000000000000000000000000000000000000000000000000000000000001`
-    signatures.push(new EthSafeSignature(owner, dummySignature))
+  for (let i = 0; i < threshold; i++) {
+    const passkeySigner = SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS
+    const isContractSignature = true
+    const passkeySignature = getSignatureBytes({
+      authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+      clientDataFields: DUMMY_CLIENT_DATA_FIELDS,
+      r: BigInt(`0x${'ec'.repeat(32)}`),
+      s: BigInt(`0x${'d5a'.repeat(21)}f`)
+    })
+
+    signatures.push(new EthSafeSignature(passkeySigner, passkeySignature, isContractSignature))
   }
 
   return {
@@ -145,4 +173,52 @@ export function addDummySignature(
       [0, 0, buildSignatureBytes(signatures)]
     )
   }
+}
+
+/**
+ * Encodes the given WebAuthn signature into a string. This computes the ABI-encoded signature parameters:
+ * ```solidity
+ * abi.encode(authenticatorData, clientDataFields, r, s);
+ * ```
+ *
+ * @param authenticatorData - The authenticator data as a Uint8Array.
+ * @param clientDataFields - The client data fields as a string.
+ * @param r - The value of r as a bigint.
+ * @param s - The value of s as a bigint.
+ * @returns The encoded string.
+ */
+export function getSignatureBytes({
+  authenticatorData,
+  clientDataFields,
+  r,
+  s
+}: {
+  authenticatorData: Uint8Array
+  clientDataFields: string
+  r: bigint
+  s: bigint
+}): string {
+  // Helper functions
+  // Convert a number to a 64-byte hex string with padded upto Hex string with 32 bytes
+  const encodeUint256 = (x: bigint | number) => x.toString(16).padStart(64, '0')
+  // Calculate the byte size of the dynamic data along with the length parameter alligned to 32 bytes
+  const byteSize = (data: Uint8Array) => 32 * (Math.ceil(data.length / 32) + 1) // +1 is for the length parameter
+  // Encode dynamic data padded with zeros if necessary in 32 bytes chunks
+  const encodeBytes = (data: Uint8Array) =>
+    `${encodeUint256(data.length)}${ethers.hexlify(data).slice(2)}`.padEnd(byteSize(data) * 2, '0')
+
+  // authenticatorData starts after the first four words.
+  const authenticatorDataOffset = 32 * 4
+  // clientDataFields starts immediately after the authenticator data.
+  const clientDataFieldsOffset = authenticatorDataOffset + byteSize(authenticatorData)
+
+  return (
+    '0x' +
+    encodeUint256(authenticatorDataOffset) +
+    encodeUint256(clientDataFieldsOffset) +
+    encodeUint256(r) +
+    encodeUint256(s) +
+    encodeBytes(authenticatorData) +
+    encodeBytes(new TextEncoder().encode(clientDataFields))
+  )
 }


### PR DESCRIPTION
## What it solves
Resolves #849 

## How this PR fixes it

Passkeys + 4337 gas estimation is not working as expected when using sponsored transactions. We add a dummy passkey signature to get a valid `verificationGasLimit` estimation.

We assume that all owners are passkeys.
