### PR TITLE
feat: add short name for zircuit-testnet

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -150,6 +150,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 44787n, shortName: 'alfa' },
   { chainId: 45000n, shortName: 'autobahnnetwork' },
   { chainId: 47805n, shortName: 'rei' },
+  { chainId: 48899n, shortName: 'zircuit-tesnet' },
   { chainId: 54211n, shortName: 'islmt' },
   { chainId: 56288n, shortName: 'boba-bnb' },
   { chainId: 57000n, shortName: 'tsys-rollux' },


### PR DESCRIPTION
## What it solves
Adds short name for Zircuit Testnet:
https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-48899.json

https://github.com/safe-global/safe-deployments/pull/640
1.3.0 release of safe-deployments
