### PR TITLE
feat: add short name for open-campus-codex

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -174,6 +174,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 534352n, shortName: 'scr' },
   { chainId: 534353n, shortName: 'scr-alpha' },
   { chainId: 622277n, shortName: 'rth' },
+  { chainId: 656476n, shortName: 'open-campus-codex' },
   { chainId: 713715n, shortName: 'sei-devnet' },
   { chainId: 7777777n, shortName: 'zora' },
   { chainId: 11155111n, shortName: 'sep' },


### PR DESCRIPTION
## What it solves
Adds short name for Open Campus Codex:
https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-656476.json

https://github.com/safe-global/safe-deployments/pull/650
1.3.0 release of safe-deployments
