### PR TITLE
fix(api-kit): update delegate address type

### DIFF
--- a/packages/api-kit/src/utils/signDelegate.ts
+++ b/packages/api-kit/src/utils/signDelegate.ts
@@ -21,7 +21,7 @@ export async function signDelegate(signer: Signer, delegateAddress: string, chai
 
   const types = {
     Delegate: [
-      { name: 'delegateAddress', type: 'bytes32' },
+      { name: 'delegateAddress', type: 'address' },
       { name: 'totp', type: 'uint256' }
     ]
   }

--- a/packages/api-kit/src/utils/signDelegate.ts
+++ b/packages/api-kit/src/utils/signDelegate.ts
@@ -1,17 +1,5 @@
 import { Signer } from 'ethers'
 
-// TODO: remove this function in favor of viem#pad
-function padHex(
-  hex: string,
-  { dir = 'left', size = 32 }: { dir?: string; size?: number } = {}
-): string {
-  if (size === null) return hex
-  const result = hex.replace('0x', '')
-  if (result.length > size * 2) throw new Error(`Size (${result.length}) exceeds padding size.`)
-
-  return `0x${result[dir === 'right' ? 'padEnd' : 'padStart'](size * 2, '0')}`
-}
-
 export async function signDelegate(signer: Signer, delegateAddress: string, chainId: bigint) {
   const domain = {
     name: 'Safe Transaction Service',
@@ -27,7 +15,6 @@ export async function signDelegate(signer: Signer, delegateAddress: string, chai
   }
 
   const totp = Math.floor(Date.now() / 1000 / 3600)
-  const paddedAddress = padHex(delegateAddress, { size: 32, dir: 'right' })
 
-  return await signer.signTypedData(domain, types, { delegateAddress: paddedAddress, totp })
+  return signer.signTypedData(domain, types, { delegateAddress, totp })
 }


### PR DESCRIPTION
## What it solves
The API team changed the EIP-712 type for the delegate address int his PR https://github.com/safe-global/safe-transaction-service/pull/2089/files

## How this PR fixes it
Update the delegate address type in the signDelegate message.