### PR TITLE
Add hashSafeOperation to Safe4337Pack

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -746,7 +746,6 @@ describe('Safe4337Pack', () => {
     })
 
     const safeOpHash = await safe4337Pack.hashSafeOperation(safeOperation)
-
-    expect(safeOpHash).toContain('ProvideExpectedHash')
+    expect(safeOpHash).toBe('0xb80f1998d7f72a3ee4c27d2db6b308d3744d15ad84d49840978f0d8fd39d82ab')
   })
 })

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -12,6 +12,7 @@ import * as constants from './constants'
 import * as fixtures from './testing-utils/fixtures'
 import { createSafe4337Pack, generateTransferCallData } from './testing-utils/helpers'
 import * as utils from './utils'
+import { ZERO_ADDRESS } from '@safe-global/relay-kit/constants'
 
 dotenv.config()
 
@@ -732,5 +733,20 @@ describe('Safe4337Pack', () => {
     const supportedEntryPoints = await safe4337Pack.getSupportedEntryPoints()
 
     expect(supportedEntryPoints).toContain('0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789')
+  })
+
+  it('should evalute the expected SafeOpHash', async () => {
+    const safe4337Pack = await createSafe4337Pack({
+      options: {
+        safeAddress: fixtures.SAFE_ADDRESS_v1_4_1
+      }
+    })
+    const safeOperation = await safe4337Pack.createTransaction({
+      transactions: [{ to: ZERO_ADDRESS, value: '1', data: '0x27' }]
+    })
+
+    const safeOpHash = await safe4337Pack.hashSafeOperation(safeOperation)
+
+    expect(safeOpHash).toContain('ProvideExpectedHash')
   })
 })

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -540,12 +540,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
         this.#SAFE_4337_MODULE_ADDRESS
       )
     } else {
-      const chainId = await this.protocolKit.getSafeProvider().getChainId()
-      const safeOpHash = calculateSafeUserOperationHash(
-        safeOp.data,
-        chainId,
-        this.#SAFE_4337_MODULE_ADDRESS
-      )
+      const safeOpHash = await this.hashSafeOperation(safeOp)
 
       signature = await this.protocolKit.signHash(safeOpHash)
     }
@@ -675,5 +670,16 @@ export class Safe4337Pack extends RelayKitBasePack<{
       transaction.data,
       transaction.operation || OperationType.Call
     ])
+  }
+
+  /**
+   * Evalute the SafeOperationHash of the provided SafeOperation
+   *
+   * @param {EthSafeOperation} safeOp - The Safe Operation data
+   * @return {string} The hash of the safe operation.
+   */
+  async hashSafeOperation(safeOp: EthSafeOperation): Promise<string> {
+    const chainId = await this.protocolKit.getSafeProvider().getChainId()
+    return calculateSafeUserOperationHash(safeOp.data, chainId, this.#SAFE_4337_MODULE_ADDRESS)
   }
 }


### PR DESCRIPTION
Currently the only way to get a SafeOpHash is to provide other details that are already part of the kit:
```ts
  const safeOp = await safeKit.createTransaction({ transactions });
  
  const safeOpHash = calculateSafeUserOperationHash(
    safeOp.data,
    // The following two values are part of the kit anyway!
    BigInt(await safeKit.getChainId()),
    await safeKit.protocolKit.getFallbackHandler(),
  );
```
If this lands, the code would look more like this:

```ts
  const safeOp = await safeKit.createTransaction({ transactions });
  const safeOpHash = await safeKit.hashSafeOperation(safeOp);
```

Note that this has was computed in the class already (which now uses the utility function).

### Alternative options:
1. It would actually be possible to put this method deeper into the `protocolKit` since both chainId and the `fallBackHandler` can be acquired from there.
2. We could also define the method on `SafeUserOperation` instead of `EthSafeOperation` (since only the data field is used to compute this).

### Test Plan

A unit test is added with expected hash.
