### PR TITLE
feat(protocol-kit): add short name for peaq Network

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -119,6 +119,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 2331n, shortName: 'rss3-testnet' },
   { chainId: 2358n, shortName: 'kroma-sepolia' },
   { chainId: 2810n, shortName: 'hmorph' },
+  { chainId: 3338n, shortName: 'PEAQ' },
   { chainId: 3636n, shortName: 'BTNX' },
   { chainId: 3737n, shortName: 'csb' },
   { chainId: 3776n, shortName: 'astrzk' },


### PR DESCRIPTION
## What it solves
Adds short name for peaq Network

Chainlist:
https://chainlist.org/chain/3338

peaq 1.4.1 safe deployment:
https://github.com/safe-global/safe-deployments/pull/709
