### PR TITLE
Refactor: static network in JsonRpcProvider

### DIFF
--- a/packages/protocol-kit/src/SafeProvider.ts
+++ b/packages/protocol-kit/src/SafeProvider.ts
@@ -42,7 +42,7 @@ class SafeProvider {
 
   constructor({ provider, signer }: SafeProviderConfig) {
     if (typeof provider === 'string') {
-      this.#externalProvider = new JsonRpcProvider(provider)
+      this.#externalProvider = new JsonRpcProvider(provider, undefined, { staticNetwork: true })
     } else {
       this.#externalProvider = new BrowserProvider(provider)
     }


### PR DESCRIPTION
## What it solves
The `staticNetwork` in the JSON provider options reduces the number of RPC requests made to detect the current chain (as a Safe Account always exists on just one chain).

See https://docs.ethers.org/v6/api/providers/jsonrpc/#JsonRpcApiProviderOptions