### PR TITLE
feat: add short name for bob-sepolia

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -227,6 +227,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 622277n, shortName: 'rth' },
   { chainId: 713715n, shortName: 'sei-devnet' },
   { chainId: 764984n, shortName: 'lamina1test' },
+  { chainId: 808813n, shortName: 'bob-sepolia' },
   { chainId: 810180n, shortName: 'zklink-nova' },
   { chainId: 7225878n, shortName: 'saakuru' },
   { chainId: 7777777n, shortName: 'zora' },


### PR DESCRIPTION
## What it solves
Resolves: https://github.com/safe-global/safe-deployments/pull/761

## How this PR fixes it
Adds the short name for the BOB Sepolia network