### PR TITLE
feat(sdk-starter-kit): Improvements

### DIFF
--- a/packages/sdk-starter-kit/src/SafeClient.ts
+++ b/packages/sdk-starter-kit/src/SafeClient.ts
@@ -145,18 +145,16 @@ export class SafeClient extends BaseClient {
    * @param extendFunc
    * @returns
    */
-  extend<T>(extendFunc: (client: SafeClient) => Promise<T>): Promise<SafeClient & T>
-  extend<T>(extendFunc: (client: SafeClient) => T): SafeClient & T
+  extend<T>(extendFunc: (client: this) => Promise<T>): Promise<this & T>
+  extend<T>(extendFunc: (client: this) => T): this & T
 
-  extend<T>(
-    extendFunc: (client: SafeClient) => T | Promise<T>
-  ): (SafeClient & T) | Promise<SafeClient & T> {
+  extend<T>(extendFunc: (client: this) => T | Promise<T>): (this & T) | Promise<this & T> {
     const result = extendFunc(this)
 
     if (result instanceof Promise) {
-      return result.then((extensions) => Object.assign(this, extensions) as SafeClient & T)
+      return result.then((extensions) => Object.assign(this, extensions) as this & T)
     } else {
-      return Object.assign(this, result) as SafeClient & T
+      return Object.assign(this, result) as this & T
     }
   }
 

--- a/packages/sdk-starter-kit/src/index.test.ts
+++ b/packages/sdk-starter-kit/src/index.test.ts
@@ -1,0 +1,40 @@
+import { createSafeClient, offChainMessages, onChainMessages } from './index'
+
+const RPC_URL = 'https://ethereum-sepolia-rpc.publicnode.com'
+const SAFE_ADDRESS = '0x60C4Ab82D06Fd7dFE9517e17736C2Dcc77443EF0'
+const SAFE_OWNERS = [
+  '0x9cCBDE03eDd71074ea9c49e413FA9CDfF16D263B',
+  '0x56e2C102c664De6DfD7315d12c0178b61D16F171'
+]
+
+describe('createSafeClient', () => {
+  it('should create a Safe client instance', async () => {
+    const safeClient = await createSafeClient({
+      provider: RPC_URL,
+      safeAddress: SAFE_ADDRESS
+    })
+
+    const safeAddress = await safeClient.getAddress()
+    const owners = await safeClient.getOwners()
+    const threshold = await safeClient.getThreshold()
+
+    expect(safeAddress).toBe('0x60C4Ab82D06Fd7dFE9517e17736C2Dcc77443EF0')
+    expect(owners).toStrictEqual(SAFE_OWNERS)
+    expect(threshold).toBe(1)
+  })
+
+  it('should allow to extend the client several times and accumulating methods', async () => {
+    const safeClient1 = await createSafeClient({
+      provider: RPC_URL,
+      safeAddress: SAFE_ADDRESS
+    })
+
+    const safeClient2 = safeClient1.extend(offChainMessages())
+    const safeClient3 = safeClient2.extend(onChainMessages())
+
+    expect(safeClient3).toBeDefined()
+    expect(safeClient3.send).toBeDefined()
+    expect(safeClient3.sendOnChainMessage).toBeDefined()
+    expect(safeClient3.sendOffChainMessage).toBeDefined()
+  })
+})

--- a/packages/sdk-starter-kit/src/types.ts
+++ b/packages/sdk-starter-kit/src/types.ts
@@ -58,7 +58,7 @@ export type PredictedSafeConfig = {
 
 export type SdkStarterKitRootConfig = {
   provider: SafeProvider['provider']
-  signer: SafeProvider['signer']
+  signer?: SafeProvider['signer']
 }
 
 export type SdkStarterKitConfig = SdkStarterKitRootConfig &


### PR DESCRIPTION
## What it solves
This PR adds several improvements to the `sdk-starter-kit`.

- Make the `signer` parameter optional, as sometimes you may want to use the SafeClient in read-only mode. This is the same behavior that we have at the [protocol-kit level](https://github.com/safe-global/safe-core-sdk/blob/4f4e4f87e894f086a36b6ed3e15182f77633e74b/packages/protocol-kit/src/types/safeConfig.ts#L43)

- The `extend` method's definition has been updated to allow nested extends. Previously, the last `extend` call would override the previous ones in the type system, leading to some errors reported by the TypeScript compiler.