### PR TITLE
Bump @safe-global/safe-deployments package version

### DIFF
--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@noble/hashes": "^1.3.3",
     "@safe-global/safe-core-sdk-types": "^5.1.0",
-    "@safe-global/safe-deployments": "^1.37.3",
+    "@safe-global/safe-deployments": "^1.37.8",
     "@safe-global/safe-modules-deployments": "^2.2.1",
     "abitype": "^1.0.2",
     "ethereumjs-util": "^7.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,10 +1796,10 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-contracts/-/safe-contracts-1.4.1-build.0.tgz#5d82e2f3fd8430b4589df992b9ee2c71386082fe"
   integrity sha512-TIpoKJtMqLcLFoid0cvpxo8YTcnRUj95MHvxzwgPbJPRONOckNS6ebgGyBBRDmnpxFh34IBpPUZ7JD+z2Cfbbg==
 
-"@safe-global/safe-deployments@^1.37.3":
-  version "1.37.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.3.tgz#ded9fa6bb04f0e8972c00c481badcf513d590b0b"
-  integrity sha512-EtbiOJVGe697+GcbHtfo75NYpp+hTlIIBqL2ETPLGoQBHoxo9HWbGX/6ZkVxsZv/NN4nKawyMi+MvpUkH9VXGg==
+"@safe-global/safe-deployments@^1.37.8":
+  version "1.37.8"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.8.tgz#5d51a57e4c3a9274ce09d8fe7fbe1265a1aaf4c4"
+  integrity sha512-BT34eqSJ1K+4xJgJVY3/Yxg8TRTEvFppkt4wcirIPGCgR4/j06HptHPyDdmmqTuvih8wi8OpFHi0ncP+cGlXWA==
   dependencies:
     semver "^7.6.2"
 


### PR DESCRIPTION
## What it solves

Fixes: https://github.com/safe-global/safe-core-sdk/issues/983

This PR bumps the version of the @safe-global/safe-deployments package. 

This will allow the use of the Safe frontend on the recently added chains (like Q, Snaxchain, etc.)

Currently, even during local installation of https://github.com/safe-global/safe-wallet-web, it forces the `^1.37.3` version, ignoring the `^` symbol