### PR TITLE
fix(protocol-kit): fixed `isL1SafeSingleton` issues and added the `replicate-address` playground

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -282,6 +282,7 @@ class Safe {
       return predictSafeAddress({
         safeProvider: this.#safeProvider,
         chainId,
+        isL1SafeSingleton: this.#contractManager.isL1SafeSingleton,
         customContracts: this.#contractManager.contractNetworks?.[chainId.toString()],
         ...this.#predictedSafe
       })

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -1521,19 +1521,22 @@ class Safe {
 
     const isL1SafeSingleton = this.#contractManager.isL1SafeSingleton
     const customContracts = this.#contractManager.contractNetworks?.[chainId.toString()]
+    const deploymentType = this.#predictedSafe.safeDeploymentConfig?.deploymentType
 
     const safeSingletonContract = await getSafeContract({
       safeProvider,
       safeVersion,
       isL1SafeSingleton,
-      customContracts
+      customContracts,
+      deploymentType
     })
 
     // we use the SafeProxyFactory.sol contract, see: https://github.com/safe-global/safe-contracts/blob/main/contracts/proxies/SafeProxyFactory.sol
     const safeProxyFactoryContract = await getSafeProxyFactoryContract({
       safeProvider,
       safeVersion,
-      customContracts
+      customContracts,
+      deploymentType
     })
 
     // this is the call to the setup method that sets the threshold & owners of the new Safe, see: https://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol#L95

--- a/packages/protocol-kit/src/contracts/BaseContract.ts
+++ b/packages/protocol-kit/src/contracts/BaseContract.ts
@@ -112,17 +112,20 @@ class BaseContract<ContractAbiType extends Abi> {
       return undefined
     }
 
-    if (typeof networkAddresses === 'string') {
-      return networkAddresses
-    }
-
     if (deploymentType) {
       const customDeploymentTypeAddress = deployment.deployments[deploymentType]?.address
 
-      return (
-        networkAddresses.find((address) => address === customDeploymentTypeAddress) ??
-        networkAddresses[0]
-      )
+      if (typeof networkAddresses === 'string') {
+        return networkAddresses === customDeploymentTypeAddress
+          ? customDeploymentTypeAddress
+          : undefined
+      }
+
+      return networkAddresses.find((address) => address === customDeploymentTypeAddress)
+    }
+
+    if (typeof networkAddresses === 'string') {
+      return networkAddresses
     }
 
     return networkAddresses[0]

--- a/packages/protocol-kit/src/contracts/BaseContract.ts
+++ b/packages/protocol-kit/src/contracts/BaseContract.ts
@@ -9,7 +9,8 @@ import {
   Chain
 } from 'viem'
 import { estimateContractGas, getTransactionReceipt } from 'viem/actions'
-import { SingletonDeployment } from '@safe-global/safe-deployments'
+import { SingletonDeploymentV2 } from '@safe-global/safe-deployments'
+import { Deployment } from '@safe-global/safe-modules-deployments'
 import { contractName, getContractDeployment } from '@safe-global/protocol-kit/contracts/config'
 import { DeploymentType } from '@safe-global/protocol-kit/types'
 import SafeProvider from '@safe-global/protocol-kit/SafeProvider'
@@ -105,14 +106,18 @@ class BaseContract<ContractAbiType extends Abi> {
 
   #resolveAddress(
     networkAddresses: string | string[] | undefined,
-    deployment: SingletonDeployment,
+    deployment: SingletonDeploymentV2 | Deployment | undefined,
     deploymentType?: DeploymentType
   ): string | undefined {
+    // If there are no addresses for the given chainId we return undefined
     if (!networkAddresses) {
       return undefined
     }
 
-    if (deploymentType) {
+    // If a custom deployment type is selected, we check that type is available in the given chain
+    // We ensure that we receive a SingletonDeploymentV2 object for this check,
+    // otherwise we continue with the next logic (`@safe-global/safe-module-deployments` is not having this property.)
+    if (deploymentType && deployment && 'deployments' in deployment) {
       const customDeploymentTypeAddress = deployment.deployments[deploymentType]?.address
 
       if (typeof networkAddresses === 'string') {
@@ -124,10 +129,12 @@ class BaseContract<ContractAbiType extends Abi> {
       return networkAddresses.find((address) => address === customDeploymentTypeAddress)
     }
 
+    // Deployment type is not selected and there is only one address for this contract in the given chain, we return it
     if (typeof networkAddresses === 'string') {
       return networkAddresses
     }
 
+    // If there are multiple addresses available for this contract, we return the first one.
     return networkAddresses[0]
   }
 

--- a/packages/protocol-kit/src/contracts/Safe/SafeBaseContract.ts
+++ b/packages/protocol-kit/src/contracts/Safe/SafeBaseContract.ts
@@ -46,15 +46,13 @@ abstract class SafeBaseContract<
     safeProvider: SafeProvider,
     defaultAbi: SafeContractAbiType,
     safeVersion: SafeVersion,
-    isL1SafeSingleton = false,
+    isL1SafeSingleton = safeDeploymentsL1ChainIds.includes(chainId),
     customContractAddress?: string,
     customContractAbi?: SafeContractAbiType,
     deploymentType?: DeploymentType
   ) {
     const isL1Contract =
-      safeDeploymentsL1ChainIds.includes(chainId) ||
-      isL1SafeSingleton ||
-      !hasSafeFeature(SAFE_FEATURES.SAFE_L2_CONTRACTS, safeVersion)
+      isL1SafeSingleton || !hasSafeFeature(SAFE_FEATURES.SAFE_L2_CONTRACTS, safeVersion)
 
     const contractName = isL1Contract ? 'safeSingletonVersion' : 'safeSingletonL2Version'
 

--- a/packages/protocol-kit/src/contracts/Safe/v1.0.0/SafeContract_v1_0_0.ts
+++ b/packages/protocol-kit/src/contracts/Safe/v1.0.0/SafeContract_v1_0_0.ts
@@ -42,7 +42,7 @@ class SafeContract_v1_0_0
   constructor(
     chainId: bigint,
     safeProvider: SafeProvider,
-    isL1SafeSingleton = false,
+    isL1SafeSingleton?: boolean,
     customContractAddress?: string,
     customContractAbi?: SafeContract_v1_0_0_Abi,
     deploymentType?: DeploymentType

--- a/packages/protocol-kit/src/contracts/Safe/v1.1.1/SafeContract_v1_1_1.ts
+++ b/packages/protocol-kit/src/contracts/Safe/v1.1.1/SafeContract_v1_1_1.ts
@@ -41,7 +41,7 @@ class SafeContract_v1_1_1
   constructor(
     chainId: bigint,
     safeProvider: SafeProvider,
-    isL1SafeSingleton = false,
+    isL1SafeSingleton?: boolean,
     customContractAddress?: string,
     customContractAbi?: SafeContract_v1_1_1_Abi,
     deploymentType?: DeploymentType

--- a/packages/protocol-kit/src/contracts/Safe/v1.2.0/SafeContract_v1_2_0.ts
+++ b/packages/protocol-kit/src/contracts/Safe/v1.2.0/SafeContract_v1_2_0.ts
@@ -40,7 +40,7 @@ class SafeContract_v1_2_0
   constructor(
     chainId: bigint,
     safeProvider: SafeProvider,
-    isL1SafeSingleton = false,
+    isL1SafeSingleton?: boolean,
     customContractAddress?: string,
     customContractAbi?: SafeContract_v1_2_0_Abi,
     deploymentType?: DeploymentType

--- a/packages/protocol-kit/src/contracts/Safe/v1.3.0/SafeContract_v1_3_0.ts
+++ b/packages/protocol-kit/src/contracts/Safe/v1.3.0/SafeContract_v1_3_0.ts
@@ -41,7 +41,7 @@ class SafeContract_v1_3_0
   constructor(
     chainId: bigint,
     safeProvider: SafeProvider,
-    isL1SafeSingleton = false,
+    isL1SafeSingleton?: boolean,
     customContractAddress?: string,
     customContractAbi?: SafeContract_v1_3_0_Abi,
     deploymentType?: DeploymentType

--- a/packages/protocol-kit/src/contracts/Safe/v1.4.1/SafeContract_v1_4_1.ts
+++ b/packages/protocol-kit/src/contracts/Safe/v1.4.1/SafeContract_v1_4_1.ts
@@ -41,7 +41,7 @@ class SafeContract_v1_4_1
   constructor(
     chainId: bigint,
     safeProvider: SafeProvider,
-    isL1SafeSingleton = false,
+    isL1SafeSingleton?: boolean,
     customContractAddress?: string,
     customContractAbi?: SafeContract_v1_4_1_Abi,
     deploymentType?: DeploymentType

--- a/packages/protocol-kit/src/contracts/config.ts
+++ b/packages/protocol-kit/src/contracts/config.ts
@@ -118,9 +118,7 @@ export const safeDeploymentsL1ChainIds = [
 
 const contractFunctions: Record<
   contractName,
-  (
-    filter?: DeploymentFilter
-  ) => SingletonDeployment | SingletonDeploymentV2 | undefined | Deployment
+  (filter?: DeploymentFilter) => SingletonDeploymentV2 | undefined | Deployment
 > = {
   safeSingletonVersion: getSafeSingletonDeployments,
   safeSingletonL2Version: getSafeL2SingletonDeployments,
@@ -148,7 +146,7 @@ export function getContractDeployment(
     released: true
   }
 
-  const deployment = contractFunctions[contractName](filters) as SingletonDeployment
+  const deployment = contractFunctions[contractName](filters)
 
   return deployment
 }

--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -254,7 +254,7 @@ export async function getPredictedSafeAddressInitCode({
   chainId,
   safeAccountConfig,
   safeDeploymentConfig = {},
-  isL1SafeSingleton = false,
+  isL1SafeSingleton,
   customContracts
 }: PredictSafeAddressProps): Promise<string> {
   validateSafeAccountConfig(safeAccountConfig)
@@ -314,7 +314,7 @@ export async function predictSafeAddress({
   chainId,
   safeAccountConfig,
   safeDeploymentConfig = {},
-  isL1SafeSingleton = false,
+  isL1SafeSingleton,
   customContracts
 }: PredictSafeAddressProps): Promise<string> {
   validateSafeAccountConfig(safeAccountConfig)

--- a/packages/protocol-kit/src/types/safeProvider.ts
+++ b/packages/protocol-kit/src/types/safeProvider.ts
@@ -43,7 +43,7 @@ export type PasskeyClient = Client<
   WalletActions<Chain | undefined, Account> & PasskeyActions
 >
 
-export type ExternalSigner = WalletClient<Transport, Chain | undefined, Account>
+export type ExternalSigner = WalletClient<Transport, Chain | undefined, Account> | PasskeyClient
 export type ExternalClient = PublicClient | (ExternalSigner & PublicClient)
 
 export type HexAddress = string

--- a/packages/protocol-kit/src/types/safeProvider.ts
+++ b/packages/protocol-kit/src/types/safeProvider.ts
@@ -43,7 +43,7 @@ export type PasskeyClient = Client<
   WalletActions<Chain | undefined, Account> & PasskeyActions
 >
 
-export type ExternalSigner = WalletClient<Transport, Chain | undefined, Account> | PasskeyClient
+export type ExternalSigner = WalletClient<Transport, Chain | undefined, Account>
 export type ExternalClient = PublicClient | (ExternalSigner & PublicClient)
 
 export type HexAddress = string

--- a/playground/config/run.ts
+++ b/playground/config/run.ts
@@ -7,6 +7,7 @@ const playInput = process.argv[2]
 const playgroundProtocolKitPaths = {
   'create-execute-transaction': 'protocol-kit/create-execute-transaction',
   'deploy-safe': 'protocol-kit/deploy-safe',
+  'replicate-address': 'protocol-kit/replicate-address',
   'generate-safe-address': 'protocol-kit/generate-safe-address',
   'validate-signatures': 'protocol-kit/validate-signatures'
 }

--- a/playground/protocol-kit/replicate-address.ts
+++ b/playground/protocol-kit/replicate-address.ts
@@ -1,0 +1,101 @@
+import Safe, { DeploymentType, SafeAccountConfig } from '@safe-global/protocol-kit'
+import { SafeVersion } from '@safe-global/types-kit'
+import {
+  gnosis,
+  mainnet,
+  base,
+  optimism,
+  arbitrum,
+  bsc,
+  polygon,
+  linea,
+  scroll,
+  xLayer,
+  celo,
+  avalanche,
+  blast,
+  mantle,
+  aurora,
+  sepolia
+} from 'viem/chains'
+
+// This file can be used to play around with the Safe Core SDK
+
+// Safe config to be replicated in different chains
+const safeAccountConfig: SafeAccountConfig = {
+  owners: ['0x0Ee26C4481485AC64BfFf2bdCaA21EdAeCEcdCa9'],
+  threshold: 1
+}
+
+// saltNonce used
+const saltNonce = '1234567890987654321'
+
+async function main() {
+  console.log('Safe Account config: ', safeAccountConfig)
+  console.log('saltNonce: ', saltNonce)
+
+  const deploymentTypes: DeploymentType[] = ['canonical'] // 'canonical' or 'eip155'
+  const isL1SafeSingletons = [true, false]
+  const safeVersions: SafeVersion[] = ['1.3.0', '1.4.1']
+
+  const chains = [
+    mainnet,
+    gnosis,
+    polygon,
+    bsc,
+    arbitrum,
+    optimism,
+    base,
+    linea,
+    scroll,
+    xLayer,
+    celo,
+    avalanche,
+    blast,
+    mantle,
+    aurora,
+
+    // tesnets
+    sepolia
+  ]
+
+  for (let i = 0; i < safeVersions.length; i++) {
+    for (let j = 0; j < deploymentTypes.length; j++) {
+      for (let k = 0; k < isL1SafeSingletons.length; k++) {
+        const safeVersion = safeVersions[i]
+        const deploymentType = deploymentTypes[j]
+        const isL1SafeSingleton = isL1SafeSingletons[k]
+
+        console.log(' ')
+        console.log(
+          ` ---------- [Safe v${safeVersion}; ${deploymentType} deployment; ${isL1SafeSingleton ? 'L1' : 'L2'} contract ] ---------- `
+        )
+        console.log(' ')
+
+        for (let l = 0; l < chains.length; l++) {
+          const chain = chains[l]
+          const provider = chain.rpcUrls.default.http[0]
+
+          const protocolKit = await Safe.init({
+            provider,
+            isL1SafeSingleton,
+            predictedSafe: {
+              safeAccountConfig,
+              safeDeploymentConfig: {
+                deploymentType,
+                saltNonce,
+                safeVersion
+              }
+            }
+          })
+
+          const safeAddress = await protocolKit.getAddress()
+
+          console.log(`${safeAddress} --> Safe address in ${chain.name} chain`)
+        }
+      }
+    }
+  }
+}
+
+main()


### PR DESCRIPTION
## What it solves
Resolves #929

Some developers would like to deploy the same Safe address into different chains when using the SDK. While this is possible is not the default behavior of the SDK, and it's also not clear that the SDK is able to manage this situation too.

## How this PR fixes it

- Created a `replicate-address` playground showing this specific example.
- Fixed a bug in the `Safe.getAddress()` method (added `isL1SafeSingleton` param to `predictSafeAddress`)
- if a custom `deploymentType` is set and the address is not present in `safe-deployments` we throw an error in the `BaseContract`.
- Fix issue in `createSafeDeploymentTransaction` (added `deploymentType` param)


### Test

I used the `generate-safe-address`playground to get a Safe address starting with `0x5afe...` pattern:

- Safe Address:  `0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3`
- Safe Owners: `[ '0x0Ee26C4481485AC64BfFf2bdCaA21EdAeCEcdCa9' ]`
- Safe Threshold: `1`
- Safe version: `v1.3.0`
- Deployment addresses: `cannonical`
- `L2` Contact used

Safe saltNonce:  `1124214`



I used the `replicate-address` playground to deploy this Safe in different chains

- `Gnosis chain`: [`0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3`](https://gnosisscan.io/address/0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3)
- `Polygon`: [`0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3`](https://polygonscan.com/address/0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3)
- `Sepolia`: [`0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3`](https://sepolia.etherscan.io/address/0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3)
- `Chaindo chain`: [`0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3`](https://gnosis-chiado.blockscout.com/address/0x5afe088ACE21Ce244c950d9c7A026C6c9Af953e3?tab=contract)


### `replicate-address` playground

![Captura de pantalla 2024-10-14 a las 10 21 56](https://github.com/user-attachments/assets/278ffced-dd0a-4846-80cf-7390b4e116b6)
