### PR TITLE
feat(api-kit): add ordering props to getPendingTransactions

### DIFF
--- a/packages/api-kit/src/types/safeTransactionServiceTypes.ts
+++ b/packages/api-kit/src/types/safeTransactionServiceTypes.ts
@@ -124,6 +124,13 @@ export type ProposeTransactionProps = {
   origin?: string
 }
 
+export type PendingTransactionsOptions = {
+  currentNonce?: number
+  hasConfirmations?: boolean
+  /** Which field to use when ordering the results. It can be: `nonce`, `created`, `modified` (default: `-created`) */
+  ordering?: string
+} & ListOptions
+
 export type SafeMultisigTransactionListResponse = ListResponse<SafeMultisigTransactionResponse>
 
 export type TransferResponse = {

--- a/packages/api-kit/tests/e2e/getPendingTransactions.test.ts
+++ b/packages/api-kit/tests/e2e/getPendingTransactions.test.ts
@@ -48,4 +48,26 @@ describe('getPendingTransactions', () => {
     chai.expect(transactionList.count).to.be.equal(10)
     chai.expect(transactionList.results.length).to.be.equal(10)
   })
+
+  it('should return a maximum of 2 transactions with limit = 2', async () => {
+    const safeAddress = '0xCa2f5A815b642c79FC530B60BC15Aee4eF6252b3' // Safe with pending transaction
+    const transactionList = await safeApiKit.getPendingTransactions(safeAddress, {
+      limit: 2
+    })
+
+    chai.expect(transactionList).to.have.property('count').greaterThan(1)
+    chai.expect(transactionList).to.have.property('results').to.be.an('array')
+    chai.expect(transactionList.results.length).to.be.equal(2)
+  })
+
+  it('should return all pending transactions excluding the first one with offset = 1', async () => {
+    const safeAddress = '0xCa2f5A815b642c79FC530B60BC15Aee4eF6252b3' // Safe with pending transaction
+    const transactionList = await safeApiKit.getPendingTransactions(safeAddress, {
+      offset: 1
+    })
+
+    chai.expect(transactionList).to.have.property('count').greaterThan(1)
+    chai.expect(transactionList).to.have.property('results').to.be.an('array')
+    chai.expect(transactionList.results.length).to.be.lessThanOrEqual(transactionList.count - 1)
+  })
 })

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -512,7 +512,7 @@ describe('Endpoint tests', () => {
     it('getPendingTransactions', async () => {
       const currentNonce = 1
       await chai
-        .expect(safeApiKit.getPendingTransactions(safeAddress, currentNonce))
+        .expect(safeApiKit.getPendingTransactions(safeAddress, { currentNonce }))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${txServiceBaseUrl}/v1/safes/${safeAddress}/multisig-transactions/?executed=false&nonce__gte=${currentNonce}`,
@@ -523,7 +523,7 @@ describe('Endpoint tests', () => {
     it('getPendingTransactions EIP-3770', async () => {
       const currentNonce = 1
       await chai
-        .expect(safeApiKit.getPendingTransactions(eip3770SafeAddress, currentNonce))
+        .expect(safeApiKit.getPendingTransactions(eip3770SafeAddress, { currentNonce }))
         .to.be.eventually.deep.equals({ data: { success: true } })
       chai.expect(fetchData).to.have.been.calledWith({
         url: `${txServiceBaseUrl}/v1/safes/${safeAddress}/multisig-transactions/?executed=false&nonce__gte=${currentNonce}`,

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -51,7 +51,6 @@
   ],
   "homepage": "https://github.com/safe-global/safe-core-sdk#readme",
   "devDependencies": {
-    "@safe-global/safe-passkey": "0.2.0-alpha.1",
     "@safe-global/testing-kit": "^0.1.0",
     "@types/chai": "^4.3.19",
     "@types/chai-as-promised": "^7.1.8",

--- a/packages/testing-kit/package.json
+++ b/packages/testing-kit/package.json
@@ -39,6 +39,7 @@
     "@nomicfoundation/hardhat-viem": "^2.0.4",
     "@openzeppelin/contracts": "^2.5.1",
     "@safe-global/safe-contracts-v1.4.1": "npm:@safe-global/safe-contracts@1.4.1",
+    "@safe-global/safe-passkey": "0.2.0-alpha.1",
     "@safe-global/types-kit": "^1.0.0",
     "@types/semver": "^7.5.8",
     "hardhat": "^2.19.3",


### PR DESCRIPTION
## What it solves
Resolves #1010 

## How this PR fixes it

Adds parameters to filter pending transactions using
 - nonce
 - limit
 - offset
 - has_confirmations
