### PR TITLE
feat: change chain 88 shortname tomo -> vic

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -38,7 +38,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 81n, shortName: 'joc' },
   { chainId: 82n, shortName: 'meter' },
   { chainId: 83n, shortName: 'meter-test' },
-  { chainId: 88n, shortName: 'tomo' },
+  { chainId: 88n, shortName: 'vic' },
   { chainId: 97n, shortName: 'bnbt' },
   { chainId: 100n, shortName: 'gno' },
   { chainId: 106n, shortName: 'vlx' },


### PR DESCRIPTION
## What it solves
- Tomochain has renamed to Viction, so the shortname should reflect that.
- It's updated here: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-88.json

## How this PR fixes it
- Change chain id 88 shortname from "tomo" to "vic"
