### PR TITLE
feat: change chain 88 shortname "tomo" -> "vic"

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -38,7 +38,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 81n, shortName: 'joc' },
   { chainId: 82n, shortName: 'meter' },
   { chainId: 83n, shortName: 'meter-test' },
-  { chainId: 88n, shortName: 'tomo' },
+  { chainId: 88n, shortName: 'vic' },
   { chainId: 97n, shortName: 'bnbt' },
   { chainId: 100n, shortName: 'gno' },
   { chainId: 106n, shortName: 'vlx' },


### PR DESCRIPTION
## What it solves
Resolves #
- Chain ID 88 (formerly Tomochain) has renamed to Viction.

## How this PR fixes it
- Change short name from "tomo" to "vic"
