### PR TITLE
feat(relay-kit): Control errors in `eth_estimateUserOperationGas` calls

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -538,10 +538,17 @@ export class Safe4337Pack extends RelayKitBasePack<{
       validAfter
     })
 
-    return await this.getEstimateFee({
-      safeOperation,
-      feeEstimator
-    })
+    try {
+      const estimateFee = await this.getEstimateFee({
+        safeOperation,
+        feeEstimator
+      })
+
+      return estimateFee
+    } catch (error) {
+      console.error(error)
+      throw new Error('Error estimating gas fees')
+    }
   }
 
   /**


### PR DESCRIPTION
## What it solves

Errors in `eth_estimateUserOperationGas` can happen easily so we are logging and throwing an exception on it