### PR TITLE
feat: add EIP-3779 shortname for nahmii mainnet

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -126,6 +126,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 3737n, shortName: 'csb' },
   { chainId: 3776n, shortName: 'astrzk' },
   { chainId: 4002n, shortName: 'tftm' },
+  { chainId: 4061n, shortName: 'nahmii-mainnet' },
   { chainId: 4062n, shortName: 'nahmii-testnet' },
   { chainId: 4078n, shortName: 'muster' },
   { chainId: 4157n, shortName: 'crossfi-testnet' },

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -126,6 +126,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 3737n, shortName: 'csb' },
   { chainId: 3776n, shortName: 'astrzk' },
   { chainId: 4002n, shortName: 'tftm' },
+  { chainId: 4062n, shortName: 'nahmii-testnet' },
   { chainId: 4078n, shortName: 'muster' },
   { chainId: 4157n, shortName: 'crossfi-testnet' },
   { chainId: 4202n, shortName: 'lisksep' },


### PR DESCRIPTION
## What it solves
Adds EIP-3779 shortname for Nahmii 3 Testnet:
https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-4061.json
Resolves #

## How this PR fixes it
