### PR TITLE
Onchain trackid via paymentReceiver & refundReceiver

### DIFF
--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -85,7 +85,7 @@ export interface encodeSetupCallDataProps {
   customContracts?: ContractNetworkConfig
   customSafeVersion?: SafeVersion
   deploymentType?: DeploymentType
-  trackId: string
+  trackId?: string
 }
 
 export function encodeCreateProxyWithNonce(

--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -75,6 +75,7 @@ export interface PredictSafeAddressProps {
   safeDeploymentConfig?: SafeDeploymentConfig
   isL1SafeSingleton?: boolean
   customContracts?: ContractNetworkConfig
+  trackId?: string
 }
 
 export interface encodeSetupCallDataProps {
@@ -84,6 +85,7 @@ export interface encodeSetupCallDataProps {
   customContracts?: ContractNetworkConfig
   customSafeVersion?: SafeVersion
   deploymentType?: DeploymentType
+  trackId: string
 }
 
 export function encodeCreateProxyWithNonce(
@@ -109,7 +111,8 @@ export async function encodeSetupCallData({
   safeContract,
   customContracts,
   customSafeVersion,
-  deploymentType
+  deploymentType,
+  trackId
 }: encodeSetupCallDataProps): Promise<string> {
   const {
     owners,
@@ -119,7 +122,7 @@ export async function encodeSetupCallData({
     fallbackHandler,
     paymentToken = ZERO_ADDRESS,
     payment = 0,
-    paymentReceiver = ZERO_ADDRESS
+    paymentReceiver = trackId || ZERO_ADDRESS
   } = safeAccountConfig
 
   const safeVersion = customSafeVersion || safeContract.safeVersion
@@ -255,7 +258,8 @@ export async function getPredictedSafeAddressInitCode({
   safeAccountConfig,
   safeDeploymentConfig = {},
   isL1SafeSingleton,
-  customContracts
+  customContracts,
+  trackId = ''
 }: PredictSafeAddressProps): Promise<string> {
   validateSafeAccountConfig(safeAccountConfig)
   validateSafeDeploymentConfig(safeDeploymentConfig)
@@ -289,7 +293,8 @@ export async function getPredictedSafeAddressInitCode({
     safeContract,
     customContracts,
     customSafeVersion: safeVersion, // it is more efficient if we provide the safeVersion manually
-    deploymentType
+    deploymentType,
+    trackId
   })
 
   const encodedNonce = safeProvider.encodeParameters('uint256', [saltNonce])
@@ -315,7 +320,8 @@ export async function predictSafeAddress({
   safeAccountConfig,
   safeDeploymentConfig = {},
   isL1SafeSingleton,
-  customContracts
+  customContracts,
+  trackId = ''
 }: PredictSafeAddressProps): Promise<string> {
   validateSafeAccountConfig(safeAccountConfig)
   validateSafeDeploymentConfig(safeDeploymentConfig)
@@ -357,7 +363,8 @@ export async function predictSafeAddress({
     safeContract,
     customContracts,
     customSafeVersion: safeVersion, // it is more efficient if we provide the safeVersion manuall
-    deploymentType
+    deploymentType,
+    trackId
   })
   const initializerHash = keccak256(asHex(initializer))
 

--- a/packages/protocol-kit/src/index.ts
+++ b/packages/protocol-kit/src/index.ts
@@ -67,6 +67,7 @@ import {
 } from './utils/eip-712'
 import { createPasskeyClient } from './utils/passkeys/PasskeyClient'
 import getPasskeyOwnerAddress from './utils/passkeys/getPasskeyOwnerAddress'
+import formatTrackId from './utils/on-chain-tracking/formatTrackId'
 
 export {
   estimateTxBaseGas,
@@ -75,6 +76,7 @@ export {
   estimateSafeDeploymentGas,
   extractPasskeyData,
   extractPasskeyCoordinates,
+  formatTrackId,
   ContractManager,
   CreateCallBaseContract,
   createERC20TokenTransferTransaction,

--- a/packages/protocol-kit/src/types/safeConfig.ts
+++ b/packages/protocol-kit/src/types/safeConfig.ts
@@ -48,6 +48,8 @@ export type SafeConfigProps = {
   isL1SafeSingleton?: boolean
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
+  // on-chain analitics
+  trackId?: string
 }
 
 export type SafeConfigWithSafeAddress = SafeConfigProps & SafeConfigWithSafeAddressProps
@@ -75,6 +77,8 @@ type ConnectSafeConfigProps = {
   isL1SafeSingleton?: boolean
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
+  // on-chain analitics
+  trackId?: string
 }
 
 export type ConnectSafeConfigWithSafeAddress = ConnectSafeConfigProps &

--- a/packages/protocol-kit/src/types/transactions.ts
+++ b/packages/protocol-kit/src/types/transactions.ts
@@ -37,6 +37,7 @@ type StandardizeSafeTransactionData = {
   tx: SafeTransactionDataPartial
   /** contractNetworks - Contract network configuration */
   contractNetworks?: ContractNetworksConfig
+  trackId: string
 }
 
 export type StandardizeSafeTxDataWithSafeContract = StandardizeSafeTransactionData &

--- a/packages/protocol-kit/src/utils/on-chain-tracking/formatTrackId.ts
+++ b/packages/protocol-kit/src/utils/on-chain-tracking/formatTrackId.ts
@@ -1,0 +1,14 @@
+import { keccak256, toHex } from 'viem'
+
+/**
+ * Formats a trackId to convert it into an Ethereum address. This address can be used in
+ * fields like `paymentReceiver` and `refundReceiver` to track Safe transactions and deployments.
+ *
+ * @param {string} trackId - The identifier provided by the user.
+ * @returns {`0x${string}`} - The Ethereum address derived from the identifier.
+ */
+function formatTrackId(trackId: string): `0x${string}` {
+  return `0x${keccak256(toHex(trackId)).substring(2, 42)}` // only first 40 chars from the hash
+}
+
+export default formatTrackId

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -61,7 +61,8 @@ export async function standardizeSafeTransactionData({
   predictedSafe,
   provider,
   tx,
-  contractNetworks
+  contractNetworks,
+  trackId
 }: StandardizeSafeTransactionDataProps): Promise<SafeTransactionData> {
   const standardizedTxs = {
     to: tx.to,
@@ -71,7 +72,7 @@ export async function standardizeSafeTransactionData({
     baseGas: tx.baseGas ?? '0',
     gasPrice: tx.gasPrice ?? '0',
     gasToken: tx.gasToken || ZERO_ADDRESS,
-    refundReceiver: tx.refundReceiver || ZERO_ADDRESS,
+    refundReceiver: tx.refundReceiver || trackId || ZERO_ADDRESS,
     nonce: tx.nonce ?? (safeContract ? Number(await safeContract.getNonce()) : 0)
   }
 

--- a/packages/protocol-kit/tests/e2e/onChainTrackId.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainTrackId.test.ts
@@ -1,0 +1,253 @@
+import { setupTests, safeVersionDeployed } from '@safe-global/testing-kit'
+import semverSatisfies from 'semver/functions/satisfies'
+import Safe, {
+  getSafeContract,
+  getSafeProxyFactoryContract,
+  PredictedSafeProps,
+  SafeAccountConfig,
+  SafeProvider
+} from '@safe-global/protocol-kit/index'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+
+import { getEip1193Provider } from './utils/setupProvider'
+import { decodeFunctionData } from 'viem'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
+
+chai.use(chaiAsPromised)
+
+describe('On-chain analytics', () => {
+  const provider = getEip1193Provider()
+
+  describe('getTrackId method', () => {
+    it('should return the correctly formatted track id when provided', async () => {
+      const trackId = 'test-track-id'
+      const { safe, contractNetworks } = await setupTests()
+      const safeAddress = safe.address
+
+      const protocolKit = await Safe.init({
+        provider,
+        safeAddress,
+        contractNetworks,
+        trackId
+      })
+
+      const formattedTrackId = '0x7ba67a7e86c9fad9f51790e7e60307f882b9c492'
+
+      chai.expect(formattedTrackId).to.equals(protocolKit.getTrackId())
+    })
+
+    it('should return an empty string when no track id is provided', async () => {
+      const { safe, contractNetworks } = await setupTests()
+      const safeAddress = safe.address
+
+      const protocolKit = await Safe.init({
+        provider,
+        safeAddress,
+        contractNetworks
+      })
+
+      chai.expect(protocolKit.getTrackId()).to.empty
+    })
+  })
+
+  describe('Tracking Safe Deployment on Chain via paymentReceiver field in setup method', () => {
+    it('should include the formatted trackId in the paymentReceiver field during Safe deployment', async () => {
+      const trackId = 'test-track-id'
+
+      const { chainId, accounts, contractNetworks } = await setupTests()
+      const [account1, account2] = accounts
+      const owners = [account1.address, account2.address]
+      const threshold = 1
+      const safeAccountConfig: SafeAccountConfig = { owners, threshold }
+      const predictedSafe: PredictedSafeProps = {
+        safeAccountConfig,
+        safeDeploymentConfig: {
+          safeVersion: safeVersionDeployed
+        }
+      }
+
+      const protocolKit = await Safe.init({
+        provider,
+        predictedSafe,
+        contractNetworks,
+        trackId
+      })
+
+      const deploymentTransaction = await protocolKit.createSafeDeploymentTransaction()
+
+      chai.expect(deploymentTransaction.data).to.include(protocolKit.getTrackId().replace('0x', ''))
+
+      const customContracts = contractNetworks[chainId.toString()]
+
+      const safeProvider = new SafeProvider({ provider })
+
+      const proxyFactoryContract = await getSafeProxyFactoryContract({
+        safeProvider,
+        safeVersion: safeVersionDeployed,
+        customContracts
+      })
+
+      proxyFactoryContract.contractAbi
+
+      const decodedDataDeployment = decodeFunctionData({
+        abi: proxyFactoryContract.contractAbi,
+        data: deploymentTransaction.data as `0x${string}`
+      })
+
+      const initializer = decodedDataDeployment.args[1]
+
+      const safeContract = await getSafeContract({
+        safeProvider,
+        safeVersion: safeVersionDeployed,
+        customContracts
+      })
+
+      if (semverSatisfies(safeVersionDeployed, '<=1.0.0')) {
+        const decodedDataSetup = decodeFunctionData({
+          abi: safeContract.contractAbi,
+          data: initializer as `0x${string}`
+        })
+
+        const paymentReceiver = (decodedDataSetup.args[6] as string)?.toLowerCase()
+
+        chai.expect(paymentReceiver).to.equals(protocolKit.getTrackId())
+      } else {
+        const decodedDataSetup = decodeFunctionData({
+          abi: safeContract.contractAbi,
+          data: initializer as `0x${string}`
+        })
+
+        const paymentReceiver = decodedDataSetup.args[7]?.toLowerCase()
+
+        chai.expect(paymentReceiver).to.equals(protocolKit.getTrackId())
+      }
+    })
+
+    it('should set the paymentReceiver to the zero address when no trackId is provided during Safe deployment', async () => {
+      const { chainId, accounts, contractNetworks } = await setupTests()
+      const [account1, account2] = accounts
+      const owners = [account1.address, account2.address]
+      const threshold = 1
+      const safeAccountConfig: SafeAccountConfig = { owners, threshold }
+      const predictedSafe: PredictedSafeProps = {
+        safeAccountConfig,
+        safeDeploymentConfig: {
+          safeVersion: safeVersionDeployed
+        }
+      }
+
+      const protocolKit = await Safe.init({
+        provider,
+        predictedSafe,
+        contractNetworks
+      })
+
+      const deploymentTransaction = await protocolKit.createSafeDeploymentTransaction()
+
+      chai.expect(deploymentTransaction.data).to.include(protocolKit.getTrackId().replace('0x', ''))
+
+      const customContracts = contractNetworks[chainId.toString()]
+
+      const safeProvider = new SafeProvider({ provider })
+
+      const proxyFactoryContract = await getSafeProxyFactoryContract({
+        safeProvider,
+        safeVersion: safeVersionDeployed,
+        customContracts
+      })
+
+      proxyFactoryContract.contractAbi
+
+      const decodedDataDeployment = decodeFunctionData({
+        abi: proxyFactoryContract.contractAbi,
+        data: deploymentTransaction.data as `0x${string}`
+      })
+
+      const initializer = decodedDataDeployment.args[1]
+
+      const safeContract = await getSafeContract({
+        safeProvider,
+        safeVersion: safeVersionDeployed,
+        customContracts
+      })
+
+      if (semverSatisfies(safeVersionDeployed, '<=1.0.0')) {
+        const decodedDataSetup = decodeFunctionData({
+          abi: safeContract.contractAbi,
+          data: initializer as `0x${string}`
+        })
+
+        const paymentReceiver = (decodedDataSetup.args[6] as string)?.toLowerCase()
+
+        chai.expect(paymentReceiver).to.equals(ZERO_ADDRESS)
+      } else {
+        const decodedDataSetup = decodeFunctionData({
+          abi: safeContract.contractAbi,
+          data: initializer as `0x${string}`
+        })
+
+        const paymentReceiver = decodedDataSetup.args[7]?.toLowerCase()
+
+        chai.expect(paymentReceiver).to.equals(ZERO_ADDRESS)
+      }
+    })
+  })
+
+  describe('Tracking Safe transactions on Chain via refundReceiver field in execTransaction method', () => {
+    it('should include the formatted trackId in the refundReceiver field during the transaction execution', async () => {
+      const trackId = 'test-track-id'
+      const { safe, contractNetworks } = await setupTests()
+      const safeAddress = safe.address
+
+      const protocolKit = await Safe.init({
+        provider,
+        safeAddress,
+        contractNetworks,
+        trackId
+      })
+
+      const testTransaction = {
+        to: safeAddress,
+        value: '0',
+        data: '0x'
+      }
+
+      const safeTransaction = await protocolKit.createTransaction({
+        transactions: [testTransaction]
+      })
+
+      const isValidTransaction = await protocolKit.isValidTransaction(safeTransaction)
+      chai.expect(isValidTransaction).to.be.eq(true)
+
+      const formattedTrackId = protocolKit.getTrackId()
+      chai.expect(safeTransaction.data.refundReceiver).to.equals(formattedTrackId)
+    })
+
+    it('should set the refundReceiver to the zero address when no trackId is provided', async () => {
+      const { safe, contractNetworks } = await setupTests()
+      const safeAddress = safe.address
+
+      const protocolKit = await Safe.init({
+        provider,
+        safeAddress,
+        contractNetworks
+      })
+
+      const testTransaction = {
+        to: safeAddress,
+        value: '0',
+        data: '0x'
+      }
+
+      const safeTransaction = await protocolKit.createTransaction({
+        transactions: [testTransaction]
+      })
+
+      const isValidTransaction = await protocolKit.isValidTransaction(safeTransaction)
+      chai.expect(isValidTransaction).to.be.eq(true)
+
+      chai.expect(safeTransaction.data.refundReceiver).to.equals(ZERO_ADDRESS)
+    })
+  })
+})

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -124,7 +124,8 @@ export class Safe4337Pack extends RelayKitBasePack<{
    * @return {Promise<Safe4337Pack>} The Promise object that will be resolved into an instance of Safe4337Pack.
    */
   static async init(initOptions: Safe4337InitOptions): Promise<Safe4337Pack> {
-    const { provider, signer, options, bundlerUrl, customContracts, paymasterOptions } = initOptions
+    const { provider, signer, options, bundlerUrl, customContracts, paymasterOptions, trackId } =
+      initOptions
     let protocolKit: Safe
     const bundlerClient = getEip4337BundlerProvider(bundlerUrl)
     const chainId = await bundlerClient.request({ method: RPC_4337_CALLS.CHAIN_ID })
@@ -172,7 +173,8 @@ export class Safe4337Pack extends RelayKitBasePack<{
       protocolKit = await Safe.init({
         provider,
         signer,
-        safeAddress: options.safeAddress
+        safeAddress: options.safeAddress,
+        trackId
       })
 
       const safeVersion = protocolKit.getContractVersion()
@@ -329,7 +331,8 @@ export class Safe4337Pack extends RelayKitBasePack<{
             payment: 0,
             paymentReceiver: zeroAddress
           }
-        }
+        },
+        trackId
       })
     }
 

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -5,7 +5,8 @@ import Safe, {
   encodeMultiSendData,
   getMultiSendContract,
   PasskeyClient,
-  SafeProvider
+  SafeProvider,
+  formatTrackId
 } from '@safe-global/protocol-kit'
 import { RelayKitBasePack } from '@safe-global/relay-kit/RelayKitBasePack'
 import {
@@ -329,7 +330,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
             fallbackHandler: safe4337ModuleAddress,
             paymentToken: zeroAddress,
             payment: 0,
-            paymentReceiver: zeroAddress
+            paymentReceiver: trackId ? formatTrackId(trackId) : zeroAddress
           }
         },
         trackId

--- a/packages/relay-kit/src/packs/safe-4337/types.ts
+++ b/packages/relay-kit/src/packs/safe-4337/types.ts
@@ -50,6 +50,7 @@ export type Safe4337InitOptions = {
   }
   options: ExistingSafeOptions | PredictedSafeOptions
   paymasterOptions?: PaymasterOptions
+  trackId?: string
 }
 
 export type Safe4337Options = {

--- a/playground/protocol-kit/deploy-safe.ts
+++ b/playground/protocol-kit/deploy-safe.ts
@@ -18,6 +18,7 @@ interface Config {
     SALT_NONCE: string
     SAFE_VERSION: string
   }
+  trackId: string
 }
 
 const config: Config = {
@@ -27,8 +28,9 @@ const config: Config = {
     OWNERS: ['OWNER_ADDRESS'],
     THRESHOLD: 1, // <SAFE_THRESHOLD>
     SALT_NONCE: '150000',
-    SAFE_VERSION: '1.3.0'
-  }
+    SAFE_VERSION: '1.0.0'
+  },
+  trackId: '' // On chain analitic
 }
 
 async function main() {
@@ -53,8 +55,14 @@ async function main() {
         saltNonce,
         safeVersion
       }
-    }
+    },
+    trackId: config.trackId
   })
+
+  if (config.trackId) {
+    console.log('trackId: ', config.trackId)
+    console.log('on-chain trackId: ', protocolKit.getTrackId())
+  }
 
   // The Account Abstraction feature is only available for Safes version 1.3.0 and above.
   if (semverSatisfies(safeVersion, '>=1.3.0')) {
@@ -96,7 +104,7 @@ async function main() {
   console.log('safeAddress:', safeAddress)
 
   // now you can use the Safe address in the instance of the protocol-kit
-  protocolKit.connect({ safeAddress })
+  await protocolKit.connect({ safeAddress })
 
   console.log('is Safe deployed:', await protocolKit.isSafeDeployed())
   console.log('Safe Address:', await protocolKit.getAddress())


### PR DESCRIPTION
## What it solves
Resolves #1056 

## How this PR fixes it

Added on chain tracking via [ `paymentReceiver` ](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L92) & [`refundReceiver`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L120) fields

## Examples

### Safe Deployment

Safe creation (v1.3.0)

Chain: Sepolia

TrackId: mi-test-track-id
Hashed trackId:  0xdda6d6dcc0edd564c5393808feb3b4e49d100cfe

Safe deployed v1.3.0 address: 0x00088ef66C3F981b07DB931f2302Ed1eB412E055

Deployment Link: https://sepolia.etherscan.io/tx/0xb0763692d198fb5df5546e3fa4bf3c431111c8aaf1010816924173c06f6e292d

Tenderly Link: https://dashboard.tenderly.co/tx/sepolia/0xb0763692d198fb5df5546e3fa4bf3c431111c8aaf1010816924173c06f6e292d/debugger?trace=0.1.1



Safe creation (v1.0.0)

Chain: gnosis

TrackId: mi-test-track-id
Hashed trackId:  0xdda6d6dcc0edd564c5393808feb3b4e49d100cfe

Safe deployed v1.0.0 address: 0x86e06Eb38B5f202a92417d06f20881B827d683CA



Deployment Link: https://gnosisscan.io/tx/0xc9803c5f2c38374d8705020ebf9600a4357c0d9e6a310dd04a3fd06d53dbdfb1


Tenderly Link: https://dashboard.tenderly.co/tx/gnosis-chain/0xc9803c5f2c38374d8705020ebf9600a4357c0d9e6a310dd04a3fd06d53dbdfb1/debugger?trace=0.1.0

### Safe Execution

Chain: Sepolia

TrackId: mi-test-track-id
Hashed trackId:  0xdda6d6dcc0edd564c5393808feb3b4e49d100cfe

Safe v1.3.0 address: 0x00088ef66C3F981b07DB931f2302Ed1eB412E055

Tenderly Link:  https://dashboard.tenderly.co/tx/sepolia/0x8d5871a6f668a3b4441f92d6f854c66dccc51ef53d3ae3362f7806c3011b1d4a/debugger?trace=0.1.3

transaction Hash: 0x8d5871a6f668a3b4441f92d6f854c66dccc51ef53d3ae3362f7806c3011b1d4a
