### PR TITLE
fix(api-kit): Missing `to` parameter

### DIFF
--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -122,14 +122,21 @@ class SafeApiKit {
    * @throws "Not Found"
    * @throws "Ensure this field has at least 1 hexadecimal chars (not counting 0x)."
    */
-  async decodeData(data: string, to: string = ''): Promise<any> {
+  async decodeData(data: string, to?: string): Promise<any> {
     if (data === '') {
       throw new Error('Invalid data')
     }
+
+    const dataDecoderRequest: { data: string; to?: string } = { data }
+
+    if (to) {
+      dataDecoderRequest.to = to
+    }
+
     return sendRequest({
       url: `${this.#txServiceBaseUrl}/v1/data-decoder/`,
       method: HttpMethod.Post,
-      body: { data, to }
+      body: dataDecoderRequest
     })
   }
 

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -115,20 +115,21 @@ class SafeApiKit {
   /**
    * Decodes the specified Safe transaction data.
    *
-   * @param data - The Safe transaction data
+   * @param data - The Safe transaction data. '0x' prefixed hexadecimal string.
+   * @param to - The address of the receiving contract. If provided, the decoded data will be more accurate, as in case of an ABI collision the Safe Transaction Service would know which ABI to use
    * @returns The transaction data decoded
    * @throws "Invalid data"
    * @throws "Not Found"
    * @throws "Ensure this field has at least 1 hexadecimal chars (not counting 0x)."
    */
-  async decodeData(data: string): Promise<any> {
+  async decodeData(data: string, to: string = ''): Promise<any> {
     if (data === '') {
       throw new Error('Invalid data')
     }
     return sendRequest({
       url: `${this.#txServiceBaseUrl}/v1/data-decoder/`,
       method: HttpMethod.Post,
-      body: { data }
+      body: { data, to }
     })
   }
 

--- a/packages/api-kit/tests/e2e/decodeData.test.ts
+++ b/packages/api-kit/tests/e2e/decodeData.test.ts
@@ -45,4 +45,22 @@ describe('decodeData', () => {
       })
     )
   })
+
+  it('should decode the data and allow to specify the receiving contract', async () => {
+    const data = '0x610b592500000000000000000000000090F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+    const to = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+    const decodedData = await safeApiKit.decodeData(data, to)
+    chai.expect(JSON.stringify(decodedData)).to.be.equal(
+      JSON.stringify({
+        method: 'enableModule',
+        parameters: [
+          {
+            name: 'module',
+            type: 'address',
+            value: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+          }
+        ]
+      })
+    )
+  })
 })


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-core-sdk/issues/1046

## How this PR fixes it
Adding the `to` parameter to the `decodeData` method
