### PR TITLE
feat: add SignatureType type

### DIFF
--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -291,7 +291,7 @@ type SafeMultisigTransactionResponse = {
       transactionHash?: string
       confirmationType?: string
       signature: string
-      signatureType?: string
+      signatureType?: SignatureType
     },
     // ...
   ]

--- a/packages/api-kit/src/types/safeTransactionServiceTypes.ts
+++ b/packages/api-kit/src/types/safeTransactionServiceTypes.ts
@@ -4,7 +4,8 @@ import {
   SafeTransactionData,
   UserOperation,
   SafeOperationResponse,
-  ListResponse
+  ListResponse,
+  SignatureType
 } from '@safe-global/types-kit'
 
 export type ListOptions = {
@@ -231,7 +232,7 @@ export type SafeMessageConfirmation = {
   readonly modified: string
   readonly owner: string
   readonly signature: string
-  readonly signatureType: string
+  readonly signatureType: SignatureType
 }
 
 export type SafeMessage = {

--- a/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/offChainSignatures.test.ts
@@ -311,7 +311,7 @@ describe('Off-chain signatures', () => {
             transactionHash: '',
             confirmationType: '',
             signature: '0x111111',
-            signatureType: ''
+            signatureType: 'EOA'
           },
           {
             owner: '0x2222222222222222222222222222222222222222',
@@ -319,7 +319,7 @@ describe('Off-chain signatures', () => {
             transactionHash: '',
             confirmationType: '',
             signature: '0x222222',
-            signatureType: ''
+            signatureType: 'EOA'
           }
         ],
         trusted: true,

--- a/packages/relay-kit/src/packs/safe-4337/testing-utils/fixtures.ts
+++ b/packages/relay-kit/src/packs/safe-4337/testing-utils/fixtures.ts
@@ -1,3 +1,4 @@
+import { SignatureTypes } from '@safe-global/types-kit'
 import { ENTRYPOINT_ADDRESS_V06, ENTRYPOINT_ADDRESS_V07 } from '../constants'
 
 export const OWNER_1 = '0xFfAC5578BE8AC1B2B9D13b34cAf4A074B96B8A1b'
@@ -109,7 +110,7 @@ export const SAFE_OPERATION_RESPONSE = {
       owner: '0x3059EfD1BCe33be41eeEfd5fb6D520d7fEd54E43',
       signature:
         '0xcb28e74375889e400a4d8aca46b8c59e1cf8825e373c26fa99c2fd7c078080e64fe30eaf1125257bdfe0b358b5caef68aa0420478145f52decc8e74c979d43ab1d',
-      signatureType: 'EOA'
+      signatureType: SignatureTypes.EOA
     }
   ],
   preparedSignature:

--- a/packages/types-kit/src/types.ts
+++ b/packages/types-kit/src/types.ts
@@ -188,13 +188,22 @@ export interface EIP712TypedData {
   primaryType?: string
 }
 
+export const SignatureTypes = {
+  CONTRACT_SIGNATURE: 'CONTRACT_SIGNATURE',
+  EOA: 'EOA',
+  APPROVED_HASH: 'APPROVED_HASH',
+  ETH_SIGN: 'ETH_SIGN'
+} as const
+
+export type SignatureType = (typeof SignatureTypes)[keyof typeof SignatureTypes]
+
 export type SafeMultisigConfirmationResponse = {
   readonly owner: string
   readonly submissionDate: string
   readonly transactionHash?: string
   readonly confirmationType?: string
   readonly signature: string
-  readonly signatureType?: string
+  readonly signatureType: SignatureType
 }
 
 export type ListResponse<T> = {
@@ -313,7 +322,7 @@ export type SafeOperationConfirmation = {
   readonly modified: string
   readonly owner: string
   readonly signature: string
-  readonly signatureType: string
+  readonly signatureType: SignatureType
 }
 
 export type UserOperationResponse = {


### PR DESCRIPTION
## What it solves

based on this suggestion: https://github.com/safe-global/safe-core-sdk/pull/1043

## How this PR fixes it

```typescript

export const SignatureTypes = {
  CONTRACT_SIGNATURE: 'CONTRACT_SIGNATURE',
  EOA: 'EOA',
  APPROVED_HASH: 'APPROVED_HASH',
  ETH_SIGN: 'ETH_SIGN'
} as const

export type SignatureType = (typeof SignatureTypes)[keyof typeof SignatureTypes]

```