### PR TITLE
typo fix README.md

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -55,7 +55,7 @@ In case you want to execute the transaction via a transaction relay, this script
 yarn play relay-sponsored-transaction
 ```
 
-#### Generate a custon Safe address
+#### Generate a custom Safe address
 
 This script allows to find the right `saltNonce` to generate a vanity Safe address with any given configuration:
 


### PR DESCRIPTION
## Summary of changes:
- Corrected a typo in the `README.md` file.

## Details:
- The word "custon" was changed to "custom" in the section describing how to generate a custom Safe address.
