### PR TITLE
fix: Generate `getProtocolKitVersion` dynamically via `prebuild` script

### DIFF
--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -35,6 +35,7 @@
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
     "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
     "unbuild": "rimraf dist artifacts deployments cache .nyc_output *.tsbuildinfo",
+    "prebuild": "node -p \"'export const getProtocolKitVersion = () => \\'' + require('./package.json').version.split('-')[0] + '\\''\" > src/utils/getProtocolKitVersion.ts",
     "build": "yarn unbuild && yarn check-safe-deployments && NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json"
   },
   "repository": {

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -88,7 +88,7 @@ import { Hash, Hex, SendTransactionParameters } from 'viem'
 import getPasskeyOwnerAddress from './utils/passkeys/getPasskeyOwnerAddress'
 import createPasskeyDeploymentTransaction from './utils/passkeys/createPasskeyDeploymentTransaction'
 import generateOnChainIdentifier from './utils/on-chain-tracking/generateOnChainIdentifier'
-import getProtocolKitVersion from './utils/getProtocolKitVersion'
+import { getProtocolKitVersion } from './utils/getProtocolKitVersion'
 
 const EQ_OR_GT_1_4_1 = '>=1.4.1'
 const EQ_OR_GT_1_3_0 = '>=1.3.0'

--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,7 +1,1 @@
-import packageJson from '../../package.json'
-
-function getProtocolKitVersion(): string {
-  return packageJson.version
-}
-
-export default getProtocolKitVersion
+export const getProtocolKitVersion = () => '5.1.1'

--- a/packages/protocol-kit/tests/e2e/onChainIdentifier.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainIdentifier.test.ts
@@ -10,7 +10,8 @@ import Sinon from 'sinon'
 import chaiAsPromised from 'chai-as-promised'
 
 import { generateHash } from '@safe-global/protocol-kit/utils/on-chain-tracking/generateOnChainIdentifier'
-import getProtocolKitVersion, * as getProtocolKitVersionModule from '@safe-global/protocol-kit/utils/getProtocolKitVersion'
+import * as getProtocolKitVersionModule from '@safe-global/protocol-kit/utils/getProtocolKitVersion'
+import { getProtocolKitVersion } from '@safe-global/protocol-kit/utils/getProtocolKitVersion'
 import { getEip1193Provider } from './utils/setupProvider'
 import { waitSafeTxReceipt } from './utils/transactions'
 
@@ -47,7 +48,7 @@ describe('On-chain analytics', () => {
         platform: 'Web'
       }
 
-      const stub = Sinon.stub(getProtocolKitVersionModule, 'default').returns('5.0.4')
+      const stub = Sinon.stub(getProtocolKitVersionModule, 'getProtocolKitVersion').returns('5.0.4')
 
       const { safe, contractNetworks } = await setupTests()
       const safeAddress = safe.address

--- a/packages/protocol-kit/tsconfig.build.json
+++ b/packages/protocol-kit/tsconfig.build.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../tsconfig.settings.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
     "composite": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*", "package.json"]
+  "include": ["src/**/*"]
 }

--- a/packages/protocol-kit/tsconfig.json
+++ b/packages/protocol-kit/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../tsconfig.settings.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
     "composite": true,
     "outDir": "dist"
   },
-  "include": ["package.json", "src/**/*", "tests/**/*", "hardhat/**/*", "hardhat.config.ts"]
+  "include": ["src/**/*", "tests/**/*", "hardhat/**/*", "hardhat.config.ts"]
 }

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -19,6 +19,7 @@
     "format:check": "prettier --check \"*/**/*.{js,json,md,ts}\"",
     "format": "prettier --write \"*/**/*.{js,json,md,ts}\"",
     "unbuild": "rimraf dist .nyc_output cache",
+    "prebuild": "node -p \"'export const getRelayKitVersion = () => \\'' + require('./package.json').version.split('-')[0] + '\\''\" > src/packs/safe-4337/utils/getRelayKitVersion.ts",
     "build": "yarn unbuild && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json"
   },
   "repository": {

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -53,7 +53,7 @@ import {
 } from './utils'
 import { entryPointToSafeModules, EQ_OR_GT_0_3_0 } from './utils/entrypoint'
 import { PimlicoFeeEstimator } from './estimators/PimlicoFeeEstimator'
-import getRelayKitVersion from './utils/getRelayKitVersion'
+import { getRelayKitVersion } from './utils/getRelayKitVersion'
 
 const MAX_ERC20_AMOUNT_TO_APPROVE =
   0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn

--- a/packages/relay-kit/src/packs/safe-4337/utils/getRelayKitVersion.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/getRelayKitVersion.ts
@@ -1,7 +1,1 @@
-import packageJson from '../../../../package.json'
-
-function getRelayKitVersion(): string {
-  return packageJson.version
-}
-
-export default getRelayKitVersion
+export const getRelayKitVersion = () => '3.3.1'

--- a/packages/relay-kit/tsconfig.build.json
+++ b/packages/relay-kit/tsconfig.build.json
@@ -1,10 +1,9 @@
 {
   "extends": "../../tsconfig.settings.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
     "composite": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*", "package.json"],
+  "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
 }

--- a/packages/relay-kit/tsconfig.json
+++ b/packages/relay-kit/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../tsconfig.settings.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
     "composite": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*", "package.json"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## What it solves

Generate `getProtocolKitVersion` dynamically via `prebuild` script

Updated Packages: `protocol-kit` and `realy-kit`

```
"prebuild": "node -p \"'export const getProtocolKitVersion = () => \\'' + require('./package.json').version.split('-')[0] + '\\''\" > src/utils/getProtocolKitVersion.ts",
```

this generates a `getProtocolKitVersion.ts` in the utils folder:

```typescript
export const getProtocolKitVersion = () => '5.1.1'
```

## How this PR fixes it

Based on: https://github.com/safe-global/safe-apps-sdk/pull/512/files#diff-5f74fd08745aa25ded644cd9a4eff498e167ba539e633f87b200cd40e4113e06R23


