### PR TITLE
feat: propagate custom contractNetworks config in Safe4337Pack.ts

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -146,7 +146,8 @@ export class Safe4337Pack extends RelayKitBasePack<{
       bundlerUrl,
       customContracts,
       paymasterOptions,
-      onchainAnalytics
+      onchainAnalytics,
+      contractNetworks
     } = initOptions
 
     let protocolKit: Safe
@@ -272,7 +273,12 @@ export class Safe4337Pack extends RelayKitBasePack<{
         setupTransactions.push(approveToPaymasterTransaction)
       }
 
-      const safeProvider = await SafeProvider.init({ provider, signer, safeVersion })
+      const safeProvider = await SafeProvider.init({
+        provider,
+        signer,
+        safeVersion,
+        contractNetworks
+      })
 
       // third transaction: passkey support via shared signer SafeWebAuthnSharedSigner
       // see: https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/4337/experimental/README.md

--- a/packages/relay-kit/src/packs/safe-4337/types.ts
+++ b/packages/relay-kit/src/packs/safe-4337/types.ts
@@ -2,7 +2,8 @@ import { Account, Address, Chain, Hash, Hex, PublicClient, PublicRpcSchema, Tran
 import Safe, {
   DeploymentType,
   SafeProviderConfig,
-  OnchainAnalyticsProps
+  OnchainAnalyticsProps,
+  ContractNetworksConfig
 } from '@safe-global/protocol-kit'
 import {
   EstimateGasData,
@@ -55,6 +56,7 @@ export type Safe4337InitOptions = {
   options: ExistingSafeOptions | PredictedSafeOptions
   paymasterOptions?: PaymasterOptions
   onchainAnalytics?: OnchainAnalyticsProps
+  contractNetworks?: ContractNetworksConfig
 }
 
 export type Safe4337Options = {


### PR DESCRIPTION
## What it solves

Ability to configure Safe contract addresses for a custom network.

## How this PR fixes it

Propagate [ContractNetworkingsConfig](https://github.com/safe-global/safe-core-sdk/blob/35a2e197b9ff76892bc370ce91845ee71819e407/packages/protocol-kit/src/types/contracts.ts#L131) through  [Safe4337Pack.init](https://github.com/safe-global/safe-core-sdk/blob/main/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts#L141).

## Description

Hello, I want to deploy a Safe account with Passkey support to my custom network. I have deployed contracts from the [safe-smart-account v1.4.1](https://github.com/safe-global/safe-smart-account), [safe-modules module 4337 v0.3.0-1](https://github.com/safe-global/safe-modules/tree/main/modules/4337) and also [safe-modules module passkey v0.2.1-1](https://github.com/safe-global/safe-modules/tree/main/modules/passkey) according to their custom deployment section in README respectively, but I don't see any way of specifying them when I use [Safe4337Pack.init](https://github.com/safe-global/safe-core-sdk/blob/main/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts#L141).

Call to [Safe4337Pack.init](https://github.com/safe-global/safe-core-sdk/blob/main/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts#L141), where `passkey` is object from [extractPasskeyData](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/utils/passkeys/extractPasskeyData.ts#L180):

```typescript
    const safe4337Pack = await Safe4337Pack.init({
      provider: RPC_URL,
      signer: passkey,
      bundlerUrl: BUNDLER_URL,
      customContracts: {
        entryPointAddress: 'SOME-ADDRESS',
        safe4337ModuleAddress: 'SOME-ADDRESS',
        addModulesLibAddress: 'SOME-ADDRESS',
        safeWebAuthnSharedSignerAddress: 'SOME-ADDRESS'
      },
      options: {
        owners: [],
        threshold: 1
      }
    })
```

I got an error:

```
BaseContract.js:74 Uncaught (in promise) Error: Invalid safeWebAuthnSignerFactory contract address
    at new BaseContract (BaseContract.js:74:19)
    at new SafeWebAuthnSignerFactoryBaseContract (SafeWebAuthnSignerFactoryBaseContract.js:34:9)
    at new SafeWebAuthnSignerFactoryContract_v0_2_1 (SafeWebAuthnSignerFactoryContract_v0_2_1.js:29:9)
    at getSafeWebAuthnSignerFactoryContractInstance (contractInstances.js:201:63)
    at async getSafeWebAuthnSignerFactoryContract (safeDeploymentContracts.js:78:47)
    at async SafeProvider.init (SafeProvider.js:56:59)
    at async Safe4337Pack.init (Safe4337Pack.js:207:34)
```



I traced the error through your source code:

1. In [Safe4337Pack.init](https://github.com/safe-global/safe-core-sdk/blob/main/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts#L141) there is a [call to SafeProvider.init](https://github.com/safe-global/safe-core-sdk/blob/main/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts#L275) with only `provider`, `signer`, `safeVersion` arguments,
2. In [SafeProvider.init](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/SafeProvider.ts#L103) a contract addresses are [retrieved with chain id from provider](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/SafeProvider.ts#L124) from `contractNetworks`, but the `contractNetworks` are undefined, because only `provider`, `signer`, `safeVersion` arguments are passed,
3. Undefined `customContracts` are [passed to getSafeWebAuthnSignerFactoryContract](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/SafeProvider.ts#L130),
4. Undefined `safeWebAuthnSignerFactoryAddress` is [passed to getSafeWebAuthnSignerFactoryContractInstance](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/contracts/safeDeploymentContracts.ts#L232) (same goes for `safeWebAuthnSignerFactoryAbi`),
5. Undefined `contractAddress` is then [used in SafeWebAuthnSignerFactoryContract_v0_2_1 constructor](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/contracts/contractInstances.ts#L461),
6. Undefined `customContractAddress` is used in [parent SafeWebAuthnSignerFactoryBaseContract constructor](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/contracts/SafeWebAuthnSignerFactory/v0.2.1/SafeWebAuthnSignerFactoryContract_v0_2_1.ts#L49) (same goes for `customContractAbi`),
7. Undefined `customContractAddress` is [passed to BaseContract constructor](customContractAddress) (same goes for `customContractAbi`),
8. In BaseContract `resolvedAddress` is [evaluated to undefined](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/contracts/BaseContract.ts#L82) because `customContractAddress` is undefined and there are no deployments on my network,
9. The above mentioned [error is thrown](https://github.com/safe-global/safe-core-sdk/blob/main/packages/protocol-kit/src/contracts/BaseContract.ts#L90).

## Versions

- `@safe-global/protocol-kit`: 5.2.0
- `@safe-global/relay-kit`: 3.4.0




