### PR TITLE
fix(protocol-kit): Fix signature generation for multiple contract signatures

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -1268,7 +1268,11 @@ class Safe {
     })
     serviceTransactionResponse.confirmations?.map(
       (confirmation: SafeMultisigConfirmationResponse) => {
-        const signature = new EthSafeSignature(confirmation.owner, confirmation.signature)
+        const signature = new EthSafeSignature(
+          confirmation.owner,
+          confirmation.signature,
+          confirmation?.signatureType === "CONTRACT_SIGNATURE",
+        )
         safeTransaction.addSignature(signature)
       }
     )

--- a/packages/protocol-kit/src/utils/signatures/SafeSignature.ts
+++ b/packages/protocol-kit/src/utils/signatures/SafeSignature.ts
@@ -38,8 +38,8 @@ export class EthSafeSignature implements SafeSignature {
    */
   dynamicPart() {
     if (this.isContractSignature) {
-      const dynamicPartLength = (this.data.slice(2).length / 2).toString(16).padStart(64, '0')
-      return `${dynamicPartLength}${this.data.slice(2)}`
+      // NOTE: Assuming single EIP-191 signaures from constructor
+      return `${this.data.slice(-1 * (130 + 64))}`
     }
 
     return ''


### PR DESCRIPTION
## What it solves
There are currently a few minor issues in `protocol-kit` related to contract signatures (i.e. [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)):

1. Contract signatures processed by the API are not recognized as such (fix in `Safe.ts`).
2. The dynamic part of a contract signature is calculated as the entire segment of the given data, when it should be the [last 97 bytes only](https://sepolia.etherscan.io/address/0x29fcb43b46531bca003ddc8fcb67ffe91900c762#code#F2#L286) (65 bytes signature + 32 bytes length).

## How this PR fixes it
These issues are fixed in the following ways:

1. All `CONTRACT_SIGNATURE` responses are registered as contract signatures.
2. The dynamic part of contract signatures is adjusted to be the last 97 bytes of the data payload.