### PR TITLE
fix(relay-kit): `userOperationToHexValues` `nonce` encode

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/utils.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils.ts
@@ -131,7 +131,7 @@ export function calculateSafeUserOperationHash(
 export function userOperationToHexValues(userOperation: UserOperation) {
   const userOperationWithHexValues = {
     ...userOperation,
-    nonce: toHex(userOperation.nonce),
+    nonce: toHex(BigInt(userOperation.nonce)),
     callGasLimit: toHex(userOperation.callGasLimit),
     verificationGasLimit: toHex(userOperation.verificationGasLimit),
     preVerificationGas: toHex(userOperation.preVerificationGas),


### PR DESCRIPTION
## What it solves

fix `userOperationToHexValues` `nonce` encode

## How this PR fixes it

``` typescript
  nonce: toHex(BigInt(userOperation.nonce)),
```