### PR TITLE
feat: Get pending SafeOperations support

### DIFF
--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -844,7 +844,7 @@ class SafeApiKit {
     }
 
     if (hasConfirmations != null) {
-      url.searchParams.set('hasConfirmations', hasConfirmations.toString())
+      url.searchParams.set('has_confirmations', hasConfirmations.toString())
     }
 
     if (executed != null) {

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -858,6 +858,22 @@ class SafeApiKit {
   }
 
   /**
+   * Get the SafeOperations that are pending to send to the bundler
+   * @param getSafeOperationsProps - The parameters to filter the list of SafeOperations
+   * @throws "Safe address must not be empty"
+   * @throws "Invalid Ethereum address {safeAddress}"
+   * @returns The pending SafeOperations
+   */
+  async getPendingSafeOperations(
+    props: GetSafeOperationListProps
+  ): Promise<GetSafeOperationListResponse> {
+    return this.getSafeOperationsByAddress({
+      ...props,
+      executed: false
+    })
+  }
+
+  /**
    * Get a SafeOperation by its hash.
    * @param safeOperationHash The SafeOperation hash
    * @throws "SafeOperation hash must not be empty"

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -817,6 +817,8 @@ class SafeApiKit {
    */
   async getSafeOperationsByAddress({
     safeAddress,
+    executed,
+    hasConfirmations,
     ordering,
     limit,
     offset
@@ -839,6 +841,14 @@ class SafeApiKit {
 
     if (offset != null) {
       url.searchParams.set('offset', offset.toString())
+    }
+
+    if (hasConfirmations != null) {
+      url.searchParams.set('hasConfirmations', hasConfirmations.toString())
+    }
+
+    if (executed != null) {
+      url.searchParams.set('executed', executed.toString())
     }
 
     return sendRequest({

--- a/packages/api-kit/src/SafeApiKit.ts
+++ b/packages/api-kit/src/SafeApiKit.ts
@@ -865,7 +865,7 @@ class SafeApiKit {
    * @returns The pending SafeOperations
    */
   async getPendingSafeOperations(
-    props: GetSafeOperationListProps
+    props: Omit<GetSafeOperationListProps, 'executed'>
   ): Promise<GetSafeOperationListResponse> {
     return this.getSafeOperationsByAddress({
       ...props,

--- a/packages/api-kit/src/types/safeTransactionServiceTypes.ts
+++ b/packages/api-kit/src/types/safeTransactionServiceTypes.ts
@@ -266,6 +266,8 @@ export type GetSafeOperationListProps = {
   safeAddress: string
   /** Which field to use when ordering the results. It can be: `user_operation__nonce`, `created` (default: `-user_operation__nonce`) */
   ordering?: string
+  executed?: boolean
+  hasConfirmations?: boolean
 } & ListOptions
 
 export type GetSafeOperationListResponse = ListResponse<SafeOperationResponse>

--- a/packages/api-kit/tests/e2e/getPendingSafeOperations.test.ts
+++ b/packages/api-kit/tests/e2e/getPendingSafeOperations.test.ts
@@ -36,8 +36,7 @@ describe('getPendingSafeOperations', () => {
 
     // Prepared 2 executed SafeOperations in the E2E Safe account
     const pendingSafeOperations = await safeApiKit.getPendingSafeOperations({
-      safeAddress: SAFE_ADDRESS,
-      executed: false
+      safeAddress: SAFE_ADDRESS
     })
 
     const executedSafeOperations = await safeApiKit.getSafeOperationsByAddress({

--- a/packages/api-kit/tests/e2e/getPendingSafeOperations.test.ts
+++ b/packages/api-kit/tests/e2e/getPendingSafeOperations.test.ts
@@ -1,0 +1,51 @@
+import SafeApiKit from '@safe-global/api-kit/index'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { getApiKit } from '../utils/setupKits'
+
+chai.use(chaiAsPromised)
+
+const SAFE_ADDRESS = '0x60C4Ab82D06Fd7dFE9517e17736C2Dcc77443EF0' // v1.4.1
+const TX_SERVICE_URL = 'https://safe-transaction-sepolia.staging.5afe.dev/api'
+
+let safeApiKit: SafeApiKit
+
+describe.only('getPendingSafeOperations', () => {
+  before(async () => {
+    safeApiKit = getApiKit(TX_SERVICE_URL)
+  })
+
+  describe('should fail', () => {
+    it('should fail if safeAddress is empty', async () => {
+      await chai
+        .expect(safeApiKit.getPendingSafeOperations({ safeAddress: '' }))
+        .to.be.rejectedWith('Safe address must not be empty')
+    })
+
+    it('should fail if safeAddress is invalid', async () => {
+      await chai
+        .expect(safeApiKit.getPendingSafeOperations({ safeAddress: '0x123' }))
+        .to.be.rejectedWith('Invalid Ethereum address 0x123')
+    })
+  })
+
+  it('should get pending safe operations', async () => {
+    const allSafeOperations = await safeApiKit.getSafeOperationsByAddress({
+      safeAddress: SAFE_ADDRESS
+    })
+
+    // Prepared 2 executed SafeOperations in the E2E Safe account
+    const pendingSafeOperations = await safeApiKit.getPendingSafeOperations({
+      safeAddress: SAFE_ADDRESS,
+      executed: false
+    })
+
+    const executedSafeOperations = await safeApiKit.getSafeOperationsByAddress({
+      safeAddress: SAFE_ADDRESS,
+      executed: true
+    })
+
+    chai.expect(executedSafeOperations.count).equals(2)
+    chai.expect(allSafeOperations.count - pendingSafeOperations.count).equals(2)
+  })
+})

--- a/packages/api-kit/tests/e2e/getPendingSafeOperations.test.ts
+++ b/packages/api-kit/tests/e2e/getPendingSafeOperations.test.ts
@@ -10,7 +10,7 @@ const TX_SERVICE_URL = 'https://safe-transaction-sepolia.staging.5afe.dev/api'
 
 let safeApiKit: SafeApiKit
 
-describe.only('getPendingSafeOperations', () => {
+describe('getPendingSafeOperations', () => {
   before(async () => {
     safeApiKit = getApiKit(TX_SERVICE_URL)
   })

--- a/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
+++ b/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
@@ -102,4 +102,16 @@ describe('getSafeOperationsByAddress', () => {
     chai.expect(response).to.have.property('results').to.be.an('array')
     chai.expect(response.results[0]).to.be.deep.equal(safeOperations[1])
   })
+
+  it('should get all pending safe operations', async () => {
+    const response = await safeApiKit.getSafeOperationsByAddress({
+      safeAddress: SAFE_ADDRESS,
+      offset: 1,
+      executed: true
+    })
+
+    chai.expect(response).to.have.property('count').equals(2)
+    chai.expect(response).to.have.property('results').to.be.an('array')
+    chai.expect(response.results[0]).to.be.deep.equal(safeOperations[1])
+  })
 })

--- a/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
+++ b/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
@@ -11,7 +11,7 @@ const TX_SERVICE_URL = 'https://safe-transaction-sepolia.staging.5afe.dev/api'
 
 let safeApiKit: SafeApiKit
 
-describe.only('getSafeOperationsByAddress', () => {
+describe('getSafeOperationsByAddress', () => {
   before(async () => {
     safeApiKit = getApiKit(TX_SERVICE_URL)
   })

--- a/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
+++ b/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
@@ -11,7 +11,7 @@ const TX_SERVICE_URL = 'https://safe-transaction-sepolia.staging.5afe.dev/api'
 
 let safeApiKit: SafeApiKit
 
-describe('getSafeOperationsByAddress', () => {
+describe.only('getSafeOperationsByAddress', () => {
   before(async () => {
     safeApiKit = getApiKit(TX_SERVICE_URL)
   })
@@ -112,6 +112,16 @@ describe('getSafeOperationsByAddress', () => {
 
     chai.expect(response).to.have.property('count').equals(2)
     chai.expect(response).to.have.property('results').to.be.an('array')
-    chai.expect(response.results[0]).to.be.deep.equal(safeOperations[1])
+  })
+
+  it('should get all safe operations without confirmations', async () => {
+    const response = await safeApiKit.getSafeOperationsByAddress({
+      safeAddress: SAFE_ADDRESS,
+      offset: 1,
+      hasConfirmations: false
+    })
+
+    chai.expect(response).to.have.property('count').equals(0)
+    chai.expect(response).to.have.property('results').to.be.an('array')
   })
 })

--- a/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
+++ b/packages/api-kit/tests/e2e/getSafeOperationsByAddress.test.ts
@@ -103,15 +103,24 @@ describe.only('getSafeOperationsByAddress', () => {
     chai.expect(response.results[0]).to.be.deep.equal(safeOperations[1])
   })
 
-  it('should get all pending safe operations', async () => {
-    const response = await safeApiKit.getSafeOperationsByAddress({
+  it('should get pending safe operations', async () => {
+    const allSafeOperations = await safeApiKit.getSafeOperationsByAddress({
+      safeAddress: SAFE_ADDRESS
+    })
+
+    // Prepared 2 executed SafeOperations in the E2E Safe account
+    const pendingSafeOperations = await safeApiKit.getSafeOperationsByAddress({
       safeAddress: SAFE_ADDRESS,
-      offset: 1,
+      executed: false
+    })
+
+    const executedSafeOperations = await safeApiKit.getSafeOperationsByAddress({
+      safeAddress: SAFE_ADDRESS,
       executed: true
     })
 
-    chai.expect(response).to.have.property('count').equals(2)
-    chai.expect(response).to.have.property('results').to.be.an('array')
+    chai.expect(executedSafeOperations.count).equals(2)
+    chai.expect(allSafeOperations.count - pendingSafeOperations.count).equals(2)
   })
 
   it('should get all safe operations without confirmations', async () => {

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.test.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.test.ts
@@ -198,9 +198,8 @@ describe('SafeOperationClient', () => {
       const result = await safeOperationClient.getPendingSafeOperations()
 
       expect(protocolKit.getAddress).toHaveBeenCalled()
-      expect(apiKit.getSafeOperationsByAddress).toHaveBeenCalledWith({
-        safeAddress: SAFE_ADDRESS,
-        executed: false
+      expect(apiKit.getPendingSafeOperations).toHaveBeenCalledWith({
+        safeAddress: SAFE_ADDRESS
       })
       expect(result).toBe(PENDING_SAFE_OPERATIONS)
     })

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.test.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.test.ts
@@ -193,7 +193,7 @@ describe('SafeOperationClient', () => {
 
   describe('getPendingSafeOperations', () => {
     it('should return the pending Safe operations for the Safe address', async () => {
-      apiKit.getSafeOperationsByAddress = jest.fn().mockResolvedValue(PENDING_SAFE_OPERATIONS)
+      apiKit.getPendingSafeOperations = jest.fn().mockResolvedValue(PENDING_SAFE_OPERATIONS)
 
       const result = await safeOperationClient.getPendingSafeOperations()
 

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.test.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.test.ts
@@ -198,7 +198,10 @@ describe('SafeOperationClient', () => {
       const result = await safeOperationClient.getPendingSafeOperations()
 
       expect(protocolKit.getAddress).toHaveBeenCalled()
-      expect(apiKit.getSafeOperationsByAddress).toHaveBeenCalledWith({ safeAddress: SAFE_ADDRESS })
+      expect(apiKit.getSafeOperationsByAddress).toHaveBeenCalledWith({
+        safeAddress: SAFE_ADDRESS,
+        executed: false
+      })
       expect(result).toBe(PENDING_SAFE_OPERATIONS)
     })
   })

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.ts
@@ -135,7 +135,7 @@ export class SafeOperationClient {
   async getPendingSafeOperations(options?: ListOptions): Promise<GetSafeOperationListResponse> {
     const safeAddress = await this.protocolKit.getAddress()
 
-    return this.apiKit.getSafeOperationsByAddress({ safeAddress, ...options })
+    return this.apiKit.getSafeOperationsByAddress({ safeAddress, ...options, executed: false })
   }
 
   /**

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/SafeOperationClient.ts
@@ -135,7 +135,7 @@ export class SafeOperationClient {
   async getPendingSafeOperations(options?: ListOptions): Promise<GetSafeOperationListResponse> {
     const safeAddress = await this.protocolKit.getAddress()
 
-    return this.apiKit.getSafeOperationsByAddress({ safeAddress, ...options, executed: false })
+    return this.apiKit.getPendingSafeOperations({ safeAddress, ...options })
   }
 
   /**


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-core-sdk/issues/1050

## How this PR fixes it

- `api-kit`: Implement the endpoint with a new method.
- `sdk-starter-kit`: Use the new method in getPendingSafeOperations.

