### PR TITLE
fix(sdk-starter-kit): Add correct `safeModulesVersion`

### DIFF
--- a/packages/sdk-starter-kit/src/constants.ts
+++ b/packages/sdk-starter-kit/src/constants.ts
@@ -1,5 +1,7 @@
 import { DeploymentType } from '@safe-global/protocol-kit'
 
+export const DEFAULT_SAFE_MODULES_VERSION = '0.2.0'
+
 export const DEFAULT_DEPLOYMENT_TYPE: DeploymentType = 'canonical'
 
 export enum SafeClientTxStatus {

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/safeOperations.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/safeOperations.ts
@@ -9,6 +9,7 @@ import {
   SafeClientResult,
   SendSafeOperationProps
 } from '@safe-global/sdk-starter-kit/types'
+import { DEFAULT_SAFE_MODULES_VERSION } from '@safe-global/sdk-starter-kit/constants'
 
 export type BundlerOptions = {
   bundlerUrl: string
@@ -56,7 +57,7 @@ export function safeOperations(
     const safe4337Pack = await Safe4337Pack.init({
       provider,
       signer,
-      safeModulesVersion: '0.2.0',
+      safeModulesVersion: DEFAULT_SAFE_MODULES_VERSION,
       bundlerUrl,
       options,
       paymasterOptions

--- a/packages/sdk-starter-kit/src/extensions/safe-operations/safeOperations.ts
+++ b/packages/sdk-starter-kit/src/extensions/safe-operations/safeOperations.ts
@@ -56,6 +56,7 @@ export function safeOperations(
     const safe4337Pack = await Safe4337Pack.init({
       provider,
       signer,
+      safeModulesVersion: '0.2.0',
       bundlerUrl,
       options,
       paymasterOptions


### PR DESCRIPTION
## What it solves
We make default the `v0.3.0` os the Safe Modules in the `relay-kit` so as `sdk-starter-kit` is not compatible until the backend services are updated then we need to default this kit to `v0.2.0`
