### PR TITLE
fix(api-kit): `node-fetch` dual compilation

### DIFF
--- a/packages/api-kit/src/utils/httpRequests.ts
+++ b/packages/api-kit/src/utils/httpRequests.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch'
-
 export enum HttpMethod {
   Get = 'get',
   Post = 'post',
@@ -13,6 +11,10 @@ interface HttpRequest {
 }
 
 export async function sendRequest<T>({ url, method, body }: HttpRequest): Promise<T> {
+  const fetch = await (typeof window === 'undefined'
+    ? import('node-fetch').then((m) => m.default)
+    : Promise.resolve(window.fetch))
+
   const response = await fetch(url, {
     method,
     headers: {


### PR DESCRIPTION
## What it solves
The dual compilation breaks node-fetch in browser environments

## How this PR fixes it
We are importing dynamically `node-fetch` only for node environments and keep the regular `fetch` for browser

Alternatively we could upgrade to `node-fetch` 3 but is only compatible with ESM so we need to include some polyfills to avoid host apps to break
