### PR TITLE
Fix: SafeERC4337Pack Compatibility with Entrypoint v0.7

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -51,7 +51,7 @@ import {
   signSafeOp,
   userOperationToHexValues
 } from './utils'
-import { entryPointToSafeModules, EQ_OR_GT_0_3_0 } from './utils/entrypoint'
+import { entryPointToSafeModules, GT_0_3_0 } from './utils/entrypoint'
 import { PimlicoFeeEstimator } from './estimators/PimlicoFeeEstimator'
 import { getRelayKitVersion } from './utils/getRelayKitVersion'
 
@@ -158,9 +158,9 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
     const safeModulesVersion = initOptions.safeModulesVersion || DEFAULT_SAFE_MODULES_VERSION
 
-    if (semverSatisfies(safeModulesVersion, EQ_OR_GT_0_3_0)) {
+    if (semverSatisfies(safeModulesVersion, GT_0_3_0)) {
       throw new Error(
-        `Incompatibility detected: Safe modules version ${safeModulesVersion} is not supported. The SDK can use 0.2.0 only.`
+        `Incompatibility detected: Safe modules version ${safeModulesVersion} is not supported. The SDK can use 0.3.0 at most.`
       )
     }
 

--- a/packages/relay-kit/src/packs/safe-4337/utils/entrypoint.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/entrypoint.ts
@@ -1,17 +1,18 @@
 import { ENTRYPOINT_ADDRESS_V06, ENTRYPOINT_ADDRESS_V07 } from '../constants'
 
 const EQ_0_2_0 = '0.2.0'
+const EQ_0_3_0 = '0.3.0'
 
-export const EQ_OR_GT_0_3_0 = '>=0.3.0'
+export const GT_0_3_0 = '>0.3.0'
 
 export function sameString(str1: string, str2: string): boolean {
   return str1.toLowerCase() === str2.toLowerCase()
 }
 
 export function entryPointToSafeModules(entryPoint: string) {
-  const moduleVersionToEntryPoint: Record<string, typeof EQ_0_2_0 | typeof EQ_OR_GT_0_3_0> = {
+  const moduleVersionToEntryPoint: Record<string, typeof EQ_0_2_0 | typeof EQ_0_3_0> = {
     [ENTRYPOINT_ADDRESS_V06]: EQ_0_2_0,
-    [ENTRYPOINT_ADDRESS_V07]: EQ_OR_GT_0_3_0
+    [ENTRYPOINT_ADDRESS_V07]: EQ_0_3_0
   }
 
   return moduleVersionToEntryPoint[entryPoint]


### PR DESCRIPTION
## What it solves
The [Safe SDK documentation](https://docs.safe.global/sdk/relay-kit/guides/4337-safe-sdk) states:

> We have added support for the Entrypoint v0.7 contract but we are not making it the default yet. If you are using Entrypoint v0.7, you need to set the `safeModuleVersion` to `0.3.0` when calling the `Safe4337Pack.init` method. This version of the Safe 4337 Module is the one compatible with the Entrypoint v0.7.

However, attempting to set `safeModuleVersion` to `0.3.0` in `SafeERC4337Pack` results in the following error:
Error: Incompatibility detected: Safe modules version 0.3.0 is not supported. The SDK can use 0.2.0 only.

### Fix
This PR resolves the issue by allowing `SafeERC4337Pack` to use version `0.3.0` as expected according to the documentation.