### PR TITLE
Use `MultiSendCallOnly` by default

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -512,7 +512,7 @@ class Safe {
    */
   async createTransaction({
     transactions,
-    onlyCalls = false,
+    onlyCalls = true,
     options
   }: CreateTransactionProps): Promise<SafeTransaction> {
     const safeVersion = this.getContractVersion()


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-core-sdk/issues/1168

## How this PR fixes it
Use the `MultiSendCallOnly` by default since `MultiSend` calls are being rejected.