### PR TITLE
feat(protocol-kit): set MultiSendCallOnly by default for MultiSend transactions

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -68,6 +68,7 @@ import EthSafeTransaction from './utils/transactions/SafeTransaction'
 import { SafeTransactionOptionalProps } from './utils/transactions/types'
 import {
   encodeMultiSendData,
+  hasDelegateCalls,
   isNewOwnerPasskey,
   isOldOwnerPasskey,
   isPasskeyParam,
@@ -528,9 +529,17 @@ class Safe {
 
     let newTransaction: SafeTransactionDataPartial
     if (transactions.length > 1) {
-      const multiSendContract = onlyCalls
-        ? this.#contractManager.multiSendCallOnlyContract
-        : this.#contractManager.multiSendContract
+      let multiSendContract
+      if (onlyCalls) {
+        if (hasDelegateCalls(transactions)) {
+          throw new Error(
+            'At least one transaction uses DELEGATECALL. By default only CALL is allowed. Check onlyCalls flag.'
+          )
+        }
+        multiSendContract = this.#contractManager.multiSendCallOnlyContract
+      } else {
+        multiSendContract = this.#contractManager.multiSendContract
+      }
 
       const multiSendData = encodeMultiSendData(transactions.map(standardizeMetaTransactionData))
 

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -512,7 +512,7 @@ class Safe {
    */
   async createTransaction({
     transactions,
-    onlyCalls = false,
+    onlyCalls = true,
     options
   }: CreateTransactionProps): Promise<SafeTransaction> {
     const safeVersion = this.getContractVersion()

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -318,7 +318,7 @@ export function createTxOptions(options?: TransactionOptions): Partial<WalletTra
 }
 
 export function hasDelegateCalls(transactions: MetaTransactionData[]): boolean {
-  return transactions.some((transaction) => {
-    transaction.operation && transaction.operation === OperationType.DelegateCall
-  })
+  return transactions.some(
+    (transaction) => transaction.operation && transaction.operation === OperationType.DelegateCall
+  )
 }

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -316,3 +316,9 @@ export function createTxOptions(options?: TransactionOptions): Partial<WalletTra
 
   return converted
 }
+
+export function hasDelegateCalls(transactions: MetaTransactionData[]): boolean {
+  return transactions.some((transaction) => {
+    transaction.operation && transaction.operation === OperationType.DelegateCall
+  })
+}

--- a/packages/protocol-kit/tests/e2e/createTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransaction.test.ts
@@ -347,13 +347,48 @@ describe('Transactions creation', () => {
           })
         }
       ]
-      const multiSendTx = await safeSdk.createTransaction({ transactions })
+      const multiSendTx = await safeSdk.createTransaction({ transactions, onlyCalls: false })
       chai
         .expect(multiSendTx.data.to)
         .to.be.eq(contractNetworks[chainId.toString()].multiSendAddress)
     })
 
-    it('should create a MultiSend transaction with options', async () => {
+    it('should create a MultiSendCallOnly transaction', async () => {
+      const { safe, accounts, contractNetworks, chainId } = await setupTests()
+      const erc20Mintable = await getERC20Mintable()
+      const safeAddress = safe.address
+      const safeSdk = await Safe.init({
+        provider,
+        safeAddress,
+        contractNetworks
+      })
+      const transactions = [
+        {
+          to: erc20Mintable.address,
+          value: '0',
+          data: encodeFunctionData({
+            abi: erc20Mintable.abi,
+            functionName: 'transfer',
+            args: [accounts[1].address, '1100000000000000000'] // 1.1 ERC20
+          })
+        },
+        {
+          to: erc20Mintable.address,
+          value: '0',
+          data: encodeFunctionData({
+            abi: erc20Mintable.abi,
+            functionName: 'transfer',
+            args: [accounts[1].address, '100000000000000000'] // 0.1 ERC20
+          })
+        }
+      ]
+      const multiSendTx = await safeSdk.createTransaction({ transactions })
+      chai
+        .expect(multiSendTx.data.to)
+        .to.be.eq(contractNetworks[chainId.toString()].multiSendCallOnlyAddress)
+    })
+
+    it('should create a MultiSendCallOnly transaction with options', async () => {
       const { safe, accounts, contractNetworks, chainId } = await setupTests()
       const erc20Mintable = await getERC20Mintable()
       const safeAddress = safe.address
@@ -387,7 +422,7 @@ describe('Transactions creation', () => {
       const multiSendTx = await safeSdk.createTransaction({ transactions, options })
       chai
         .expect(multiSendTx.data.to)
-        .to.be.eq(contractNetworks[chainId.toString()].multiSendAddress)
+        .to.be.eq(contractNetworks[chainId.toString()].multiSendCallOnlyAddress)
       chai.expect(multiSendTx.data.value).to.be.eq('0')
       chai.expect(multiSendTx.data.baseGas).to.be.eq(BASE_OPTIONS.baseGas)
       chai.expect(multiSendTx.data.gasPrice).to.be.eq(BASE_OPTIONS.gasPrice)

--- a/packages/protocol-kit/tests/e2e/createTransaction.test.ts
+++ b/packages/protocol-kit/tests/e2e/createTransaction.test.ts
@@ -21,7 +21,7 @@ const BASE_OPTIONS: SafeTransactionOptionalProps = {
   safeTxGas: '666'
 }
 
-describe.only('Transactions creation', () => {
+describe('Transactions creation', () => {
   const provider = getEip1193Provider()
 
   describe('standardizeSafeTransactionData', async () => {

--- a/packages/protocol-kit/tests/e2e/passkey.test.ts
+++ b/packages/protocol-kit/tests/e2e/passkey.test.ts
@@ -211,7 +211,8 @@ describe('Passkey', () => {
         const transactions = [addSharedSignerAddressOwner, configureSharedSignerTransaction]
 
         const configureSharedSignerSafeTransaction = await safeSdk.createTransaction({
-          transactions
+          transactions,
+          onlyCalls: false
         })
 
         // Sign the configure the shared Signer transaction with the EOA signer
@@ -346,7 +347,8 @@ describe('Passkey', () => {
           const transactions = [addSharedSignerAddressOwner, configureSharedSignerTransaction]
 
           const configureSharedSignerSafeTransaction = await safeSdk.createTransaction({
-            transactions
+            transactions,
+            onlyCalls: false
           })
 
           // Sign the configure the shared Signer transaction with the EOA signer
@@ -406,7 +408,8 @@ describe('Passkey', () => {
           const transactions = [addSharedSignerAddressOwner, configureSharedSignerTransaction]
 
           const configureSharedSignerSafeTransaction = await safeSdk.createTransaction({
-            transactions
+            transactions,
+            onlyCalls: false
           })
 
           // Sign the configure the shared Signer transaction with the EOA signer


### PR DESCRIPTION
## What it solves
Resolves #1168 and #803

## How this PR fixes it
Sets MultiSendCallOnly as default multisend operation