### PR TITLE
fix: check node process in config is available

### DIFF
--- a/packages/protocol-kit/scripts/safe-deployments/updateLocalNetworks.ts
+++ b/packages/protocol-kit/scripts/safe-deployments/updateLocalNetworks.ts
@@ -26,7 +26,7 @@ function updateLocalNetworks(networks: NetworkShortName[]) {
     const startIndex =
       content.indexOf('export const networks: NetworkShortName[] = [') +
       'export const networks: NetworkShortName[] = ['.length
-    const endIndex = content.indexOf(']\n\nif (process.env.TEST_NETWORK ===')
+    const endIndex = content.indexOf(']\n\nif (process && process.env.TEST_NETWORK ===')
 
     const sortedNetworks = networks
       .sort((a, b) => Number(a.chainId - b.chainId))

--- a/packages/protocol-kit/scripts/safe-deployments/updateLocalNetworks.ts
+++ b/packages/protocol-kit/scripts/safe-deployments/updateLocalNetworks.ts
@@ -26,7 +26,7 @@ function updateLocalNetworks(networks: NetworkShortName[]) {
     const startIndex =
       content.indexOf('export const networks: NetworkShortName[] = [') +
       'export const networks: NetworkShortName[] = ['.length
-    const endIndex = content.indexOf(']\n\nif (process && process.env.TEST_NETWORK ===')
+    const endIndex = content.indexOf(']\n\ntry {')
 
     const sortedNetworks = networks
       .sort((a, b) => Number(a.chainId - b.chainId))

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -396,6 +396,10 @@ export const networks: NetworkShortName[] = [
   { chainId: 920637907288165n, shortName: 'kkrt-starknet-sepolia' }
 ]
 
-if (process && process.env.TEST_NETWORK === 'hardhat') {
-  networks.push({ shortName: 'local', chainId: 31337n })
+try {
+  if (process.env.TEST_NETWORK === 'hardhat') {
+    networks.push({ shortName: 'local', chainId: 31337n })
+  }
+} catch {
+  // When process is not available we run on a browser environment
 }

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -396,6 +396,6 @@ export const networks: NetworkShortName[] = [
   { chainId: 920637907288165n, shortName: 'kkrt-starknet-sepolia' }
 ]
 
-if (process.env.TEST_NETWORK === 'hardhat') {
+if (process && process.env.TEST_NETWORK === 'hardhat') {
   networks.push({ shortName: 'local', chainId: 31337n })
 }


### PR DESCRIPTION
## What it solves
Resolves #1189

## How this PR fixes it
Check that node `process` exists before trying to fetch environment parameter