### PR TITLE
fix: zksync lens predict address

### DIFF
--- a/packages/protocol-kit/src/contracts/utils.ts
+++ b/packages/protocol-kit/src/contracts/utils.ts
@@ -49,6 +49,7 @@ export const PREDETERMINED_SALT_NONCE =
 
 const ZKSYNC_MAINNET = 324n
 const ZKSYNC_TESTNET = 300n
+const ZKSYNC_LENS = 232n
 // For bundle size efficiency we store SafeProxy.sol/GnosisSafeProxy.sol zksync bytecode hash in hex.
 // To get the values below we need to:
 // 1. Compile Safe smart contracts for zksync
@@ -62,6 +63,9 @@ const ZKSYNC_SAFE_PROXY_DEPLOYED_BYTECODE: {
 } = {
   '1.3.0': {
     deployedBytecodeHash: '0x0100004124426fb9ebb25e27d670c068e52f9ba631bd383279a188be47e3f86d'
+  },
+  '1.4.1': {
+    deployedBytecodeHash: '0x0100003b6cfa15bd7d1cae1c9c022074524d7785d34859ad0576d8fab4305d4f'
   }
 }
 
@@ -369,10 +373,10 @@ export async function predictSafeAddress({
 
   const from = safeProxyFactoryContract.getAddress()
 
-  // On the zkSync Era chain, the counterfactual deployment address is calculated differently
-  const isZkSyncEraChain = [ZKSYNC_MAINNET, ZKSYNC_TESTNET].includes(chainId)
-  if (isZkSyncEraChain) {
-    const proxyAddress = zkSyncEraCreate2Address(from, safeVersion, salt, asHex(input))
+  // On the zkSync chains, the counterfactual deployment address is calculated differently
+  const isZkSyncChain = [ZKSYNC_MAINNET, ZKSYNC_TESTNET, ZKSYNC_LENS].includes(chainId)
+  if (isZkSyncChain) {
+    const proxyAddress = zkSyncCreate2Address(from, safeVersion, salt, asHex(input))
 
     return safeProvider.getChecksummedAddress(proxyAddress)
   }
@@ -472,9 +476,9 @@ export function getSafeAddressFromDeploymentTx(
  * @param {`0x${string}`} salt - The salt used for address derivation.
  * @param {`0x${string}`} input - Additional input data for the derivation.
  *
- * @returns {string} The derived zkSync Era address.
+ * @returns {string} The derived zkSync address.
  */
-export function zkSyncEraCreate2Address(
+export function zkSyncCreate2Address(
   from: string,
   safeVersion: SafeVersion,
   salt: Hex,

--- a/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
+++ b/packages/protocol-kit/tests/e2e/utilsContracts.test.ts
@@ -548,7 +548,7 @@ describe('Contract utils', () => {
     )
 
     itif(safeVersionDeployed === '1.3.0')(
-      'returns the predicted address for Safes deployed on zkSync Era',
+      'returns the predicted address for Safes deployed on zkSync EVM',
       async () => {
         const { contractNetworks } = await setupTests()
 


### PR DESCRIPTION
## What it solves
Resolves #1195

## How this PR fixes it
 - Adds bytecodeHash for Safes v1.4.1
 - Adds Lens to the list of zkSync chains