### PR TITLE
[FIX] pass through onchainAnalytics

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -215,13 +215,21 @@ class Safe {
    * @throws "MultiSendCallOnly contract is not deployed on the current network"
    */
   async connect(config: ConnectSafeConfig): Promise<Safe> {
-    const { provider, signer, safeAddress, predictedSafe, isL1SafeSingleton, contractNetworks } =
-      config
+    const {
+      provider,
+      signer,
+      safeAddress,
+      predictedSafe,
+      isL1SafeSingleton,
+      contractNetworks,
+      onchainAnalytics
+    } = config
     const configProps: SafeConfigProps = {
       provider: provider || this.#safeProvider.provider,
       signer,
       isL1SafeSingleton: isL1SafeSingleton || this.#contractManager.isL1SafeSingleton,
-      contractNetworks: contractNetworks || this.#contractManager.contractNetworks
+      contractNetworks: contractNetworks || this.#contractManager.contractNetworks,
+      onchainAnalytics
     }
 
     // A new existing Safe is connected to the Signer


### PR DESCRIPTION
## What it solves
Adds onchain tracking when you connect a signer using the .connect() method. Otherwise, `onchainAnalytics` are not available when executing.

https://docs.safe.global/sdk/onchain-tracking

## How this PR fixes it
Allows signer to use the onchain tracking after connecting a signer to an initialized safe before execution.