### PR TITLE
feat(api-kit): add sonic transaction service url

### DIFF
--- a/packages/api-kit/src/utils/config.ts
+++ b/packages/api-kit/src/utils/config.ts
@@ -5,6 +5,7 @@ export const TRANSACTION_SERVICE_URLS: Record<string, string> = {
   '100': 'https://safe-transaction-gnosis-chain.safe.global/api',
   '130': 'https://safe-transaction-unichain.safe.global/api',
   '137': 'https://safe-transaction-polygon.safe.global/api',
+  '146': 'https://safe-transaction-sonic.safe.global/api',
   '196': 'https://safe-transaction-xlayer.safe.global/api',
   '324': 'https://safe-transaction-zksync.safe.global/api',
   '480': 'https://safe-transaction-worldchain.safe.global/api',


### PR DESCRIPTION
## What it solves
When initializing safe api key with Sonic chainId `46` without specifying the `txServiceUrl` 

```js
new SafeApiKit({
      chainId: 46n,
      // txServiceUrl: 'https://safe-transaction-sonic.safe.global/api'
})
```

The error `TypeError: There is no transaction service available for chainId 46. Please set the txServiceUrl property to use a custom transaction service.` is thrown

## How this PR fixes it
By adding the Sonic tx service url to the `TRANSACTION_SERVICE_URLS` dict
