### PR TITLE
ci: add GitHub Actions workflow for Safe Core SDK build and test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Safe Core SDK CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  safe-sdk-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: 📦 Install dependencies
+        run: |
+          corepack enable
+          pnpm install
+
+      - name: 🔍 TypeScript Check
+        run: pnpm tsc --noEmit
+
+      - name: 🧪 Run Safe SDK script
+        run: pnpm ts-node scripts/safe-client.ts
+
+      - name: ✅ Done
+        run: echo "Safe SDK CI complete!"


### PR DESCRIPTION
- Added `.github/workflows/main.yml` for CI using GitHub Actions
- Installs Safe Core SDK dependencies via pnpm
- Runs TypeScript type check (`tsc --noEmit`)
- Executes Safe SDK test script from `scripts/safe-client.ts`
- Supports manual dispatch, push, and pull_request events
- Uses Node.js 18 with pnpm caching enabled for faster CI

## What it solves
Resolves #

## How this PR fixes it
