### PR TITLE
Add Autonomys EVM

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -104,6 +104,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 747n, shortName: 'flow-mainnet' },
   { chainId: 787n, shortName: 'aca' },
   { chainId: 842n, shortName: 'taratest' },
+  { chainId: 870n, shortName: 'amn' },
   { chainId: 919n, shortName: 'modesep' },
   { chainId: 938n, shortName: 'haust' },
   { chainId: 943n, shortName: 't4pls' },


### PR DESCRIPTION
This pull request adds support for a new network in the EIP-3770 configuration.

Network support:

* Added the `amn` network with `chainId` 870 to the `networks` array in `config.ts`.