### PR TITLE
chore: V5 lts bump safe deployments

### DIFF
--- a/packages/api-kit/package.json
+++ b/packages/api-kit/package.json
@@ -58,7 +58,7 @@
     "web3": "^4.12.1"
   },
   "dependencies": {
-    "@safe-global/protocol-kit": "^5.2.14",
+    "@safe-global/protocol-kit": "^5.2.15",
     "@safe-global/types-kit": "^1.0.5",
     "node-fetch": "^2.7.0",
     "viem": "^2.21.8"

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/protocol-kit",
-  "version": "5.2.14",
+  "version": "5.2.15",
   "description": "SDK that facilitates the interaction with Safe Smart Accounts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -69,8 +69,8 @@
     "web3": "^4.12.1"
   },
   "dependencies": {
-    "@safe-global/safe-deployments": "^1.37.42",
-    "@safe-global/safe-modules-deployments": "^2.2.14",
+    "@safe-global/safe-deployments": "^1.37.44",
+    "@safe-global/safe-modules-deployments": "^2.2.15",
     "@safe-global/types-kit": "^1.0.5",
     "abitype": "^1.0.2",
     "semver": "^7.6.3",

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -261,6 +261,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 9369n, shortName: 'z' },
   { chainId: 9700n, shortName: 'MainnetDev' },
   { chainId: 9728n, shortName: 'boba-testnet' },
+  { chainId: 9745n, shortName: 'plasma' },
   { chainId: 9746n, shortName: 'plasma' },
   { chainId: 10000n, shortName: 'smartbch' },
   { chainId: 10001n, shortName: 'smartbchtest' },

--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,1 +1,1 @@
-export const getProtocolKitVersion = () => '5.2.14'
+export const getProtocolKitVersion = () => '5.2.15'

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.5.0",
     "@safe-global/protocol-kit": "^5.2.14",
-    "@safe-global/safe-modules-deployments": "^2.2.14",
+    "@safe-global/safe-modules-deployments": "^2.2.15",
     "@safe-global/types-kit": "^1.0.5",
     "semver": "^7.6.3",
     "viem": "^2.21.8"

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.5.0",
-    "@safe-global/protocol-kit": "^5.2.14",
+    "@safe-global/protocol-kit": "^5.2.15",
     "@safe-global/safe-modules-deployments": "^2.2.15",
     "@safe-global/types-kit": "^1.0.5",
     "semver": "^7.6.3",

--- a/packages/sdk-starter-kit/package.json
+++ b/packages/sdk-starter-kit/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@safe-global/api-kit": "^2.5.11",
-    "@safe-global/protocol-kit": "^5.2.14",
+    "@safe-global/protocol-kit": "^5.2.15",
     "@safe-global/relay-kit": "^3.4.6",
     "@safe-global/types-kit": "^1.0.5",
     "viem": "^2.21.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,17 +1729,17 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-contracts/-/safe-contracts-1.4.1.tgz#82605342f3289dc6b99818f599a3409ec2cb3fdc"
   integrity sha512-fP1jewywSwsIniM04NsqPyVRFKPMAuirC3ftA/TA4X3Zc5EnwQp/UCJUU2PL/37/z/jMo8UUaJ+pnFNWmMU7dQ==
 
-"@safe-global/safe-deployments@^1.37.42":
-  version "1.37.42"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.42.tgz#dea932a447fe2c76d894df8de4f0aed72ed7fcef"
-  integrity sha512-hu/GEQhO5lmHsSeVJavtVysdqy16VAumd3pgILN9bTj82ImlHWgkFNYXyeOSbjPvmizdnVVEUzH49yBmoM6oMQ==
+"@safe-global/safe-deployments@^1.37.44":
+  version "1.37.44"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.44.tgz#160035504f46e7d063c7f8ba12132f81b4f0e263"
+  integrity sha512-fdmWxU7U5FLqfIl2aFFRFKBiOxWVAFYtpbneJIYfeNObvAnFsoQDKN4qym2hCDKTuIrnfX2jv8tqfrIxxMyOpA==
   dependencies:
     semver "^7.6.2"
 
-"@safe-global/safe-modules-deployments@^2.2.14":
-  version "2.2.14"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.14.tgz#420731687dbc5dfbeb2da0143e73e225979eb39b"
-  integrity sha512-tSwTXIroF7ynxcWKGBsEspHspYcuvd5yF0Y85xFe3Gk4rGoQ20onalF4N8yHsa4+exIXpHEyKiysWqVBmwgDpw==
+"@safe-global/safe-modules-deployments@^2.2.15":
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.15.tgz#75ce38443e60a9c38a026abb55da950fceab949c"
+  integrity sha512-fQWcc11+n+8I3vV+gAK9ivnemxz4VZkfmybuCuMjBTtz9fqlUiCP1+qCaQKhVbSt7Kz5gyg6//mXR7CFSrIkYw==
 
 "@safe-global/safe-passkey@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What it solves
Bump Safe deployments to the latest version