### PR TITLE
fix: stable shortname duplication with testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "./packages/**/*.{json,md}": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/api-kit/package.json
+++ b/packages/api-kit/package.json
@@ -58,7 +58,7 @@
     "web3": "^4.12.1"
   },
   "dependencies": {
-    "@safe-global/protocol-kit": "^5.2.19",
+    "@safe-global/protocol-kit": "^5.2.20",
     "@safe-global/types-kit": "^1.0.5",
     "node-fetch": "^2.7.0",
     "viem": "^2.21.8"

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/protocol-kit",
-  "version": "5.2.19",
+  "version": "5.2.20",
   "description": "SDK that facilitates the interaction with Safe Smart Accounts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -181,7 +181,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 2039n, shortName: 'aleph' },
   { chainId: 2187n, shortName: 'g7' },
   { chainId: 2192n, shortName: 'snax' },
-  { chainId: 2201n, shortName: 'stable' },
+  { chainId: 2201n, shortName: 'stable-testnet' },
   { chainId: 2221n, shortName: 'tkava' },
   { chainId: 2222n, shortName: 'kava' },
   { chainId: 2331n, shortName: 'rss3-testnet' },

--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,1 +1,1 @@
-export const getProtocolKitVersion = () => '5.2.19'
+export const getProtocolKitVersion = () => '5.2.20'

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.5.0",
-    "@safe-global/protocol-kit": "^5.2.19",
+    "@safe-global/protocol-kit": "^5.2.20",
     "@safe-global/safe-modules-deployments": "^2.2.19",
     "@safe-global/types-kit": "^1.0.5",
     "semver": "^7.6.3",

--- a/packages/sdk-starter-kit/package.json
+++ b/packages/sdk-starter-kit/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@safe-global/api-kit": "^2.5.11",
-    "@safe-global/protocol-kit": "^5.2.19",
+    "@safe-global/protocol-kit": "^5.2.20",
     "@safe-global/relay-kit": "^3.4.6",
     "@safe-global/types-kit": "^1.0.5",
     "viem": "^2.21.8"


### PR DESCRIPTION
## What it solves
Solves shortname duplication for Stable chain as testnet used same short name in DefiLlama

## How this PR fixes it
Update the testnet shortname to the new one.

Adds `packageManager` to package.json so it's easier to understand which package manager to use with the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames EIP-3770 shortname for chain 2201 to `stable-testnet`, bumps `protocol-kit` to 5.2.20 with dependent packages updated, and adds `packageManager` to root `package.json`.
> 
> - **Protocol Kit**:
>   - **EIP-3770**: Update `shortName` for chain `2201` from `stable` to `stable-testnet` in `src/utils/eip-3770/config.ts`.
>   - **Versioning**: Bump to `5.2.20` and update `getProtocolKitVersion`.
> - **Dependencies**:
>   - Update `@safe-global/protocol-kit` to `^5.2.20` in `packages/api-kit`, `packages/relay-kit`, and `packages/sdk-starter-kit`.
> - **Tooling**:
>   - Add `packageManager` to root `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d515a400bb8a843e7d5b32c34aefeac0b03ccbb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->