### PR TITLE
feat: add short name for Sophon OS Testnet

### DIFF
--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -453,6 +453,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 333000333n, shortName: 'meld' },
   { chainId: 476462898n, shortName: 'Skopje' },
   { chainId: 531050104n, shortName: 'sophon-testnet' },
+  { chainId: 531050204n, shortName: 'sophon-os-testnet' },
   { chainId: 666666666n, shortName: 'degen-chain' },
   { chainId: 888888888n, shortName: 'ancient8' },
   { chainId: 994873017n, shortName: 'lumia-mainnet' },


### PR DESCRIPTION
## What it solves
Adds short name for Sophon OS Testnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `sophon-os-testnet` (chainId `531050204`) to the EIP-3770 `networks` mapping in `packages/protocol-kit/src/utils/eip-3770/config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd8f685e87441cb91d24a3e93aad1334d87e682f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->