### PR TITLE
Migrate relay-kit from @gelatonetwork/relay-sdk to @gelatocloud/gasless

### DIFF
--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -55,11 +55,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@gelatonetwork/relay-sdk": "^5.6.0",
+    "@gelatocloud/gasless": "^0.0.7",
     "@safe-global/protocol-kit": "^6.1.2",
     "@safe-global/safe-modules-deployments": "^2.2.21",
     "@safe-global/types-kit": "^3.0.0",
     "semver": "^7.7.2",
-    "viem": "^2.21.8"
+    "viem": "2.21.59"
   }
 }

--- a/packages/relay-kit/src/RelayKitBasePack.ts
+++ b/packages/relay-kit/src/RelayKitBasePack.ts
@@ -1,7 +1,5 @@
 import Safe from '@safe-global/protocol-kit'
 type RelayKitBasePackTypes = {
-  EstimateFeeProps?: unknown
-  EstimateFeeResult?: unknown
   CreateTransactionProps?: unknown
   CreateTransactionResult: unknown
   ExecuteTransactionProps: {
@@ -23,8 +21,6 @@ type DefaultRelayKitBasePackTypes = {
  * Abstract class. The base class for all RelayKit packs.
  * It provides the Safe SDK instance and the abstract methods to be implemented by the packs.
  * @abstract
- * @template EstimateFeeProps
- * @template EstimateFeeResult
  * @template CreateTransactionProps
  * @template CreateTransactionResult,
  * @template ExecuteTransactionProps
@@ -46,14 +42,6 @@ export abstract class RelayKitBasePack<
   constructor(protocolKit: Safe) {
     this.protocolKit = protocolKit
   }
-
-  /**
-   * Abstract function to get an estimate of the fee that will be paid for a transaction.
-   * @abstract
-   * @param {EstimateFeeProps} props - The props for fee estimation.
-   * @returns Promise<EstimateFeeResult> - The estimated fee result.
-   */
-  abstract getEstimateFee(props: T['EstimateFeeProps']): Promise<T['EstimateFeeResult']>
 
   /**
    * Abstract function to create a Safe transaction, designed to be executed using the relayer.

--- a/packages/relay-kit/src/constants.ts
+++ b/packages/relay-kit/src/constants.ts
@@ -1,13 +1,1 @@
-export const GELATO_NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
-
-export const GELATO_FEE_COLLECTOR = '0x3AC05161b76a35c1c28dC99Aa01BEd7B24cEA3bf'
-
-export const GELATO_RELAY_URL = 'https://relay.gelato.digital'
-
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-
-// see: https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters#optional-parameters
-export const GELATO_GAS_EXECUTION_OVERHEAD = 150_000
-
-// gas cost of the separate ERC20 transfer to pay the fees to the Gelato relayer
-export const GELATO_TRANSFER_GAS_COST = 15_000

--- a/packages/relay-kit/src/index.ts
+++ b/packages/relay-kit/src/index.ts
@@ -17,9 +17,3 @@ export * from './RelayKitBasePack'
 
 export { GenericFeeEstimator } from './packs/safe-4337/estimators/generic/GenericFeeEstimator'
 export { PimlicoFeeEstimator } from './packs/safe-4337/estimators/pimlico/PimlicoFeeEstimator'
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayPack.test.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayPack.test.ts
@@ -1,43 +1,18 @@
-import { TransactionStatusResponse } from '@gelatonetwork/relay-sdk'
-import Safe, {
-  isGasTokenCompatibleWithHandlePayment,
-  estimateTxBaseGas,
-  estimateSafeTxGas,
-  estimateSafeDeploymentGas,
-  createERC20TokenTransferTransaction
-} from '@safe-global/protocol-kit'
+import Safe from '@safe-global/protocol-kit'
 import { MetaTransactionData, OperationType, SafeTransaction } from '@safe-global/types-kit'
 
-import {
-  GELATO_FEE_COLLECTOR,
-  GELATO_NATIVE_TOKEN_ADDRESS,
-  ZERO_ADDRESS
-} from '@safe-global/relay-kit/constants'
 import { GelatoRelayPack } from './GelatoRelayPack'
-
-enum TaskState {
-  CheckPending = 'CheckPending'
-}
 
 const CHAIN_ID = 1n
 const ADDRESS = '0x...address'
-const GAS_TOKEN = '0x...gasToken'
 const SAFE_ADDRESS = '0x...safe-address'
 const API_KEY = 'api-key'
-const FEE_ESTIMATION = BigInt(100_000)
-const BASEGAS_ESTIMATION = '20000'
-const SAFETXGAS_ESTIMATION = '10000'
-const SAFE_DEPLOYMENT_GAS_ESTIMATION = '30000'
 const TASK_ID = 'task-id'
-const TASK_STATUS: TransactionStatusResponse = {
-  chainId: Number(CHAIN_ID),
-  taskState: TaskState.CheckPending,
-  taskId: TASK_ID,
-  creationDate: Date.now().toString()
+const TASK_STATUS = {
+  status: 'Included',
+  receipt: { transactionHash: '0x...hash' }
 }
-const RELAY_RESPONSE = {
-  taskId: TASK_ID
-}
+
 const SAFE_TRANSACTION = {
   data: {
     operation: OperationType.Call,
@@ -53,49 +28,27 @@ const SAFE_TRANSACTION = {
   }
 }
 
-const mockGetEstimateFee = jest.fn().mockResolvedValue(FEE_ESTIMATION)
-const mockGetTaskStatus = jest.fn().mockResolvedValue(TASK_STATUS)
-const mockSponsoredCall = jest.fn().mockResolvedValue(RELAY_RESPONSE)
-const mockCallWithSyncFee = jest.fn().mockResolvedValue(RELAY_RESPONSE)
+const mockSendTransaction = jest.fn().mockResolvedValue(TASK_ID)
+const mockWaitForStatus = jest.fn().mockResolvedValue(TASK_STATUS)
 
-jest.mock('@gelatonetwork/relay-sdk', () => {
+jest.mock('@gelatocloud/gasless', () => {
   return {
-    GelatoRelay: jest.fn().mockImplementation(() => {
+    createGelatoEvmRelayerClient: jest.fn().mockImplementation(() => {
       return {
-        getEstimatedFee: mockGetEstimateFee,
-        getTaskStatus: mockGetTaskStatus,
-        sponsoredCall: mockSponsoredCall,
-        callWithSyncFee: mockCallWithSyncFee
+        sendTransaction: mockSendTransaction,
+        waitForStatus: mockWaitForStatus
       }
-    })
+    }),
+    sponsored: jest.fn().mockReturnValue({ type: 'sponsored' })
   }
 })
 
-jest.mock('@safe-global/protocol-kit')
-
-// Cast the import to jest.Mocked type
-const mockEstimateTxBaseGas = estimateTxBaseGas as jest.MockedFunction<typeof estimateTxBaseGas>
-const mockEstimateSafeTxGas = estimateSafeTxGas as jest.MockedFunction<typeof estimateSafeTxGas>
-const mockEstimateSafeDeploymentGas = estimateSafeDeploymentGas as jest.MockedFunction<
-  typeof estimateSafeDeploymentGas
->
-const mockCreateERC20TokenTransferTransaction =
-  createERC20TokenTransferTransaction as jest.MockedFunction<
-    typeof createERC20TokenTransferTransaction
-  >
-const mockedIsGasTokenCompatibleWithHandlePayment =
-  isGasTokenCompatibleWithHandlePayment as jest.MockedFunction<
-    typeof isGasTokenCompatibleWithHandlePayment
-  >
-
-jest.doMock('@safe-global/protocol-kit', () => ({
-  ...jest.requireActual('@safe-global/protocol-kit'),
-  estimateTxBaseGas: mockEstimateTxBaseGas,
-  estimateSafeTxGas: mockEstimateSafeTxGas,
-  estimateSafeDeploymentGas: mockEstimateSafeDeploymentGas,
-  createERC20TokenTransferTransaction: mockCreateERC20TokenTransferTransaction,
-  isGasTokenCompatibleWithHandlePayment: mockedIsGasTokenCompatibleWithHandlePayment
-}))
+jest.mock('@safe-global/protocol-kit', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({}))
+  }
+})
 
 const safe: Safe = new Safe()
 
@@ -104,348 +57,65 @@ const gelatoRelayPack = new GelatoRelayPack({ apiKey: API_KEY, protocolKit: safe
 describe('GelatoRelayPack', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockEstimateTxBaseGas.mockResolvedValue(Promise.resolve(BASEGAS_ESTIMATION))
-    mockEstimateSafeTxGas.mockResolvedValue(Promise.resolve(SAFETXGAS_ESTIMATION))
-    mockEstimateSafeDeploymentGas.mockResolvedValue(Promise.resolve(SAFE_DEPLOYMENT_GAS_ESTIMATION))
-  })
-
-  it('should allow to get a fee estimation', async () => {
-    const chainId = 1n
-    const gasLimit = '100000'
-    const gasToken = '0x0000000000000000000000000000000000000000'
-    const estimation = await gelatoRelayPack.getEstimateFee({ chainId, gasLimit, gasToken })
-
-    expect(estimation).toBe(FEE_ESTIMATION.toString())
-    expect(mockGetEstimateFee).toHaveBeenCalledWith(
-      chainId,
-      GELATO_NATIVE_TOKEN_ADDRESS,
-      BigInt(gasLimit),
-      false
-    )
-    expect(BigInt(estimation) > 0).toBe(true)
   })
 
   it('should allow to check the task status', async () => {
-    const taskId = 'task-id'
-    const status = await gelatoRelayPack.getTaskStatus(taskId)
+    const status = await gelatoRelayPack.getTaskStatus(TASK_ID)
 
     expect(status).toBe(TASK_STATUS)
-    expect(mockGetTaskStatus).toHaveBeenCalledWith('task-id')
+    expect(mockWaitForStatus).toHaveBeenCalledWith({ id: TASK_ID })
   })
 
   it('should allow to make a sponsored transaction', async () => {
     const response = await gelatoRelayPack.sendSponsorTransaction(SAFE_ADDRESS, '0x', CHAIN_ID)
 
-    expect(response).toBe(RELAY_RESPONSE)
-    expect(mockSponsoredCall).toHaveBeenCalledWith(
-      {
-        chainId: CHAIN_ID,
-        target: SAFE_ADDRESS,
-        data: '0x'
-      },
-      API_KEY
-    )
-  })
-
-  it('should throw an error when trying to do a sponsored transaction without an api key', async () => {
-    const relayPack = new GelatoRelayPack({ protocolKit: safe })
-
-    await expect(relayPack.sendSponsorTransaction(SAFE_ADDRESS, '0x', CHAIN_ID)).rejects.toThrow(
-      'API key not defined'
-    )
-  })
-
-  describe('when creating a relayed transaction', () => {
-    describe('When gas limit is manually defined', () => {
-      let relayPack: GelatoRelayPack
-      const transactions: MetaTransactionData[] = [
-        {
-          to: ADDRESS,
-          data: '0x',
-          value: '0'
-        }
-      ]
-      const options = {
-        gasLimit: '100',
-        isSponsored: true
-      }
-
-      beforeEach(() => {
-        jest.clearAllMocks()
-        relayPack = new GelatoRelayPack({ protocolKit: safe })
-        safe.getNonce = jest.fn().mockResolvedValue(0)
-        safe.getChainId = jest.fn().mockResolvedValue(0)
-        safe.getContractManager = jest.fn().mockReturnValue({ safeContract: {} })
-        safe.createTransaction = jest.fn().mockResolvedValue(SAFE_TRANSACTION)
-        mockedIsGasTokenCompatibleWithHandlePayment.mockResolvedValue(Promise.resolve(true))
-      })
-
-      it('should allow you to create a sponsored one', async () => {
-        await relayPack.createTransaction({ transactions, options })
-
-        expect(safe.createTransaction).toHaveBeenCalledWith({
-          transactions,
-          onlyCalls: false,
-          options: {
-            nonce: 0
-          }
-        })
-      })
-
-      it('should allow to create a sync fee one', async () => {
-        await relayPack.createTransaction({
-          transactions,
-          options: { ...options, isSponsored: false }
-        })
-
-        expect(safe.createTransaction).toHaveBeenCalledWith({
-          transactions,
-          onlyCalls: false,
-          options: {
-            baseGas: FEE_ESTIMATION.toString(),
-            safeTxGas: SAFETXGAS_ESTIMATION,
-            gasPrice: '1',
-            gasToken: ZERO_ADDRESS, // native token
-            refundReceiver: GELATO_FEE_COLLECTOR,
-            nonce: 0
-          }
-        })
-      })
-
-      it('should return the correct gasToken when being sent through the options', async () => {
-        await relayPack.createTransaction({
-          transactions,
-          options: { ...options, isSponsored: false, gasToken: GAS_TOKEN }
-        })
-
-        expect(safe.createTransaction).toHaveBeenCalledWith({
-          transactions,
-          onlyCalls: false,
-          options: {
-            baseGas: FEE_ESTIMATION.toString(),
-            safeTxGas: SAFETXGAS_ESTIMATION,
-            gasPrice: '1',
-            gasToken: GAS_TOKEN,
-            refundReceiver: GELATO_FEE_COLLECTOR,
-            nonce: 0
-          }
-        })
-      })
-
-      it('should allow you to create relay transaction using a non standard ERC20 gas token to pay Gelato fees', async () => {
-        // non standard ERC20 like USDC
-        mockedIsGasTokenCompatibleWithHandlePayment.mockResolvedValue(Promise.resolve(false))
-
-        const options = {
-          gasToken: GAS_TOKEN,
-          isSponsored: false,
-          gasLimit: '5000' // manual gas limit
-        }
-
-        const transferToGelato = {
-          to: GELATO_FEE_COLLECTOR,
-          value: FEE_ESTIMATION.toString(),
-          data: '0x'
-        }
-
-        mockCreateERC20TokenTransferTransaction.mockReturnValue(transferToGelato)
-
-        await relayPack.createTransaction({ transactions, options })
-
-        expect(safe.createTransaction).toHaveBeenCalledWith({
-          transactions: [...transactions, transferToGelato], // the transfer to Gelato is prensent
-          onlyCalls: false,
-          options: {
-            gasToken: GAS_TOKEN, // non standard ERC20 gas token
-            nonce: 0
-          }
-        })
-      })
+    expect(response).toBe(TASK_ID)
+    expect(mockSendTransaction).toHaveBeenCalledWith({
+      chainId: Number(CHAIN_ID),
+      to: SAFE_ADDRESS,
+      data: '0x',
+      payment: { type: 'sponsored' }
     })
+  })
 
-    describe('When gas limit is automatically estimate', () => {
-      let relayPack: GelatoRelayPack
-      const mockTransferTransacton: MetaTransactionData = {
+  describe('when creating a transaction', () => {
+    const transactions: MetaTransactionData[] = [
+      {
         to: ADDRESS,
         data: '0x',
         value: '0'
       }
+    ]
 
-      const transactions: MetaTransactionData[] = [mockTransferTransacton]
+    beforeEach(() => {
+      jest.clearAllMocks()
+      safe.getNonce = jest.fn().mockResolvedValue(0)
+      safe.createTransaction = jest.fn().mockResolvedValue(SAFE_TRANSACTION)
+    })
 
-      beforeEach(() => {
-        jest.clearAllMocks()
-        relayPack = new GelatoRelayPack({ protocolKit: safe })
-        safe.getNonce = jest.fn().mockResolvedValue(0)
-        safe.getChainId = jest.fn().mockResolvedValue(0)
-        safe.getContractManager = jest.fn().mockReturnValue({ safeContract: {} })
-        safe.createTransaction = jest.fn().mockResolvedValue(SAFE_TRANSACTION)
-        mockedIsGasTokenCompatibleWithHandlePayment.mockResolvedValue(Promise.resolve(true))
-      })
+    it('should create a sponsored transaction', async () => {
+      await gelatoRelayPack.createTransaction({ transactions })
 
-      it('should allow you to create a sponsored one', async () => {
-        const options = {
-          isSponsored: true
+      expect(safe.createTransaction).toHaveBeenCalledWith({
+        transactions,
+        onlyCalls: false,
+        options: {
+          nonce: 0
         }
-
-        await relayPack.createTransaction({ transactions, options })
-
-        expect(safe.createTransaction).toHaveBeenCalledWith({
-          transactions,
-          onlyCalls: false,
-          options: {
-            nonce: 0
-          }
-        })
-      })
-
-      describe('When a compatible gas token is used', () => {
-        beforeEach(() => {
-          jest.clearAllMocks()
-          mockedIsGasTokenCompatibleWithHandlePayment.mockResolvedValue(Promise.resolve(true))
-        })
-
-        it('should allow you to create relay transaction using the native token to pay Gelato fees', async () => {
-          await relayPack.createTransaction({ transactions })
-
-          expect(safe.createTransaction).toHaveBeenCalledWith({
-            transactions,
-            onlyCalls: false,
-            options: {
-              baseGas: FEE_ESTIMATION.toString(),
-              gasPrice: '1',
-              safeTxGas: SAFETXGAS_ESTIMATION,
-              gasToken: ZERO_ADDRESS, // native token
-              refundReceiver: GELATO_FEE_COLLECTOR,
-              nonce: 0
-            }
-          })
-        })
-
-        it('should allow you to create relay transaction using a compatible ERC20 token to pay Gelato fees', async () => {
-          const options = {
-            gasToken: GAS_TOKEN
-          }
-
-          await relayPack.createTransaction({ transactions, options })
-
-          expect(safe.createTransaction).toHaveBeenCalledWith({
-            transactions,
-            onlyCalls: false,
-            options: {
-              baseGas: FEE_ESTIMATION.toString(),
-              gasPrice: '1',
-              safeTxGas: SAFETXGAS_ESTIMATION,
-              gasToken: GAS_TOKEN, // ERC20 gas token
-              refundReceiver: GELATO_FEE_COLLECTOR,
-              nonce: 0
-            }
-          })
-        })
-      })
-
-      describe('When a non compatible gas token is used', () => {
-        beforeEach(() => {
-          jest.clearAllMocks()
-          mockedIsGasTokenCompatibleWithHandlePayment.mockResolvedValue(Promise.resolve(false))
-        })
-
-        it('should allow you to create relay transaction using a non standard ERC20 gas token to pay Gelato fees', async () => {
-          const options = {
-            gasToken: GAS_TOKEN
-          }
-
-          const transferToGelato = {
-            to: GELATO_FEE_COLLECTOR,
-            value: FEE_ESTIMATION.toString(),
-            data: '0x'
-          }
-
-          mockCreateERC20TokenTransferTransaction.mockReturnValue(transferToGelato)
-
-          await relayPack.createTransaction({ transactions, options })
-
-          expect(safe.createTransaction).toHaveBeenCalledWith({
-            transactions: [...transactions, transferToGelato], // the transfer to Gelato is prensent
-            onlyCalls: false,
-            options: {
-              gasToken: GAS_TOKEN, // non standard ERC20 gas token
-              nonce: 0
-            }
-          })
-        })
       })
     })
-  })
 
-  it('should allow to make a sync fee transaction', async () => {
-    const response = await gelatoRelayPack.sendSyncTransaction(SAFE_ADDRESS, '0x', CHAIN_ID, {
-      gasLimit: '100000'
+    it('should create a transaction with onlyCalls option', async () => {
+      await gelatoRelayPack.createTransaction({ transactions, onlyCalls: true })
+
+      expect(safe.createTransaction).toHaveBeenCalledWith({
+        transactions,
+        onlyCalls: true,
+        options: {
+          nonce: 0
+        }
+      })
     })
-
-    expect(response).toBe(RELAY_RESPONSE)
-    expect(mockCallWithSyncFee).toHaveBeenCalledWith(
-      {
-        chainId: CHAIN_ID,
-        target: SAFE_ADDRESS,
-        data: '0x',
-        feeToken: GELATO_NATIVE_TOKEN_ADDRESS,
-        isRelayContext: false
-      },
-      {
-        gasLimit: BigInt(100_000)
-      }
-    )
-  })
-
-  it('should expose a relayTransaction doing a sponsored or sync fee transaction depending on an optional parameter', async () => {
-    const sponsoredResponse = await gelatoRelayPack.relayTransaction({
-      target: SAFE_ADDRESS,
-      encodedTransaction: '0x',
-      chainId: CHAIN_ID,
-      options: {
-        gasLimit: '100000',
-        isSponsored: true
-      }
-    })
-
-    expect(sponsoredResponse).toBe(RELAY_RESPONSE)
-    expect(mockSponsoredCall).toHaveBeenCalledWith(
-      {
-        chainId: CHAIN_ID,
-        target: SAFE_ADDRESS,
-        data: '0x'
-      },
-      API_KEY
-    )
-
-    const paidResponse = await gelatoRelayPack.relayTransaction({
-      target: SAFE_ADDRESS,
-      encodedTransaction: '0x',
-      chainId: CHAIN_ID,
-      options: {
-        gasLimit: '100000',
-        isSponsored: false
-      }
-    })
-
-    expect(paidResponse).toBe(RELAY_RESPONSE)
-    expect(mockCallWithSyncFee).toHaveBeenCalledWith(
-      {
-        chainId: CHAIN_ID,
-        target: SAFE_ADDRESS,
-        data: '0x',
-        feeToken: GELATO_NATIVE_TOKEN_ADDRESS,
-        isRelayContext: false
-      },
-      {
-        gasLimit: BigInt(100_000)
-      }
-    )
-  })
-
-  it('should allow to retrieve the fee collector address', () => {
-    expect(gelatoRelayPack.getFeeCollector()).toBe(GELATO_FEE_COLLECTOR)
   })
 
   describe('executeTransaction', () => {
@@ -454,7 +124,7 @@ describe('GelatoRelayPack', () => {
     const SAFE_DEPLOYMENT_BATCH = {
       to: MULTISEND_ADDRESS,
       value: '0',
-      data: '0x...deplymentBachData'
+      data: '0x...deploymentBatchData'
     }
 
     beforeEach(() => {
@@ -479,57 +149,17 @@ describe('GelatoRelayPack', () => {
           }
         }
 
-        const gelatoResponse = await gelatoRelayPack.executeTransaction({
-          executable: relayTransaction as SafeTransaction,
-          options: {
-            isSponsored: true
-          }
-        })
-
-        expect(gelatoResponse).toBe(RELAY_RESPONSE)
-        expect(mockSponsoredCall).toHaveBeenCalledWith(
-          {
-            chainId: CHAIN_ID,
-            target: SAFE_ADDRESS,
-            data: ENCODED_TRANSACTION_DATA
-          },
-          API_KEY
-        )
-        // no counterfactual deployment present
-        expect(safe.wrapSafeTransactionIntoDeploymentBatch).not.toHaveBeenCalled()
-      })
-
-      it('should execute a sync relay transaction', async () => {
-        const relayTransaction = {
-          data: {
-            operation: OperationType.Call,
-            safeTxGas: SAFETXGAS_ESTIMATION,
-            baseGas: FEE_ESTIMATION.toString(),
-            gasPrice: '1',
-            nonce: 0,
-            gasToken: GAS_TOKEN,
-            refundReceiver: GELATO_FEE_COLLECTOR,
-            to: ADDRESS,
-            value: '0',
-            data: '0x'
-          }
-        }
-
-        const gelatoResponse = await gelatoRelayPack.executeTransaction({
+        const taskId = await gelatoRelayPack.executeTransaction({
           executable: relayTransaction as SafeTransaction
         })
 
-        expect(gelatoResponse).toBe(RELAY_RESPONSE)
-        expect(mockCallWithSyncFee).toHaveBeenCalledWith(
-          {
-            chainId: CHAIN_ID,
-            target: SAFE_ADDRESS,
-            data: ENCODED_TRANSACTION_DATA,
-            feeToken: GAS_TOKEN,
-            isRelayContext: false
-          },
-          { gasLimit: undefined }
-        )
+        expect(taskId).toBe(TASK_ID)
+        expect(mockSendTransaction).toHaveBeenCalledWith({
+          chainId: Number(CHAIN_ID),
+          to: SAFE_ADDRESS,
+          data: ENCODED_TRANSACTION_DATA,
+          payment: { type: 'sponsored' }
+        })
         // no counterfactual deployment present
         expect(safe.wrapSafeTransactionIntoDeploymentBatch).not.toHaveBeenCalled()
       })
@@ -549,59 +179,18 @@ describe('GelatoRelayPack', () => {
           }
         }
 
-        const gelatoResponse = await gelatoRelayPack.executeTransaction({
-          executable: relayTransaction as SafeTransaction,
-          options: { isSponsored: true }
-        })
-
-        expect(gelatoResponse).toBe(RELAY_RESPONSE)
-        expect(mockSponsoredCall).toHaveBeenCalledWith(
-          {
-            chainId: CHAIN_ID,
-            target: MULTISEND_ADDRESS, // multiSend contract as a target address because a counterfactual deployment is present
-            data: SAFE_DEPLOYMENT_BATCH.data
-          },
-          API_KEY
-        )
-        // counterfactual deployment in present
-        expect(safe.wrapSafeTransactionIntoDeploymentBatch).toHaveBeenCalled()
-      })
-
-      it('should execute a sync relay transaction & counterfactual deployment', async () => {
-        // Safe is not deployed
-        safe.isSafeDeployed = jest.fn().mockResolvedValue(false)
-
-        const relayTransaction = {
-          data: {
-            operation: OperationType.Call,
-            safeTxGas: SAFETXGAS_ESTIMATION,
-            baseGas: FEE_ESTIMATION.toString(),
-            gasPrice: '1',
-            nonce: 0,
-            gasToken: GAS_TOKEN,
-            refundReceiver: GELATO_FEE_COLLECTOR,
-            to: ADDRESS,
-            value: '0',
-            data: '0x'
-          }
-        }
-
-        const gelatoResponse = await gelatoRelayPack.executeTransaction({
+        const taskId = await gelatoRelayPack.executeTransaction({
           executable: relayTransaction as SafeTransaction
         })
 
-        expect(gelatoResponse).toBe(RELAY_RESPONSE)
-        expect(mockCallWithSyncFee).toHaveBeenCalledWith(
-          {
-            chainId: CHAIN_ID,
-            target: MULTISEND_ADDRESS, // multiSend contract as a target address because a counterfactual deployment is present
-            data: SAFE_DEPLOYMENT_BATCH.data,
-            feeToken: GAS_TOKEN,
-            isRelayContext: false
-          },
-          { gasLimit: undefined }
-        )
-        // counterfactual deployment in present
+        expect(taskId).toBe(TASK_ID)
+        expect(mockSendTransaction).toHaveBeenCalledWith({
+          chainId: Number(CHAIN_ID),
+          to: MULTISEND_ADDRESS, // multiSend contract as a target address because a counterfactual deployment is present
+          data: SAFE_DEPLOYMENT_BATCH.data,
+          payment: { type: 'sponsored' }
+        })
+        // counterfactual deployment is present
         expect(safe.wrapSafeTransactionIntoDeploymentBatch).toHaveBeenCalled()
       })
     })

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts
@@ -1,476 +1,108 @@
-import {
-  CallWithSyncFeeRequest,
-  GelatoRelay as GelatoNetworkRelay,
-  RelayRequestOptions,
-  RelayResponse,
-  SponsoredCallRequest,
-  TransactionStatusResponse
-} from '@gelatonetwork/relay-sdk'
-import {
-  estimateTxBaseGas,
-  estimateSafeTxGas,
-  estimateSafeDeploymentGas,
-  createERC20TokenTransferTransaction,
-  isGasTokenCompatibleWithHandlePayment
-} from '@safe-global/protocol-kit'
+import { createGelatoEvmRelayerClient, sponsored } from '@gelatocloud/gasless'
+import { type Hex } from 'viem'
 import { RelayKitBasePack } from '@safe-global/relay-kit/RelayKitBasePack'
-import {
-  GELATO_FEE_COLLECTOR,
-  GELATO_GAS_EXECUTION_OVERHEAD,
-  GELATO_NATIVE_TOKEN_ADDRESS,
-  GELATO_TRANSFER_GAS_COST,
-  ZERO_ADDRESS
-} from '@safe-global/relay-kit/constants'
-import {
-  MetaTransactionOptions,
-  RelayTransaction,
-  SafeTransaction,
-  Transaction
-} from '@safe-global/types-kit'
+import { SafeTransaction } from '@safe-global/types-kit'
 
 import {
   GelatoCreateTransactionProps,
-  GelatoEstimateFeeProps,
-  GelatoEstimateFeeResult,
   GelatoExecuteTransactionProps,
-  GelatoOptions
+  GelatoOptions,
+  GelatoTaskStatus
 } from './types'
 
 export class GelatoRelayPack extends RelayKitBasePack<{
-  EstimateFeeProps: GelatoEstimateFeeProps
-  EstimateFeeResult: GelatoEstimateFeeResult
   CreateTransactionProps: GelatoCreateTransactionProps
   CreateTransactionResult: SafeTransaction
   ExecuteTransactionProps: GelatoExecuteTransactionProps
-  ExecuteTransactionsResult: RelayResponse
+  ExecuteTransactionResult: string
 }> {
-  #gelatoRelay: GelatoNetworkRelay
-  #apiKey?: string
+  #relayer: ReturnType<typeof createGelatoEvmRelayerClient>
 
   constructor({ apiKey, protocolKit }: GelatoOptions) {
     super(protocolKit)
-    this.#gelatoRelay = new GelatoNetworkRelay()
-
-    this.#apiKey = apiKey
-  }
-
-  private _getFeeToken(gasToken?: string): string {
-    return !gasToken || gasToken === ZERO_ADDRESS ? GELATO_NATIVE_TOKEN_ADDRESS : gasToken
-  }
-
-  getFeeCollector(): string {
-    return GELATO_FEE_COLLECTOR
+    this.#relayer = createGelatoEvmRelayerClient({ apiKey })
   }
 
   /**
-   * Estimates the fee for a transaction.
-   * @param {GelatoEstimateFeeProps} props - Props for the fee estimation.
-   * @returns {Promise<GelatoEstimateFeeResult>} Returns a Promise that resolves with the estimated fee result.
+   * Gets the status of a relayed transaction.
+   * @param {string} taskId - The task ID returned by the relayer.
+   * @returns {Promise<GelatoTaskStatus>} The status of the task.
    */
-  async getEstimateFee(props: GelatoEstimateFeeProps): Promise<GelatoEstimateFeeResult>
-  /**
-   * @deprecated The method should not be used
-   * @param chainId - The chain id.
-   * @param gasLimit - The gas limit.
-   * @param gasToken - The gas token.
-   */
-  async getEstimateFee(chainId: bigint, gasLimit: string, gasToken?: string): Promise<string>
-  async getEstimateFee(
-    propsOrChainId: GelatoEstimateFeeProps | bigint,
-    inputGasLimit?: string,
-    inputGasToken?: string
-  ): Promise<GelatoEstimateFeeResult | string> {
-    let chainId: bigint
-    let gasLimit: string
-    let gasToken: string | undefined
-
-    if (typeof propsOrChainId === 'object') {
-      ;({ chainId, gasLimit, gasToken } = propsOrChainId)
-    } else {
-      chainId = propsOrChainId
-      gasLimit = inputGasLimit as string
-      gasToken = inputGasToken
-    }
-
-    const feeToken = this._getFeeToken(gasToken)
-    const estimation = await this.#gelatoRelay.getEstimatedFee(
-      chainId,
-      feeToken,
-      BigInt(gasLimit),
-      false
-    )
-
-    return estimation.toString()
-  }
-
-  async getTaskStatus(taskId: string): Promise<TransactionStatusResponse | undefined> {
-    return this.#gelatoRelay.getTaskStatus(taskId)
-  }
-
-  /**
-   * Creates a payment transaction to Gelato
-   *
-   * @private
-   * @async
-   * @function
-   * @param {string} gas - The gas amount for the payment.
-   * @param {MetaTransactionOptions} options - Options for the meta transaction.
-   * @returns {Promise<Transaction>} Promise object representing the created payment transaction.
-   *
-   */
-  private async createPaymentToGelato(
-    gas: string,
-    options: MetaTransactionOptions
-  ): Promise<Transaction> {
-    const chainId = await this.protocolKit.getChainId()
-    const gelatoAddress = this.getFeeCollector()
-    const gasToken = options.gasToken ?? ZERO_ADDRESS
-
-    const paymentToGelato = await this.getEstimateFee({ chainId, gasLimit: gas, gasToken })
-
-    // The Gelato payment transaction
-    const transferToGelato = createERC20TokenTransferTransaction(
-      gasToken,
-      gelatoAddress,
-      paymentToGelato
-    )
-
-    return transferToGelato
-  }
-
-  /**
-   * @deprecated Use createTransaction instead
-   */
-  async createRelayedTransaction({
-    transactions,
-    onlyCalls = false,
-    options = {}
-  }: GelatoCreateTransactionProps): Promise<SafeTransaction> {
-    return this.createTransaction({ transactions, onlyCalls, options })
+  async getTaskStatus(taskId: string): Promise<GelatoTaskStatus> {
+    return this.#relayer.waitForStatus({ id: taskId })
   }
 
   /**
    * Creates a Safe transaction designed to be executed using the Gelato Relayer.
    *
-   * @param {GelatoCreateTransactionProps} options - Options for Gelato.
-   * @param {MetaTransactionData[]} [options.transactions] - The transactions batch.
-   * @param {boolean} [options.onlyCalls=false] - If true, MultiSendCallOnly contract should be used. Remember to not use delegate calls in the batch.
-   * @param {MetaTransactionOptions} [options.options={}] - Gas Options for the transaction batch.
+   * @param {GelatoCreateTransactionProps} props - Options for creating the transaction.
+   * @param {MetaTransactionData[]} props.transactions - The transactions batch.
+   * @param {boolean} [props.onlyCalls=false] - If true, MultiSendCallOnly contract should be used.
    * @returns {Promise<SafeTransaction>} Returns a Promise that resolves with a SafeTransaction object.
    */
   async createTransaction({
     transactions,
-    onlyCalls = false,
-    options = {}
+    onlyCalls = false
   }: GelatoCreateTransactionProps): Promise<SafeTransaction> {
-    const { isSponsored = false } = options
+    const nonce = await this.protocolKit.getNonce()
 
-    if (isSponsored) {
-      const nonce = await this.protocolKit.getNonce()
-
-      const sponsoredTransaction = await this.protocolKit.createTransaction({
-        transactions,
-        onlyCalls,
-        options: {
-          nonce
-        }
-      })
-
-      return sponsoredTransaction
-    }
-
-    // If the ERC20 gas token does not follow the standard 18 decimals, we cannot use handlePayment to pay Gelato fees.
-
-    const gasToken = options.gasToken ?? ZERO_ADDRESS
-    const isGasTokenCompatible = await isGasTokenCompatibleWithHandlePayment(
-      gasToken,
-      this.protocolKit
-    )
-
-    if (!isGasTokenCompatible) {
-      // if the ERC20 gas token is not compatible (less than 18 decimals like USDC), a separate transfer is required to pay Gelato fees.
-
-      return this.createTransactionWithTransfer({ transactions, onlyCalls, options })
-    }
-
-    // If the gas token is compatible (Native token or standard ERC20), we use handlePayment function present in the Safe contract to pay Gelato fees
-    return this.createTransactionWithHandlePayment({ transactions, onlyCalls, options })
+    return this.protocolKit.createTransaction({
+      transactions,
+      onlyCalls,
+      options: {
+        nonce
+      }
+    })
   }
 
   /**
-   * Creates a Safe transaction designed to be executed using the Gelato Relayer and
-   * uses the handlePayment function defined in the Safe contract to pay the fees
-   * to the Gelato relayer.
+   * Sends a sponsored transaction to the Gelato Relayer.
    *
-   * @async
-   * @function createTransactionWithHandlePayment
-   * @param {GelatoCreateTransactionProps} options - Options for Gelato.
-   * @param {MetaTransactionData[]} [options.transactions] - The transactions batch.
-   * @param {boolean} [options.onlyCalls=false] - If true, MultiSendCallOnly contract should be used. Remember to not use delegate calls in the batch.
-   * @param {MetaTransactionOptions} [options.options={}] - Gas Options for the transaction batch.
-   * @returns {Promise<SafeTransaction>} Returns a promise that resolves to the created SafeTransaction.
-   * @private
+   * @param {string} target - The target contract address.
+   * @param {string} encodedTransaction - The encoded transaction data.
+   * @param {bigint} chainId - The chain ID.
+   * @returns {Promise<string>} Returns a Promise that resolves with the task ID.
    */
-  private async createTransactionWithHandlePayment({
-    transactions,
-    onlyCalls = false,
-    options = {}
-  }: GelatoCreateTransactionProps): Promise<SafeTransaction> {
-    const { gasLimit } = options
-    const nonce = await this.protocolKit.getNonce()
-
-    // this transaction is only used for gas estimations
-    const transactionToEstimateGas = await this.protocolKit.createTransaction({
-      transactions,
-      onlyCalls,
-      options: {
-        nonce
-      }
-    })
-
-    // as we set gasPrice to 1, safeTxGas is set to a non-zero value to prevent transaction failure due to out-of-gas errors. value see: https://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol#L203
-    const gasPrice = '1'
-    const safeTxGas = await estimateSafeTxGas(this.protocolKit, transactionToEstimateGas)
-    const gasToken = options.gasToken ?? ZERO_ADDRESS
-    const refundReceiver = this.getFeeCollector()
-    const chainId = await this.protocolKit.getChainId()
-
-    // if a custom gasLimit is provided, we do not need to estimate the gas cost
-    if (gasLimit) {
-      const paymentToGelato = await this.getEstimateFee({ chainId, gasLimit, gasToken })
-
-      const syncTransaction = await this.protocolKit.createTransaction({
-        transactions,
-        onlyCalls,
-        options: {
-          baseGas: paymentToGelato,
-          gasPrice,
-          safeTxGas,
-          gasToken,
-          refundReceiver,
-          nonce
-        }
-      })
-
-      return syncTransaction
-    }
-
-    // If gasLimit is not provided, we need to estimate the gas cost.
-
-    const baseGas = await estimateTxBaseGas(this.protocolKit, transactionToEstimateGas)
-    const safeDeploymentGasCost = await estimateSafeDeploymentGas(this.protocolKit)
-
-    const totalGas =
-      Number(baseGas) + // baseGas
-      Number(safeTxGas) + // safeTxGas
-      Number(safeDeploymentGasCost) + // Safe deploymet gas cost if it is required
-      GELATO_GAS_EXECUTION_OVERHEAD // Gelato execution overhead
-
-    const paymentToGelato = await this.getEstimateFee({
-      chainId,
-      gasLimit: String(totalGas),
-      gasToken
-    })
-
-    const syncTransaction = await this.protocolKit.createTransaction({
-      transactions,
-      onlyCalls,
-      options: {
-        baseGas: paymentToGelato, // payment to Gelato
-        gasPrice,
-        safeTxGas,
-        gasToken,
-        refundReceiver,
-        nonce
-      }
-    })
-
-    return syncTransaction
-  }
-
-  /**
-   * Creates a Safe transaction designed to be executed using the Gelato Relayer and
-   * uses a separate ERC20 transfer to pay the fees to the Gelato relayer.
-   *
-   * @async
-   * @function createTransactionWithTransfer
-   * @param {GelatoCreateTransactionProps} options - Options for Gelato.
-   * @param {MetaTransactionData[]} [options.transactions] - The transactions batch.
-   * @param {boolean} [options.onlyCalls=false] - If true, MultiSendCallOnly contract should be used. Remember to not use delegate calls in the batch.
-   * @param {MetaTransactionOptions} [options.options={}] - Gas Options for the transaction batch.
-   * @returns {Promise<SafeTransaction>} Returns a promise that resolves to the created SafeTransaction.
-   * @private
-   */
-  private async createTransactionWithTransfer({
-    transactions,
-    onlyCalls = false,
-    options = {}
-  }: GelatoCreateTransactionProps): Promise<SafeTransaction> {
-    const { gasLimit } = options
-    const nonce = await this.protocolKit.getNonce()
-    const gasToken = options.gasToken ?? ZERO_ADDRESS
-
-    // if a custom gasLimit is provided, we do not need to estimate the gas cost
-    if (gasLimit) {
-      const transferToGelato = await this.createPaymentToGelato(gasLimit, options)
-
-      const syncTransaction = await this.protocolKit.createTransaction({
-        transactions: [...transactions, transferToGelato],
-        onlyCalls,
-        options: {
-          nonce,
-          gasToken
-        }
-      })
-
-      return syncTransaction
-    }
-
-    // If gasLimit is not provided, we need to estimate the gas cost.
-
-    // this transaction is only used for gas estimations
-    const transactionToEstimateGas = await this.protocolKit.createTransaction({
-      transactions,
-      onlyCalls,
-      options: {
-        nonce
-      }
-    })
-
-    const safeTxGas = await estimateSafeTxGas(this.protocolKit, transactionToEstimateGas)
-    const baseGas = await estimateTxBaseGas(this.protocolKit, transactionToEstimateGas)
-    const safeDeploymentGasCost = await estimateSafeDeploymentGas(this.protocolKit)
-
-    const totalGas =
-      Number(baseGas) + // baseGas
-      Number(safeTxGas) + // safeTxGas without Gelato payment transfer
-      Number(safeDeploymentGasCost) + // Safe deploymet gas cost if it is required
-      GELATO_TRANSFER_GAS_COST + // Gelato payment transfer
-      GELATO_GAS_EXECUTION_OVERHEAD // Gelato execution overhead
-
-    const transferToGelato = await this.createPaymentToGelato(String(totalGas), options)
-
-    const syncTransaction = await this.protocolKit.createTransaction({
-      transactions: [...transactions, transferToGelato],
-      onlyCalls,
-      options: {
-        nonce,
-        gasToken
-      }
-    })
-
-    return syncTransaction
-  }
-
   async sendSponsorTransaction(
     target: string,
     encodedTransaction: string,
     chainId: bigint
-  ): Promise<RelayResponse> {
-    if (!this.#apiKey) {
-      throw new Error('API key not defined')
-    }
-    const request: SponsoredCallRequest = {
-      chainId,
-      target,
-      data: encodedTransaction
-    }
-    const response = await this.#gelatoRelay.sponsoredCall(request, this.#apiKey)
-    return response
-  }
+  ): Promise<string> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `payment` is not yet in the @gelatocloud/gasless type definitions
+    const taskId = await (this.#relayer.sendTransaction as (args: any) => Promise<string>)({
+      chainId: Number(chainId),
+      to: target,
+      data: encodedTransaction as Hex,
+      payment: sponsored()
+    })
 
-  async sendSyncTransaction(
-    target: string,
-    encodedTransaction: string,
-    chainId: bigint,
-    options: MetaTransactionOptions
-  ): Promise<RelayResponse> {
-    const { gasLimit, gasToken } = options
-    const feeToken = this._getFeeToken(gasToken)
-    const request: CallWithSyncFeeRequest = {
-      chainId,
-      target,
-      data: encodedTransaction,
-      feeToken,
-      isRelayContext: false
-    }
-    const relayRequestOptions: RelayRequestOptions = {
-      gasLimit: gasLimit ? BigInt(gasLimit) : undefined
-    }
-    const response = await this.#gelatoRelay.callWithSyncFee(request, relayRequestOptions)
-    return response
-  }
-
-  async relayTransaction({
-    target,
-    encodedTransaction,
-    chainId,
-    options = {}
-  }: RelayTransaction): Promise<RelayResponse> {
-    const response = options.isSponsored
-      ? this.sendSponsorTransaction(target, encodedTransaction, chainId)
-      : this.sendSyncTransaction(target, encodedTransaction, chainId, options)
-    return response
-  }
-
-  /**
-   * @deprecated Use executeTransaction instead
-   */
-  async executeRelayTransaction(
-    safeTransaction: SafeTransaction,
-    options?: MetaTransactionOptions
-  ): Promise<RelayResponse> {
-    return this.executeTransaction({ executable: safeTransaction, options })
+    return taskId
   }
 
   /**
    * Sends the Safe transaction to the Gelato Relayer for execution.
    * If the Safe is not deployed, it creates a batch of transactions including the Safe deployment transaction.
    *
-   * @param {GelatoExecuteTransactionProps} props - Execution props
+   * @param {GelatoExecuteTransactionProps} props - Execution props.
    * @param {SafeTransaction} props.executable - The Safe transaction to be executed.
-   * @param {MetaTransactionOptions} props.options - Options for the transaction.
-   * @returns {Promise<RelayResponse>} Returns a Promise that resolves with a RelayResponse object.
+   * @returns {Promise<string>} Returns a Promise that resolves with the task ID.
    */
   async executeTransaction({
-    executable: safeTransaction,
-    options
-  }: GelatoExecuteTransactionProps): Promise<RelayResponse> {
+    executable: safeTransaction
+  }: GelatoExecuteTransactionProps): Promise<string> {
     const isSafeDeployed = await this.protocolKit.isSafeDeployed()
     const chainId = await this.protocolKit.getChainId()
     const safeAddress = await this.protocolKit.getAddress()
     const safeTransactionEncodedData = await this.protocolKit.getEncodedTransaction(safeTransaction)
 
-    const gasToken = options?.gasToken || safeTransaction.data.gasToken
-
     if (isSafeDeployed) {
-      const relayTransaction: RelayTransaction = {
-        target: safeAddress,
-        encodedTransaction: safeTransactionEncodedData,
-        chainId,
-        options: {
-          ...options,
-          gasToken
-        }
-      }
-
-      return this.relayTransaction(relayTransaction)
+      return this.sendSponsorTransaction(safeAddress, safeTransactionEncodedData, chainId)
     }
 
     // if the Safe is not deployed we create a batch with the Safe deployment transaction and the provided Safe transaction
     const safeDeploymentBatch =
       await this.protocolKit.wrapSafeTransactionIntoDeploymentBatch(safeTransaction)
 
-    const relayTransaction: RelayTransaction = {
-      target: safeDeploymentBatch.to, // multiSend Contract address
-      encodedTransaction: safeDeploymentBatch.data,
-      chainId,
-      options: {
-        ...options,
-        gasToken
-      }
-    }
-
-    return this.relayTransaction(relayTransaction)
+    return this.sendSponsorTransaction(safeDeploymentBatch.to, safeDeploymentBatch.data, chainId)
   }
 }

--- a/packages/relay-kit/src/packs/gelato/types.ts
+++ b/packages/relay-kit/src/packs/gelato/types.ts
@@ -1,32 +1,26 @@
 import Safe from '@safe-global/protocol-kit'
-import {
-  MetaTransactionData,
-  MetaTransactionOptions,
-  SafeTransaction
-} from '@safe-global/types-kit'
+import { MetaTransactionData, SafeTransaction } from '@safe-global/types-kit'
 
 export type GelatoOptions = {
-  apiKey?: string
+  apiKey: string
   protocolKit: Safe
 }
 
-export type GelatoEstimateFeeProps = {
-  chainId: bigint
-  gasLimit: string
-  gasToken?: string
-}
-
-export type GelatoEstimateFeeResult = string
-
 export type GelatoCreateTransactionProps = {
   transactions: MetaTransactionData[]
-  /** options - The transaction array optional properties */
-  options?: MetaTransactionOptions
   /** onlyCalls - Forces the execution of the transaction array with MultiSendCallOnly contract */
   onlyCalls?: boolean
 }
 
 export type GelatoExecuteTransactionProps = {
   executable: SafeTransaction
-  options?: MetaTransactionOptions
+}
+
+/** Status response from the Gelato Relay service. */
+export type GelatoTaskStatus = {
+  /** Status code: 100=Pending, 110=Submitted, 200=Success, 210=Finalized, 400=Rejected, 500=Reverted */
+  status: number
+  receipt?: {
+    transactionHash: string
+  }
 }

--- a/packages/relay-kit/src/packs/safe-4337/BaseSafeOperation.ts
+++ b/packages/relay-kit/src/packs/safe-4337/BaseSafeOperation.ts
@@ -57,7 +57,7 @@ abstract class BaseSafeOperation implements SafeOperation {
     return hashTypedData({
       domain: {
         chainId: Number(this.options.chainId),
-        verifyingContract: this.options.moduleAddress
+        verifyingContract: this.options.moduleAddress as Hex
       },
       types: this.getEIP712Type(),
       primaryType: 'SafeOp',

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -401,7 +401,7 @@ describe('Safe4337Pack', () => {
           abi: constants.ABI,
           functionName: 'executeUserOp',
           args: [
-            safe4337Pack.protocolKit.getMultiSendAddress(),
+            safe4337Pack.protocolKit.getMultiSendAddress() as viem.Hex,
             0n,
             viem.encodeFunctionData({
               abi: constants.ABI,
@@ -437,7 +437,7 @@ describe('Safe4337Pack', () => {
           abi: constants.ABI,
           functionName: 'executeUserOp',
           args: [
-            transferUSDC.to,
+            transferUSDC.to as viem.Hex,
             BigInt(transferUSDC.value),
             transferUSDC.data as viem.Hex,
             OperationType.Call
@@ -501,7 +501,7 @@ describe('Safe4337Pack', () => {
           abi: constants.ABI,
           functionName: 'executeUserOp',
           args: [
-            transferUSDC.to,
+            transferUSDC.to as viem.Hex,
             BigInt(transferUSDC.value),
             transferUSDC.data as viem.Hex,
             OperationType.Call
@@ -564,7 +564,7 @@ describe('Safe4337Pack', () => {
           abi: constants.ABI,
           functionName: 'executeUserOp',
           args: [
-            safe4337Pack.protocolKit.getMultiSendAddress(),
+            safe4337Pack.protocolKit.getMultiSendAddress() as viem.Hex,
             0n,
             viem.encodeFunctionData({
               abi: constants.ABI,

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -232,7 +232,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
         data: encodeFunctionData({
           abi: ABI,
           functionName: 'enableModules',
-          args: [[safe4337ModuleAddress]]
+          args: [[safe4337ModuleAddress as Hex]]
         }),
         operation: OperationType.DelegateCall // DelegateCall required for enabling the 4337 module
       }
@@ -253,7 +253,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
           data: encodeFunctionData({
             abi: ABI,
             functionName: 'approve',
-            args: [paymasterAddress, amountToApprove]
+            args: [paymasterAddress as Hex, amountToApprove]
           }),
           value: '0',
           operation: OperationType.Call // Call for approve

--- a/packages/relay-kit/src/packs/safe-4337/utils/userOperations.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/userOperations.ts
@@ -30,7 +30,7 @@ function encodeExecuteUserOpCallData(transaction: MetaTransactionData): string {
     abi: ABI,
     functionName: 'executeUserOp',
     args: [
-      transaction.to,
+      transaction.to as Hex,
       BigInt(transaction.value),
       transaction.data as Hex,
       transaction.operation || OperationType.Call
@@ -58,7 +58,7 @@ async function getCallData(
       data: encodeFunctionData({
         abi: ABI,
         functionName: 'approve',
-        args: [paymasterOptions.paymasterAddress, amountToApprove]
+        args: [paymasterOptions.paymasterAddress as Hex, amountToApprove]
       }),
       value: '0',
       operation: OperationType.Call // Call for approve

--- a/packages/relay-kit/test-utils/helpers.ts
+++ b/packages/relay-kit/test-utils/helpers.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, parseAbi } from 'viem'
+import { encodeFunctionData, Hex, parseAbi } from 'viem'
 import { Safe4337InitOptions } from '../src/packs/safe-4337/types'
 import { Safe4337Pack } from '../src/packs/safe-4337/Safe4337Pack'
 import * as fixtures from './fixtures'
@@ -9,7 +9,7 @@ export const generateTransferCallData = (to: string, value: bigint) => {
   return encodeFunctionData({
     abi: functionAbi,
     functionName: 'transfer',
-    args: [to, value]
+    args: [to as Hex, value]
   })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
-"@adraffy/ens-normalize@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz"
-  integrity sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==
+"@adraffy/ens-normalize@^1.10.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz#6c2d657d4b2dfb37f8ea811dcb3e60843d4ac24a"
+  integrity sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
@@ -813,15 +813,12 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
   integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
 
-"@gelatonetwork/relay-sdk@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@gelatonetwork/relay-sdk/-/relay-sdk-5.6.0.tgz#02c3114472cbe6dd310415818fb5477e444f3c4a"
-  integrity sha512-pSXE9xdPj6wmdcmoT7ETlbEjpvQvyFIZT1CoyzcUEupPplugm59ieUiX5E41oLeByQ7M1dliq2b96d/iIIA3kw==
+"@gelatocloud/gasless@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@gelatocloud/gasless/-/gasless-0.0.7.tgz#0c7d82b01bd6e1fcd8cd385da9a2e690941398da"
+  integrity sha512-0WEWHUs28zsoNVy3sV9PrblxES7njcAY/lWFzB7pKtdWYUyw85BaCpRbXiyPR2r2Dg7Ekvu2B/tPNESfCMGdxw==
   dependencies:
-    axios "0.29.0"
-    ethers "6.7.0"
-    isomorphic-ws "^5.0.0"
-    ws "^8.18.0"
+    zod "4.1.13"
 
 "@gnosis.pm/safe-contracts-v1.3.0@npm:@gnosis.pm/safe-contracts@1.3.0":
   version "1.3.0"
@@ -1227,6 +1224,13 @@
   dependencies:
     "@noble/hashes" "1.4.0"
 
+"@noble/curves@1.7.0", "@noble/curves@~1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
+  integrity sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==
+  dependencies:
+    "@noble/hashes" "1.6.0"
+
 "@noble/curves@^1.4.0", "@noble/curves@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.6.0.tgz#be5296ebcd5a1730fccea4786d420f87abfeb40b"
@@ -1241,10 +1245,12 @@
   dependencies:
     "@noble/hashes" "1.4.0"
 
-"@noble/hashes@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz"
-  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+"@noble/curves@~1.9.0":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
 
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
@@ -1265,6 +1271,21 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
   integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
+
+"@noble/hashes@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
+  integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
+
+"@noble/hashes@1.6.1", "@noble/hashes@~1.6.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.1.tgz#df6e5943edcea504bac61395926d6fd67869a0d5"
+  integrity sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.5.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
@@ -1853,6 +1874,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.8.tgz#8f23646c352f020c83bca750a82789e246d42b50"
   integrity sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==
 
+"@scure/base@~1.2.1", "@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
 "@scure/bip32@1.1.5":
   version "1.1.5"
   resolved "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz"
@@ -1871,6 +1897,24 @@
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
 
+"@scure/bip32@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.6.0.tgz#6dbc6b4af7c9101b351f41231a879d8da47e0891"
+  integrity sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==
+  dependencies:
+    "@noble/curves" "~1.7.0"
+    "@noble/hashes" "~1.6.0"
+    "@scure/base" "~1.2.1"
+
+"@scure/bip32@^1.5.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
 "@scure/bip39@1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz"
@@ -1886,6 +1930,22 @@
   dependencies:
     "@noble/hashes" "~1.5.0"
     "@scure/base" "~1.1.8"
+
+"@scure/bip39@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.5.0.tgz#c8f9533dbd787641b047984356531d84485f19be"
+  integrity sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==
+  dependencies:
+    "@noble/hashes" "~1.6.0"
+    "@scure/base" "~1.2.1"
+
+"@scure/bip39@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@sentry/core@5.30.0":
   version "5.30.0"
@@ -2216,11 +2276,6 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@18.15.13":
-  version "18.15.13"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz"
-  integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
-
 "@types/node@22.7.5":
   version "22.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
@@ -2436,10 +2491,20 @@ abitype@1.0.5, abitype@^1.0.2:
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.5.tgz#29d0daa3eea867ca90f7e4123144c1d1270774b6"
   integrity sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==
 
+abitype@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.7.tgz#876a0005d211e1c9132825d45bcee7b46416b284"
+  integrity sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==
+
 abitype@^0.9.8:
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.10.tgz#fa6fa30a6465da98736f98b6c601a02ed49f6eec"
   integrity sha512-FIS7U4n7qwAT58KibwYig5iFG4K61rbhAqaQh/UWj8v1Y8mjX3F8TC9gd8cz9yT1TYel9f8nS5NO5kZp2RW0jQ==
+
+abitype@^1.0.6:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.2.3.tgz#bec3e09dea97d99ef6c719140bee663a329ad1f4"
+  integrity sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2663,15 +2728,6 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
-
-axios@0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.29.0.tgz#5eed1a0bc4c0ffe060624eb7900aff66b7881eeb"
-  integrity sha512-Kjsq1xisgO5DjjNQwZFsy0gpcU1P2j36dZeQDXVhpIU26GVgkDUnROaHLSuluhMqtDE7aKA2hbKXG5yu5DN8Tg==
-  dependencies:
-    follow-redirects "^1.15.4"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -4053,19 +4109,6 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethers@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz"
-  integrity sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==
-  dependencies:
-    "@adraffy/ens-normalize" "1.9.2"
-    "@noble/hashes" "1.1.2"
-    "@noble/secp256k1" "1.7.1"
-    "@types/node" "18.15.13"
-    aes-js "4.0.0-beta.5"
-    tslib "2.4.0"
-    ws "8.5.0"
-
 ethers@^5.7.0, ethers@~5.7.0:
   version "5.7.2"
   resolved "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz"
@@ -4123,15 +4166,15 @@ ethjs-util@0.1.6, ethjs-util@^0.1.6:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
+eventemitter3@5.0.1, eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
-
-eventemitter3@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz"
-  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -4351,7 +4394,7 @@ fmix@^0.1.0:
   dependencies:
     imul "^1.0.0"
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.15.4, follow-redirects@^1.15.6:
+follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -5329,15 +5372,15 @@ isobject@^3.0.1:
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
-isomorphic-ws@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz"
-  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
-
 isows@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.4.tgz#810cd0d90cc4995c26395d2aa4cfa4037ebdf061"
   integrity sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==
+
+isows@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.6.tgz#0da29d706fa51551c663c627ace42769850f86e7"
+  integrity sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -7029,6 +7072,19 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+ox@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.4.4.tgz#9d1757c026406e60097680d98ffedf9e3bc1fa0b"
+  integrity sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.10.1"
+    "@noble/curves" "^1.6.0"
+    "@noble/hashes" "^1.5.0"
+    "@scure/bip32" "^1.5.0"
+    "@scure/bip39" "^1.4.0"
+    abitype "^1.0.6"
+    eventemitter3 "5.0.1"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
@@ -8490,11 +8546,6 @@ tsconfig-paths@^4.1.2, tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
 tslib@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
@@ -8730,6 +8781,21 @@ validate-npm-package-name@5.0.1, validate-npm-package-name@^5.0.0:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
+viem@2.21.59:
+  version "2.21.59"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.59.tgz#6b737166dd98cab1293578195d713c2b28c1acc7"
+  integrity sha512-aHycB6LRxmUiKArOoQ1nYmhtVvZgU+ltAVvK7J1g+MuSbZZW5pXUtosRCBLlCO2gs05zYfrhVih+LmbRrdEXKg==
+  dependencies:
+    "@noble/curves" "1.7.0"
+    "@noble/hashes" "1.6.1"
+    "@scure/bip32" "1.6.0"
+    "@scure/bip39" "1.5.0"
+    abitype "1.0.7"
+    isows "1.0.6"
+    ox "0.4.4"
+    webauthn-p256 "0.0.10"
+    ws "8.18.0"
+
 viem@^2.21.8:
   version "2.21.8"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.8.tgz#12a6aaa386038675ddec9ec2be943963133dde33"
@@ -8763,6 +8829,14 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+webauthn-p256@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/webauthn-p256/-/webauthn-p256-0.0.10.tgz#877e75abe8348d3e14485932968edf3325fd2fdd"
+  integrity sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==
+  dependencies:
+    "@noble/curves" "^1.4.0"
+    "@noble/hashes" "^1.4.0"
 
 webauthn-p256@0.0.5:
   version "0.0.5"
@@ -8962,20 +9036,15 @@ ws@8.17.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
-ws@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz"
-  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
-
-ws@^8.18.0:
-  version "8.18.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.1.tgz#ea131d3784e1dfdff91adb0a4a116b127515e3cb"
-  integrity sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==
 
 xtend@~4.0.1:
   version "4.0.2"
@@ -9099,3 +9168,8 @@ zksync-ethers@^5.0.0:
   integrity sha512-Y2Mx6ovvxO6UdC2dePLguVzvNToOY8iLWeq5ne+jgGSJxAi/f4He/NF6FNsf6x1aWX0o8dy4Df8RcOQXAkj5qw==
   dependencies:
     ethers "~5.7.0"
+
+zod@4.1.13:
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.13.tgz#93699a8afe937ba96badbb0ce8be6033c0a4b6b1"
+  integrity sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==


### PR DESCRIPTION
## Summary

- Migrate Gelato Relay integration from deprecated `@gelatonetwork/relay-sdk` to the new `@gelatocloud/gasless` SDK
- Remove SyncFee (paid) transaction support — only sponsored transactions via 1Balance are now supported
- Bump viem to `2.21.59` in relay-kit only (required by `@gelatocloud/gasless` which uses `viem/experimental/erc7821`)
- Fix `0x${string}` type errors caused by viem bump (scoped to relay-kit, no changes to other packages)

## Breaking Changes

- `apiKey` is now **required** in `GelatoOptions` (was optional)
- Removed `getEstimateFee()`, `getFeeCollector()`, `sendSyncTransaction()`, `relayTransaction()` methods
- Removed deprecated `createRelayedTransaction()` and `executeRelayTransaction()` methods
- Removed `EstimateFeeProps` / `EstimateFeeResult` from `RelayKitBasePack` abstract class
- `executeTransaction()` now returns a task ID (`string`) instead of `RelayResponse`
- `createTransaction()` no longer accepts `options` (gas token, gas limit, isSponsored)
- Removed Gelato constants (fee collector, native token address, gas overheads)

## Changes by file

**Gelato migration:**
- `package.json` — `@gelatonetwork/relay-sdk` → `@gelatocloud/gasless`, viem `^2.21.8` → `2.21.59`
- `GelatoRelayPack.ts` — Rewritten to use `createGelatoEvmRelayerClient` + `sponsored()`
- `GelatoRelayPack.test.ts` — Updated mocks and tests for new SDK
- `types.ts` — Simplified types, added `GelatoTaskStatus`
- `RelayKitBasePack.ts` — Removed fee estimation from abstract class
- `constants.ts` — Removed Gelato-specific constants
- `src/index.ts` — Removed broken `abitype` module augmentation

**Viem type fixes (relay-kit only):**
- `BaseSafeOperation.ts`, `Safe4337Pack.ts`, `userOperations.ts`, `test-utils/helpers.ts`, `Safe4337Pack.test.ts` — `as Hex` casts for stricter viem types

## Test plan

- [x] All 6 packages build successfully
- [x] relay-kit tests pass (20/20, 1 pre-existing failure unrelated to this PR — missing `PASSKEY_PRIVATE_KEY` env var)
- [x] protocol-kit unit tests pass (40/40)
- [x] sdk-starter-kit tests pass (28/28)
- [x] No changes outside `packages/relay-kit/` (except `yarn.lock`)
- [x] Manual test with Gelato 1Balance sponsored transaction on testnet
