### PR TITLE
fix(protocol-kit): consider `new-account` creation cost in `baseGas` estimation

### DIFF
--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -37,7 +37,8 @@ const HASH_GENERATION_GAS_COST = 1_500
 const ECRECOVER_GAS_COST = 6_000
 
 // transfer gas cost
-const TRANSAFER_GAS_COST = 32_000
+const TRANSFER_GAS_COST = 32_000
+const NEW_ACCOUNT_GAS_COST = 25_000
 
 // numbers < 256 (0x00(31*2)..ff) are 192 -> 31 * 4 + 1 * CALL_DATA_BYTE_GAS_COST
 // numbers < 65535 (0x(30*2)..ffff) are 256 -> 30 * 4 + 2 * CALL_DATA_BYTE_GAS_COST
@@ -60,6 +61,27 @@ function estimateDataGasCosts(data: string): number {
 
     return gasCost + CALL_DATA_BYTE_GAS_COST
   }, 0)
+}
+
+async function isNewEthRefundReceiver(
+  safeProvider: SafeProvider,
+  gasToken: string,
+  refundReceiver: string
+): Promise<boolean> {
+  if (
+    gasToken.toLowerCase() !== ZERO_ADDRESS.toLowerCase() ||
+    refundReceiver.toLowerCase() === ZERO_ADDRESS.toLowerCase()
+  ) {
+    return false
+  }
+
+  const [contractCode, nonce, balance] = await Promise.all([
+    safeProvider.getContractCode(refundReceiver),
+    safeProvider.getNonce(refundReceiver),
+    safeProvider.getBalance(refundReceiver)
+  ])
+
+  return contractCode === '0x' && nonce === 0 && balance === 0n
 }
 
 export async function estimateGas(
@@ -159,23 +181,26 @@ export async function estimateTxBaseGas(
   const safeTransactionData = safeTransaction.data
   const { to, value, data, operation, safeTxGas, gasToken, refundReceiver } = safeTransactionData
 
-  const safeThreshold = await safe.getThreshold()
-  const safeNonce = await safe.getNonce()
-
-  const signaturesGasCost = safeThreshold * GAS_COST_PER_SIGNATURE
-
   const encodeSafeTxGas = safeTxGas || 0
   const encodeBaseGas = 0
   const gasPrice = 1
   const encodeGasToken = gasToken || ZERO_ADDRESS
   const encodeRefundReceiver = refundReceiver || ZERO_ADDRESS
   const signatures = '0x'
-
-  const safeVersion = safe.getContractVersion()
   const safeProvider = safe.getSafeProvider()
-  const isL1SafeSingleton = safe.getContractManager().isL1SafeSingleton
-  const chainId = await safe.getChainId()
-  const customContracts = safe.getContractManager().contractNetworks?.[chainId.toString()]
+  const safeVersion = safe.getContractVersion()
+  const contractManager = safe.getContractManager()
+  const isL1SafeSingleton = contractManager.isL1SafeSingleton
+
+  const [safeThreshold, safeNonce, chainId, isNewRefundReceiver] = await Promise.all([
+    safe.getThreshold(),
+    safe.getNonce(),
+    safe.getChainId(),
+    isNewEthRefundReceiver(safeProvider, encodeGasToken, encodeRefundReceiver)
+  ])
+
+  const signaturesGasCost = safeThreshold * GAS_COST_PER_SIGNATURE
+  const customContracts = contractManager.contractNetworks?.[chainId.toString()]
 
   const safeSingletonContract = await getSafeContract({
     safeProvider,
@@ -213,7 +238,11 @@ export async function estimateTxBaseGas(
   baseGas > 65536 ? (baseGas += 64) : (baseGas += 128)
 
   // Base tx costs, transfer costs...
-  baseGas += TRANSAFER_GAS_COST
+  baseGas += TRANSFER_GAS_COST
+
+  if (isNewRefundReceiver) {
+    baseGas += NEW_ACCOUNT_GAS_COST
+  }
 
   return baseGas.toString()
 }

--- a/packages/protocol-kit/tests/unit/gas.test.ts
+++ b/packages/protocol-kit/tests/unit/gas.test.ts
@@ -1,0 +1,170 @@
+import { OperationType, SafeTransaction } from '@safe-global/types-kit'
+import { estimateTxBaseGas } from '@safe-global/protocol-kit/utils'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/utils/constants'
+import * as safeDeploymentContracts from '@safe-global/protocol-kit/contracts/safeDeploymentContracts'
+import chai from 'chai'
+import sinon from 'sinon'
+
+const EXISTING_REFUND_RECEIVER = '0x1000000000000000000000000000000000000001'
+const NEW_REFUND_RECEIVER = '0x2000000000000000000000000000000000000002'
+const ERC20_TOKEN = '0x3000000000000000000000000000000000000003'
+
+describe('estimateTxBaseGas', () => {
+  beforeEach(() => {
+    sinon.stub(safeDeploymentContracts, 'getSafeContract').resolves({
+      encode: sinon.stub().returns('0x1234')
+    })
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  function buildSafe({
+    contractCode = '0x',
+    nonce = 0,
+    balance = 0n
+  }: {
+    contractCode?: string
+    nonce?: number
+    balance?: bigint
+  } = {}) {
+    const safeProvider = {
+      getContractCode: sinon.stub().resolves(contractCode),
+      getNonce: sinon.stub().resolves(nonce),
+      getBalance: sinon.stub().resolves(balance)
+    }
+
+    return {
+      getThreshold: sinon.stub().resolves(1),
+      getNonce: sinon.stub().resolves(1),
+      getContractVersion: sinon.stub().returns('1.3.0'),
+      getSafeProvider: sinon.stub().returns(safeProvider),
+      getContractManager: sinon.stub().returns({
+        isL1SafeSingleton: false,
+        contractNetworks: {}
+      }),
+      getChainId: sinon.stub().resolves(1n)
+    } as any
+  }
+
+  function buildTransaction(overrides: Partial<SafeTransaction['data']> = {}): SafeTransaction {
+    return {
+      data: {
+        to: '0x4000000000000000000000000000000000000004',
+        value: '0',
+        data: '0x',
+        operation: OperationType.Call,
+        safeTxGas: '0',
+        baseGas: '0',
+        gasPrice: '1',
+        gasToken: ZERO_ADDRESS,
+        refundReceiver: EXISTING_REFUND_RECEIVER,
+        nonce: 1,
+        ...overrides
+      },
+      signatures: new Map(),
+      addSignature: sinon.stub(),
+      encodedSignatures: sinon.stub().returns('0x')
+    } as any
+  }
+
+  it('adds the account creation cost for ETH refunds to a fresh refund receiver', async () => {
+    const existingSafe = buildSafe({
+      contractCode: '0x1234',
+      nonce: 1,
+      balance: 1n
+    })
+    const newAccountSafe = buildSafe()
+
+    const existingRefundBaseGas = await estimateTxBaseGas(existingSafe, buildTransaction())
+    const newRefundBaseGas = await estimateTxBaseGas(
+      newAccountSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+
+    chai.expect(Number(newRefundBaseGas) - Number(existingRefundBaseGas)).to.eq(25_000)
+  })
+
+  it('does not add the account creation cost for token refunds', async () => {
+    const safe = buildSafe()
+
+    const ethRefundBaseGas = await estimateTxBaseGas(
+      safe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+    const tokenRefundBaseGas = await estimateTxBaseGas(
+      safe,
+      buildTransaction({
+        gasToken: ERC20_TOKEN,
+        refundReceiver: NEW_REFUND_RECEIVER
+      })
+    )
+
+    chai.expect(Number(ethRefundBaseGas) - Number(tokenRefundBaseGas)).to.eq(25_000)
+  })
+
+  it('does not add the account creation cost when refundReceiver is the zero address', async () => {
+    const newAccountSafe = buildSafe()
+    const zeroAddressSafe = buildSafe()
+
+    const newReceiverBaseGas = await estimateTxBaseGas(
+      newAccountSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+    const zeroAddressBaseGas = await estimateTxBaseGas(
+      zeroAddressSafe,
+      buildTransaction({ refundReceiver: ZERO_ADDRESS })
+    )
+
+    chai.expect(Number(newReceiverBaseGas) - Number(zeroAddressBaseGas)).to.eq(25_000)
+  })
+
+  it('does not add the account creation cost when the receiver has a non-zero balance', async () => {
+    const newAccountSafe = buildSafe()
+    const fundedSafe = buildSafe({ balance: 1n })
+
+    const newReceiverBaseGas = await estimateTxBaseGas(
+      newAccountSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+    const fundedReceiverBaseGas = await estimateTxBaseGas(
+      fundedSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+
+    chai.expect(Number(newReceiverBaseGas) - Number(fundedReceiverBaseGas)).to.eq(25_000)
+  })
+
+  it('does not add the account creation cost when the receiver has a non-zero nonce', async () => {
+    const newAccountSafe = buildSafe()
+    const usedNonceSafe = buildSafe({ nonce: 1 })
+
+    const newReceiverBaseGas = await estimateTxBaseGas(
+      newAccountSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+    const usedNonceReceiverBaseGas = await estimateTxBaseGas(
+      usedNonceSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+
+    chai.expect(Number(newReceiverBaseGas) - Number(usedNonceReceiverBaseGas)).to.eq(25_000)
+  })
+
+  it('does not add the account creation cost when the receiver is a contract', async () => {
+    const newAccountSafe = buildSafe()
+    const contractSafe = buildSafe({ contractCode: '0x1234' })
+
+    const newReceiverBaseGas = await estimateTxBaseGas(
+      newAccountSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+    const contractReceiverBaseGas = await estimateTxBaseGas(
+      contractSafe,
+      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    )
+
+    chai.expect(Number(newReceiverBaseGas) - Number(contractReceiverBaseGas)).to.eq(25_000)
+  })
+})

--- a/packages/protocol-kit/tests/unit/gas.test.ts
+++ b/packages/protocol-kit/tests/unit/gas.test.ts
@@ -11,9 +11,9 @@ const ERC20_TOKEN = '0x3000000000000000000000000000000000000003'
 
 describe('estimateTxBaseGas', () => {
   beforeEach(() => {
-    sinon.stub(safeDeploymentContracts, 'getSafeContract').resolves({
-      encode: sinon.stub().returns('0x1234')
-    })
+    sinon
+      .stub(safeDeploymentContracts, 'getSafeContract')
+      .resolves({ encode: sinon.stub().returns('0x1234') } as any)
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Adds 25k gas to `estimateTxBaseGas` when the ETH refund receiver is a fresh account (no code, nonce, or balance), matching the EVM NEWACCOUNT cost defined in EIP-161
- Parallelises the sequential async calls (`getThreshold`, `getNonce`, `getChainId`) in `estimateTxBaseGas` using `Promise.all`, reducing RPC round-trips
- Fixes the pre-existing `TRANSAFER_GAS_COST` typo → `TRANSFER_GAS_COST`
- Adds unit tests covering the new account cost logic including edge cases: zero address receiver, receiver with existing balance, nonce, or contract code

Closes PLA-1364