### PR TITLE
Handle Transaction Service contract signatures

### DIFF
--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -2,6 +2,7 @@ import {
   OperationType,
   SafeMultisigTransactionResponse,
   SafeMultisigConfirmationResponse,
+  SignatureTypes,
   SafeSignature,
   SafeTransaction,
   SafeTransactionDataPartial,
@@ -62,7 +63,8 @@ import {
   preimageSafeMessageHash,
   preimageSafeTransactionHash,
   adjustVInSignature,
-  extractPasskeyData
+  extractPasskeyData,
+  extractContractSignatureData
 } from './utils'
 import EthSafeTransaction from './utils/transactions/SafeTransaction'
 import { SafeTransactionOptionalProps } from './utils/transactions/types'
@@ -1600,7 +1602,15 @@ class Safe {
     })
     serviceTransactionResponse.confirmations?.map(
       (confirmation: SafeMultisigConfirmationResponse) => {
-        const signature = new EthSafeSignature(confirmation.owner, confirmation.signature)
+        const signatureData =
+          confirmation.signatureType === SignatureTypes.CONTRACT_SIGNATURE
+            ? extractContractSignatureData(confirmation.signature)
+            : confirmation.signature
+        const signature = new EthSafeSignature(
+          confirmation.owner,
+          signatureData,
+          confirmation.signatureType === SignatureTypes.CONTRACT_SIGNATURE
+        )
         safeTransaction.addSignature(signature)
       }
     )

--- a/packages/protocol-kit/src/utils/signatures/utils.ts
+++ b/packages/protocol-kit/src/utils/signatures/utils.ts
@@ -15,6 +15,10 @@ import { encodeTypedData } from '../eip-712/encode'
 import { asHash, asHex } from '../types'
 import { EMPTY_DATA } from '../constants'
 
+const SIGNATURE_LENGTH_BYTES = 65
+const WORD_HEX_LENGTH = 64
+const BYTE_HEX_LENGTH = 2
+
 export function generatePreValidatedSignature(ownerAddress: string): SafeSignature {
   const signature =
     '0x000000000000000000000000' +
@@ -147,9 +151,49 @@ export const buildContractSignature = async (
   return contractSignature
 }
 
-export const buildSignatureBytes = (signatures: SafeSignature[]): string => {
-  const SIGNATURE_LENGTH_BYTES = 65
+export const extractContractSignatureData = (signature: string): string => {
+  const signatureData = signature.startsWith('0x') ? signature.slice(2) : signature
+  const staticPartHexLength = SIGNATURE_LENGTH_BYTES * BYTE_HEX_LENGTH
 
+  if (signatureData.length < staticPartHexLength + WORD_HEX_LENGTH) {
+    throw new Error('Invalid contract signature')
+  }
+
+  const signatureType = signatureData.slice(
+    staticPartHexLength - BYTE_HEX_LENGTH,
+    staticPartHexLength
+  )
+
+  if (signatureType !== '00') {
+    throw new Error('Invalid contract signature')
+  }
+
+  const dynamicPartOffset = Number(
+    BigInt(`0x${signatureData.slice(WORD_HEX_LENGTH, WORD_HEX_LENGTH * 2)}`)
+  )
+  const dynamicPartOffsetHexLength = dynamicPartOffset * BYTE_HEX_LENGTH
+  const dynamicPartLengthHex = signatureData.slice(
+    dynamicPartOffsetHexLength,
+    dynamicPartOffsetHexLength + WORD_HEX_LENGTH
+  )
+
+  if (dynamicPartLengthHex.length !== WORD_HEX_LENGTH) {
+    throw new Error('Invalid contract signature')
+  }
+
+  const dynamicPartLength = Number(BigInt(`0x${dynamicPartLengthHex}`))
+  const signatureStart = dynamicPartOffsetHexLength + WORD_HEX_LENGTH
+  const signatureEnd = signatureStart + dynamicPartLength * BYTE_HEX_LENGTH
+  const contractSignatureData = signatureData.slice(signatureStart, signatureEnd)
+
+  if (contractSignatureData.length !== dynamicPartLength * BYTE_HEX_LENGTH) {
+    throw new Error('Invalid contract signature')
+  }
+
+  return `0x${contractSignatureData}`
+}
+
+export const buildSignatureBytes = (signatures: SafeSignature[]): string => {
   signatures.sort((left, right) =>
     left.signer.toLowerCase().localeCompare(right.signer.toLowerCase())
   )

--- a/packages/protocol-kit/tests/unit/signatures.test.ts
+++ b/packages/protocol-kit/tests/unit/signatures.test.ts
@@ -1,0 +1,31 @@
+import chai from 'chai'
+import {
+  buildSignatureBytes,
+  EthSafeSignature,
+  extractContractSignatureData
+} from '@safe-global/protocol-kit/utils/signatures'
+
+describe('Signature utils', () => {
+  describe('extractContractSignatureData', () => {
+    it('extracts the dynamic signature data from an exported contract signature', () => {
+      const contractSigner = '0x1234567890123456789012345678901234567890'
+      const contractSignatureData = '0xdeadbeef'
+      const exportedSignature = buildSignatureBytes([
+        new EthSafeSignature(contractSigner, contractSignatureData, true)
+      ])
+
+      chai.expect(extractContractSignatureData(exportedSignature)).to.be.eq(contractSignatureData)
+      chai
+        .expect(
+          buildSignatureBytes([
+            new EthSafeSignature(
+              contractSigner,
+              extractContractSignatureData(exportedSignature),
+              true
+            )
+          ])
+        )
+        .to.be.eq(exportedSignature)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Detect `CONTRACT_SIGNATURE` confirmations when converting Transaction Service responses into `SafeTransaction`s.
- Extract the dynamic inner signature data from the exported Safe signature layout before creating `EthSafeSignature(..., true)`.
- Add a unit regression test proving an exported contract signature can be parsed and rebuilt into the same Safe signature bytes.

Fixes #1300.

## Validation
- `yarn workspace @safe-global/types-kit build`
- `yarn workspace @safe-global/protocol-kit format:check`
- `yarn workspace @safe-global/protocol-kit test` -> 47 passing
