### PR TITLE
fix: scope abitype AddressType overrides to SDK builds

### DIFF
--- a/packages/api-kit/src/abitype.d.ts
+++ b/packages/api-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/api-kit/src/index.ts
+++ b/packages/api-kit/src/index.ts
@@ -3,9 +3,3 @@ import SafeApiKit, { SafeApiKitConfig } from './SafeApiKit'
 export * from './types/safeTransactionServiceTypes'
 export { SafeApiKitConfig }
 export default SafeApiKit
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/protocol-kit/src/abitype.d.ts
+++ b/packages/protocol-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/protocol-kit/src/index.ts
+++ b/packages/protocol-kit/src/index.ts
@@ -151,9 +151,3 @@ export {
 export * from './types'
 
 export default Safe
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/relay-kit/src/abitype.d.ts
+++ b/packages/relay-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/relay-kit/src/index.ts
+++ b/packages/relay-kit/src/index.ts
@@ -17,9 +17,3 @@ export * from './RelayKitBasePack'
 
 export { GenericFeeEstimator } from './packs/safe-4337/estimators/generic/GenericFeeEstimator'
 export { PimlicoFeeEstimator } from './packs/safe-4337/estimators/pimlico/PimlicoFeeEstimator'
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/sdk-starter-kit/src/abitype.d.ts
+++ b/packages/sdk-starter-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/types-kit/src/abitype.d.ts
+++ b/packages/types-kit/src/abitype.d.ts
@@ -1,0 +1,13 @@
+import 'abitype'
+
+// See docs: https://abitype.dev/config
+declare module 'abitype' {
+  export interface Register {
+    // AddressType: `0x${string}`
+    // BytesType: {
+    //   inputs: `0x${string}` | Uint8Array
+    //   outputs: `0x${string}`
+    // }
+    AddressType: string
+  }
+}

--- a/packages/types-kit/src/index.ts
+++ b/packages/types-kit/src/index.ts
@@ -11,15 +11,3 @@ export * from './contracts/SafeWebAuthnSharedSigner'
 export * from './contracts/common/BaseContract'
 export * from './contracts/assets'
 export * from './types'
-
-// see docs: https://abitype.dev/config
-declare module 'abitype' {
-  export interface Register {
-    // AddressType: `0x${string}`
-    // BytesType: {
-    //   inputs: `0x${string}` | Uint8Array
-    //   outputs: `0x${string}`
-    // }
-    AddressType: string
-  }
-}


### PR DESCRIPTION
## Summary
- Move the Safe SDK `abitype` `AddressType: string` augmentation out of public package entrypoints
- Keep the override in package-local non-emitted `src/abitype.d.ts` files so internal builds continue to accept existing string address usage
- Cover `types-kit`, `protocol-kit`, `api-kit`, `relay-kit`, and `sdk-starter-kit` so consumers are no longer affected transitively

## Why
The published `dist/src/index.d.ts` entrypoints currently include `declare module 'abitype'`, which widens `viem`/`abitype` `Address` from `` `0x${string}` `` to `string` for any downstream app that imports Safe packages. This keeps the SDK-local compatibility shim but stops exporting it into consumer TypeScript programs.

Closes #1323.

## Validation
- `yarn build`
- targeted ESLint on changed files
- targeted Prettier check on changed files
- scanned generated `packages/*/dist` declarations for `declare module 'abitype'` / `AddressType: string`
- external consumer `tsc --noEmit` fixture importing built Safe package declarations and verifying `viem` `Address` remains narrow