### PR TITLE
fix(protocol-kit): refine baseGas estimation against execTransaction

### DIFF
--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,1 +1,1 @@
-export const getProtocolKitVersion = () => '7.0.0'
+export const getProtocolKitVersion = () => '7.1.0'

--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -177,6 +177,9 @@ async function hasExistingTokenBalance(
  *   (EIP-161) when the receiver is a fresh account.
  * - ERC20 refund: typical transfer cost; adds extra gas (SSTORE 0->non-zero per EIP-2200)
  *   when the receiver has no prior balance for the token.
+ *
+ * Note: underestimations are expected if `gasToken` is set and ERC20
+ * contract is a proxy or includes additional logic
  */
 async function calculateRefundGas(
   safeProvider: SafeProvider,

--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -183,7 +183,7 @@ async function hasExistingTokenBalance(
  */
 async function calculateRefundGas(
   safeProvider: SafeProvider,
-  gasPrice: number | string,
+  gasPrice: string,
   gasToken: string,
   refundReceiver: string
 ): Promise<number> {

--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -124,8 +124,7 @@ function calculateExecTransactionEventsGas(
     const additionalInfoDynamicBytes = 32 + 3 * 32 // (nonce, msg.sender, threshold)
     const eventDataBytes =
       headBytes + dataDynamicBytes + signaturesDynamicBytes + additionalInfoDynamicBytes
-    gas +=
-      LOG_BASE_GAS_COST + LOG_TOPIC_GAS_COST + eventDataBytes * LOG_DATA_GAS_COST_PER_BYTE + 500 // additionalInfo abi.encode + memory expansion
+    gas += LOG_BASE_GAS_COST + LOG_TOPIC_GAS_COST + eventDataBytes * LOG_DATA_GAS_COST_PER_BYTE
   }
 
   return gas
@@ -163,7 +162,7 @@ async function hasExistingTokenBalance(
     args: [account as `0x${string}`]
   })
   try {
-    const response = await safeProvider.call({ to: gasToken, value: '0', data })
+    const response = await safeProvider.call({ to: gasToken, from: gasToken, value: '0', data })
     return BigInt(response || '0x0') > 0n
   } catch {
     // Reverts and empty responses are treated as "no balance" (conservative: higher cost)

--- a/packages/protocol-kit/src/utils/transactions/gas.ts
+++ b/packages/protocol-kit/src/utils/transactions/gas.ts
@@ -1,4 +1,10 @@
-import { BaseError, CallExecutionErrorType, RawContractErrorType } from 'viem'
+import {
+  BaseError,
+  CallExecutionErrorType,
+  RawContractErrorType,
+  encodeFunctionData,
+  parseAbi
+} from 'viem'
 import { OperationType, SafeVersion, SafeTransaction } from '@safe-global/types-kit'
 import semverSatisfies from 'semver/functions/satisfies.js'
 import Safe from '@safe-global/protocol-kit/Safe'
@@ -24,8 +30,8 @@ const CALL_DATA_ZERO_BYTE_GAS_COST = 4
 // Every byte != 00 -> 16 Gas cost (68 before Istanbul)
 const CALL_DATA_BYTE_GAS_COST = 16
 
-// gas cost initialization of a Safe
-const INITIZATION_GAS_COST = 20_000
+// gas cost initialization of a Safe (SSTORE 0→non-zero on a cold slot = 20 000 + 2 100 cold-load surcharge per EIP-2929)
+const INITIALIZATION_GAS_COST = 22_100
 
 // increment nonce gas cost
 const INCREMENT_NONCE_GAS_COST = 5_000
@@ -36,12 +42,44 @@ const HASH_GENERATION_GAS_COST = 1_500
 // ecrecover gas cost for ecdsa ~= 4K gas, we use 6K
 const ECRECOVER_GAS_COST = 6_000
 
-// transfer gas cost
-const TRANSFER_GAS_COST = 32_000
+// Intrinsic transaction fee charged by the EVM (always paid by the relayer)
+const INTRINSIC_TX_GAS_COST = 21_000
+
+// Cold SLOADs always paid in execTransaction: `threshold` (in checkSignatures) + `getGuard()` slot
+const PRE_EXEC_STORAGE_GAS_COST = 2 * 2_100
+
+// Headroom for SafeMath wrappers, memory expansion, control-flow checks, and the cold owners
+// SLOAD on the first signature. Rounded up to leave slack for dynamic signature types and misc.
+const MISC_OVERHEAD_GAS_COST = 3_000
+
+// Base operations always paid on top of the contract-counted gas (not in safeTxGas / refundGas / events)
+const EXTRA_BASE_GAS_COST =
+  INTRINSIC_TX_GAS_COST + PRE_EXEC_STORAGE_GAS_COST + MISC_OVERHEAD_GAS_COST
+
+// New account creation cost (EIP-161)
 const NEW_ACCOUNT_GAS_COST = 25_000
 
-// numbers < 256 (0x00(31*2)..ff) are 192 -> 31 * 4 + 1 * CALL_DATA_BYTE_GAS_COST
-// numbers < 65535 (0x(30*2)..ffff) are 256 -> 30 * 4 + 2 * CALL_DATA_BYTE_GAS_COST
+// Cold address access (EIP-2929) — first touch of the refund receiver in this tx
+const COLD_ACCOUNT_ACCESS_GAS_COST = 2_600
+
+// Extra gas charged when CALL forwards a non-zero value
+const CALL_VALUE_GAS_COST = 9_000
+
+// Approximate ERC20 transfer gas:
+//  - existing token holder: cold token + dispatch + 2 SSTOREs + LOG3 + Safe wrapper (~21k)
+//  - new token holder: extra ~17k from SSTORE 0->non-zero on receiver balance (EIP-2200)
+const ERC20_TRANSFER_GAS_COST = 21_000
+const ERC20_NEW_HOLDER_TRANSFER_GAS_COST = 38_000
+
+// LOG opcode gas costs (yellow paper)
+const LOG_BASE_GAS_COST = 375
+const LOG_TOPIC_GAS_COST = 375
+const LOG_DATA_GAS_COST_PER_BYTE = 8
+
+// ExecutionSuccess/ExecutionFailure event: ~1262 gas pre-1.3.0 (LOG1 + 64 bytes),
+// ~1381 gas from 1.3.0 onwards (LOG2 with indexed txHash + 32 bytes). Flat estimate.
+const EXECUTION_RESULT_EVENT_GAS_COST = 1_500
+
 // Calculate gas for signatures
 // (array count (3 -> r, s, v) + ecrecover costs) * signature count
 const GAS_COST_PER_SIGNATURE =
@@ -63,6 +101,36 @@ function estimateDataGasCosts(data: string): number {
   }, 0)
 }
 
+/**
+ * Estimates the gas cost of the events emitted during execTransaction.
+ * - The Safe singleton always emits ExecutionSuccess or ExecutionFailure.
+ * - The SafeL2 singleton (>= 1.3.0) additionally emits SafeMultiSigTransaction
+ *   in its onBeforeExecTransaction hook.
+ */
+function calculateExecTransactionEventsGas(
+  isL1SafeSingleton: boolean,
+  data: string,
+  threshold: number
+): number {
+  let gas = EXECUTION_RESULT_EVENT_GAS_COST
+
+  if (!isL1SafeSingleton) {
+    // `SafeMultiSigTransaction` event for SafeL2
+    const dataBytes = (data.length - 2) / 2
+    const signaturesBytes = threshold * 65
+    const headBytes = 11 * 32 // 11 top-level event params
+    const dataDynamicBytes = 32 + Math.ceil(dataBytes / 32) * 32
+    const signaturesDynamicBytes = 32 + Math.ceil(signaturesBytes / 32) * 32
+    const additionalInfoDynamicBytes = 32 + 3 * 32 // (nonce, msg.sender, threshold)
+    const eventDataBytes =
+      headBytes + dataDynamicBytes + signaturesDynamicBytes + additionalInfoDynamicBytes
+    gas +=
+      LOG_BASE_GAS_COST + LOG_TOPIC_GAS_COST + eventDataBytes * LOG_DATA_GAS_COST_PER_BYTE + 500 // additionalInfo abi.encode + memory expansion
+  }
+
+  return gas
+}
+
 async function isNewEthRefundReceiver(
   safeProvider: SafeProvider,
   gasToken: string,
@@ -82,6 +150,55 @@ async function isNewEthRefundReceiver(
   ])
 
   return contractCode === '0x' && nonce === 0 && balance === 0n
+}
+
+async function hasExistingTokenBalance(
+  safeProvider: SafeProvider,
+  gasToken: string,
+  account: string
+): Promise<boolean> {
+  const data = encodeFunctionData({
+    abi: parseAbi(['function balanceOf(address account) view returns (uint256)']),
+    functionName: 'balanceOf',
+    args: [account as `0x${string}`]
+  })
+  try {
+    const response = await safeProvider.call({ to: gasToken, value: '0', data })
+    return BigInt(response || '0x0') > 0n
+  } catch {
+    // Reverts and empty responses are treated as "no balance" (conservative: higher cost)
+    return false
+  }
+}
+
+/**
+ * Estimates the gas cost of `handlePayment` in `execTransaction`.
+ * - Returns 0 when `gasPrice` is 0 — `handlePayment` is gated by `if (gasPrice > 0)`.
+ * - Native ETH refund: cold account access (EIP-2929) + value transfer; adds NEWACCOUNT
+ *   (EIP-161) when the receiver is a fresh account.
+ * - ERC20 refund: typical transfer cost; adds extra gas (SSTORE 0->non-zero per EIP-2200)
+ *   when the receiver has no prior balance for the token.
+ */
+async function calculateRefundGas(
+  safeProvider: SafeProvider,
+  gasPrice: number | string,
+  gasToken: string,
+  refundReceiver: string
+): Promise<number> {
+  if (BigInt(gasPrice) === 0n) {
+    return 0
+  }
+
+  if (gasToken.toLowerCase() === ZERO_ADDRESS.toLowerCase()) {
+    let gas = COLD_ACCOUNT_ACCESS_GAS_COST + CALL_VALUE_GAS_COST
+    if (await isNewEthRefundReceiver(safeProvider, gasToken, refundReceiver)) {
+      gas += NEW_ACCOUNT_GAS_COST
+    }
+    return gas
+  }
+
+  const hasBalance = await hasExistingTokenBalance(safeProvider, gasToken, refundReceiver)
+  return hasBalance ? ERC20_TRANSFER_GAS_COST : ERC20_NEW_HOLDER_TRANSFER_GAS_COST
 }
 
 export async function estimateGas(
@@ -179,11 +296,12 @@ export async function estimateTxBaseGas(
   safeTransaction: SafeTransaction
 ): Promise<string> {
   const safeTransactionData = safeTransaction.data
-  const { to, value, data, operation, safeTxGas, gasToken, refundReceiver } = safeTransactionData
+  const { to, value, data, operation, safeTxGas, gasPrice, gasToken, refundReceiver } =
+    safeTransactionData
 
   const encodeSafeTxGas = safeTxGas || 0
   const encodeBaseGas = 0
-  const gasPrice = 1
+  const encodeGasPrice = 1
   const encodeGasToken = gasToken || ZERO_ADDRESS
   const encodeRefundReceiver = refundReceiver || ZERO_ADDRESS
   const signatures = '0x'
@@ -192,14 +310,18 @@ export async function estimateTxBaseGas(
   const contractManager = safe.getContractManager()
   const isL1SafeSingleton = contractManager.isL1SafeSingleton
 
-  const [safeThreshold, safeNonce, chainId, isNewRefundReceiver] = await Promise.all([
+  const [safeThreshold, safeNonce, chainId, refundGas] = await Promise.all([
     safe.getThreshold(),
     safe.getNonce(),
     safe.getChainId(),
-    isNewEthRefundReceiver(safeProvider, encodeGasToken, encodeRefundReceiver)
+    calculateRefundGas(safeProvider, gasPrice, encodeGasToken, encodeRefundReceiver)
   ])
 
   const signaturesGasCost = safeThreshold * GAS_COST_PER_SIGNATURE
+
+  // TODO: Account for transaction guard hooks (checkTransaction, checkAfterExecution)
+  // when a guard is set on the Safe — cost depends on the guard implementation.
+
   const customContracts = contractManager.contractNetworks?.[chainId.toString()]
 
   const safeSingletonContract = await getSafeContract({
@@ -218,7 +340,7 @@ export async function estimateTxBaseGas(
     operation,
     encodeSafeTxGas,
     encodeBaseGas,
-    gasPrice,
+    encodeGasPrice,
     encodeGasToken,
     encodeRefundReceiver,
     signatures
@@ -226,7 +348,9 @@ export async function estimateTxBaseGas(
 
   // If nonce == 0, nonce storage has to be initialized
   const isSafeInitialized = safeNonce !== 0
-  const incrementNonceGasCost = isSafeInitialized ? INCREMENT_NONCE_GAS_COST : INITIZATION_GAS_COST
+  const incrementNonceGasCost = isSafeInitialized
+    ? INCREMENT_NONCE_GAS_COST
+    : INITIALIZATION_GAS_COST
 
   let baseGas =
     signaturesGasCost +
@@ -234,15 +358,18 @@ export async function estimateTxBaseGas(
     incrementNonceGasCost +
     HASH_GENERATION_GAS_COST
 
-  // Add additional gas costs
-  baseGas > 65536 ? (baseGas += 64) : (baseGas += 128)
+  // handlePayment refund gas
+  baseGas += refundGas
 
-  // Base tx costs, transfer costs...
-  baseGas += TRANSFER_GAS_COST
+  // Add events gas
+  baseGas += calculateExecTransactionEventsGas(isL1SafeSingleton ?? false, data, safeThreshold)
 
-  if (isNewRefundReceiver) {
-    baseGas += NEW_ACCOUNT_GAS_COST
-  }
+  // Extra costs
+  baseGas += EXTRA_BASE_GAS_COST
+
+  // Base gas encoding gas costs. Base gas was already encoded as `0` with `32 bytes (uint256)`, so we only need to add the data needed
+  const baseGasUsedBytes = Math.ceil(baseGas.toString(16).length / 2)
+  baseGas += baseGasUsedBytes * (CALL_DATA_BYTE_GAS_COST - CALL_DATA_ZERO_BYTE_GAS_COST)
 
   return baseGas.toString()
 }

--- a/packages/protocol-kit/tests/unit/gas.test.ts
+++ b/packages/protocol-kit/tests/unit/gas.test.ts
@@ -11,9 +11,13 @@ const ERC20_TOKEN = '0x3000000000000000000000000000000000000003'
 
 describe('estimateTxBaseGas', () => {
   beforeEach(() => {
+    // Long enough to keep baseGas in the 3-byte range (>= 65_536) so the calldata-encoding
+    // adjustment for the final baseGas value contributes the same number of bytes for every
+    // test case — otherwise crossing the 2->3 byte boundary adds +12 gas to the delta.
+    const execTransactionDataStub = '0x' + '12'.repeat(500)
     sinon
       .stub(safeDeploymentContracts, 'getSafeContract')
-      .resolves({ encode: sinon.stub().returns('0x1234') } as any)
+      .resolves({ encode: sinon.stub().returns(execTransactionDataStub) } as any)
   })
 
   afterEach(() => {

--- a/packages/protocol-kit/tests/unit/gas.test.ts
+++ b/packages/protocol-kit/tests/unit/gas.test.ts
@@ -23,16 +23,25 @@ describe('estimateTxBaseGas', () => {
   function buildSafe({
     contractCode = '0x',
     nonce = 0,
-    balance = 0n
+    balance = 0n,
+    tokenBalance = 0n,
+    tokenBalanceReverts = false
   }: {
     contractCode?: string
     nonce?: number
     balance?: bigint
+    tokenBalance?: bigint
+    tokenBalanceReverts?: boolean
   } = {}) {
+    const balanceOfResponse = '0x' + tokenBalance.toString(16).padStart(64, '0')
+    const callStub = tokenBalanceReverts
+      ? sinon.stub().rejects(new Error('reverted'))
+      : sinon.stub().resolves(balanceOfResponse)
     const safeProvider = {
       getContractCode: sinon.stub().resolves(contractCode),
       getNonce: sinon.stub().resolves(nonce),
-      getBalance: sinon.stub().resolves(balance)
+      getBalance: sinon.stub().resolves(balance),
+      call: callStub
     }
 
     return {
@@ -86,22 +95,36 @@ describe('estimateTxBaseGas', () => {
     chai.expect(Number(newRefundBaseGas) - Number(existingRefundBaseGas)).to.eq(25_000)
   })
 
-  it('does not add the account creation cost for token refunds', async () => {
-    const safe = buildSafe()
+  it('adds extra ERC20 transfer cost when refund receiver has no prior token balance', async () => {
+    const existingHolderSafe = buildSafe({ tokenBalance: 1n })
+    const newHolderSafe = buildSafe({ tokenBalance: 0n })
 
-    const ethRefundBaseGas = await estimateTxBaseGas(
-      safe,
-      buildTransaction({ refundReceiver: NEW_REFUND_RECEIVER })
+    const existingHolderBaseGas = await estimateTxBaseGas(
+      existingHolderSafe,
+      buildTransaction({ gasToken: ERC20_TOKEN, refundReceiver: NEW_REFUND_RECEIVER })
     )
-    const tokenRefundBaseGas = await estimateTxBaseGas(
-      safe,
-      buildTransaction({
-        gasToken: ERC20_TOKEN,
-        refundReceiver: NEW_REFUND_RECEIVER
-      })
+    const newHolderBaseGas = await estimateTxBaseGas(
+      newHolderSafe,
+      buildTransaction({ gasToken: ERC20_TOKEN, refundReceiver: NEW_REFUND_RECEIVER })
     )
 
-    chai.expect(Number(ethRefundBaseGas) - Number(tokenRefundBaseGas)).to.eq(25_000)
+    chai.expect(Number(newHolderBaseGas) - Number(existingHolderBaseGas)).to.eq(17_000)
+  })
+
+  it('treats a reverting balanceOf call as a new token holder (conservative)', async () => {
+    const existingHolderSafe = buildSafe({ tokenBalance: 1n })
+    const revertingSafe = buildSafe({ tokenBalanceReverts: true })
+
+    const existingHolderBaseGas = await estimateTxBaseGas(
+      existingHolderSafe,
+      buildTransaction({ gasToken: ERC20_TOKEN, refundReceiver: NEW_REFUND_RECEIVER })
+    )
+    const revertingBaseGas = await estimateTxBaseGas(
+      revertingSafe,
+      buildTransaction({ gasToken: ERC20_TOKEN, refundReceiver: NEW_REFUND_RECEIVER })
+    )
+
+    chai.expect(Number(revertingBaseGas) - Number(existingHolderBaseGas)).to.eq(17_000)
   })
 
   it('does not add the account creation cost when refundReceiver is the zero address', async () => {


### PR DESCRIPTION
## Summary

Aligns `estimateTxBaseGas` with the current Safe `execTransaction` implementation so refunds (especially ERC20) and event emission are not under-counted, which could lead to relayer-side reverts.

- Replace the flat `TRANSFER_GAS_COST = 32_000` with `calculateRefundGas`, which models `handlePayment` per gas token:
  - **native ETH**: cold address access (EIP-2929) + value transfer, plus NEWACCOUNT (EIP-161) when the receiver is a fresh account
  - **ERC20**: typical transfer cost, plus the SSTORE 0→non-zero delta (EIP-2200) when the receiver has no prior token balance (detected via `balanceOf`; reverts treated as new-holder, conservative)
  - returns `0` when `gasPrice == 0` (`handlePayment` is gated by it)
- Add `calculateExecTransactionEventsGas` accounting for `ExecutionSuccess`/`ExecutionFailure` (always emitted) and `SafeMultiSigTransaction` (L2 singleton only).
- Drop the stale pre-Istanbul `+64/+128` adjustment for the `baseGas` calldata placeholder, replacing it with the correct delta based on the byte count of the **final** value, applied at the end of the function so the count reflects all add-ons.
- Break the previously-bundled overhead into `INTRINSIC_TX_GAS_COST` + `PRE_EXEC_STORAGE_GAS_COST` + `MISC_OVERHEAD_GAS_COST` for traceability and headroom.
- Add a TODO for transaction guard hooks (cost depends on the guard implementation).

## Net change vs. pre-refactor

| Scenario | Old `baseGas` add-ons | New `baseGas` add-ons | Δ |
|---|---|---|---|
| ETH refund, existing receiver | 32 000 | 28 200 + 11 600 + 1 500 = **41 300** | +9 300 |
| ETH refund, fresh receiver | 32 000 + 25 000 = 57 000 | 28 200 + 36 600 + 1 500 = **66 300** | +9 300 |
| ERC20, existing token holder | 32 000 | 28 200 + 21 000 + 1 500 = **50 700** | +18 700 |
| ERC20, new token holder | 32 000 | 28 200 + 38 000 + 1 500 = **67 700** | +35 700 |
| `gasPrice = 0` | 32 000 (+ 25k if new ETH) | 28 200 + 0 + 1 500 = **29 700** | -2 300 / -27 300 |

The `gasPrice = 0` row is the only place we go *below* the old number. That is correct: the old code charged `TRANSFER_GAS_COST` (and even `NEW_ACCOUNT_GAS_COST`) when `handlePayment` was never invoked.

Refs: [PLA-1429](https://linear.app/safe-global/issue/PLA-1429/fix-base-gas-estimation-for-gtf)