### PR TITLE
feat(api-kit): add HttpError class with statusCode for programmatic error handling

### DIFF
--- a/packages/api-kit/src/index.ts
+++ b/packages/api-kit/src/index.ts
@@ -2,6 +2,7 @@ import SafeApiKit, { SafeApiKitConfig } from './SafeApiKit'
 
 export * from './types/safeTransactionServiceTypes'
 export { SafeApiKitConfig }
+export { HttpError } from './utils/httpRequests'
 export default SafeApiKit
 
 declare module 'abitype' {

--- a/packages/api-kit/src/utils/httpRequests.ts
+++ b/packages/api-kit/src/utils/httpRequests.ts
@@ -10,6 +10,18 @@ export interface HttpRequest {
   body?: any
 }
 
+export class HttpError extends Error {
+  statusCode: number
+  data: unknown
+
+  constructor(statusCode: number, message: string, data: unknown) {
+    super(message)
+    this.name = 'HttpError'
+    this.statusCode = statusCode
+    this.data = data
+  }
+}
+
 export async function sendRequest<T>(
   { url, method, body }: HttpRequest,
   apiKey?: string
@@ -33,38 +45,42 @@ export async function sendRequest<T>(
     body: JSON.stringify(body)
   })
 
-  let jsonResponse: any
-  try {
-    jsonResponse = await response.json()
-  } catch (error) {
-    if (!response.ok) {
-      throw new Error(response.statusText)
+  const text = await response.text()
+
+  if (!response.ok) {
+    let jsonResponse: any
+    try {
+      jsonResponse = JSON.parse(text)
+    } catch {
+      throw new HttpError(response.status, response.statusText, undefined)
     }
+    if (jsonResponse.data) {
+      throw new HttpError(response.status, jsonResponse.data, jsonResponse)
+    }
+    if (jsonResponse.detail) {
+      throw new HttpError(response.status, jsonResponse.detail, jsonResponse)
+    }
+    if (jsonResponse.message) {
+      throw new HttpError(response.status, jsonResponse.message, jsonResponse)
+    }
+    if (jsonResponse.nonFieldErrors) {
+      throw new HttpError(response.status, jsonResponse.nonFieldErrors, jsonResponse)
+    }
+    if (jsonResponse.delegate) {
+      throw new HttpError(response.status, jsonResponse.delegate, jsonResponse)
+    }
+    if (jsonResponse.safe) {
+      throw new HttpError(response.status, jsonResponse.safe, jsonResponse)
+    }
+    if (jsonResponse.delegator) {
+      throw new HttpError(response.status, jsonResponse.delegator, jsonResponse)
+    }
+    throw new HttpError(response.status, response.statusText, jsonResponse)
   }
 
-  if (response.ok) {
-    return jsonResponse as T
+  if (!text) {
+    return undefined as unknown as T
   }
-  if (jsonResponse.data) {
-    throw new Error(jsonResponse.data)
-  }
-  if (jsonResponse.detail) {
-    throw new Error(jsonResponse.detail)
-  }
-  if (jsonResponse.message) {
-    throw new Error(jsonResponse.message)
-  }
-  if (jsonResponse.nonFieldErrors) {
-    throw new Error(jsonResponse.nonFieldErrors)
-  }
-  if (jsonResponse.delegate) {
-    throw new Error(jsonResponse.delegate)
-  }
-  if (jsonResponse.safe) {
-    throw new Error(jsonResponse.safe)
-  }
-  if (jsonResponse.delegator) {
-    throw new Error(jsonResponse.delegator)
-  }
-  throw new Error(response.statusText)
+
+  return JSON.parse(text) as T
 }

--- a/packages/api-kit/tests/endpoint/httpRequests.test.ts
+++ b/packages/api-kit/tests/endpoint/httpRequests.test.ts
@@ -1,0 +1,136 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import sinon from 'sinon'
+import { HttpError, HttpMethod, sendRequest } from '@safe-global/api-kit/utils/httpRequests'
+
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+const STATUS_TEXTS: Record<number, string> = {
+  200: 'OK',
+  201: 'Created',
+  204: 'No Content',
+  400: 'Bad Request',
+  404: 'Not Found',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  503: 'Service Unavailable'
+}
+
+function mockResponse(status: number, body: string | object): Response {
+  const text = typeof body === 'string' ? body : JSON.stringify(body)
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: STATUS_TEXTS[status] ?? 'Unknown',
+    text: () => Promise.resolve(text)
+  } as unknown as Response
+}
+
+describe('sendRequest', () => {
+  let fetchStub: sinon.SinonStub
+  let originalWindow: unknown
+
+  const request = { url: 'https://example.com/api', method: HttpMethod.Get }
+
+  beforeEach(() => {
+    originalWindow = (globalThis as any).window
+    fetchStub = sinon.stub()
+    ;(globalThis as any).window = { fetch: fetchStub }
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).window = originalWindow
+  })
+
+  describe('successful responses', () => {
+    it('returns parsed JSON body', async () => {
+      fetchStub.resolves(mockResponse(200, { safe: '0x123' }))
+      const result = await sendRequest(request)
+      expect(result).to.deep.equal({ safe: '0x123' })
+    })
+
+    it('returns undefined for an empty body (204 No Content)', async () => {
+      fetchStub.resolves(mockResponse(204, ''))
+      const result = await sendRequest(request)
+      expect(result).to.be.undefined
+    })
+
+    it('sets Authorization header when apiKey is provided', async () => {
+      fetchStub.resolves(mockResponse(200, {}))
+      await sendRequest(request, 'my-api-key')
+      const [, options] = fetchStub.firstCall.args
+      expect(options.headers['Authorization']).to.equal('Bearer my-api-key')
+    })
+
+    it('does not set Authorization header when no apiKey is provided', async () => {
+      fetchStub.resolves(mockResponse(200, {}))
+      await sendRequest(request)
+      const [, options] = fetchStub.firstCall.args
+      expect(options.headers).not.to.have.property('Authorization')
+    })
+  })
+
+  describe('error responses', () => {
+    it('throws HttpError for a 429 with detail field', async () => {
+      fetchStub.resolves(mockResponse(429, { detail: 'Monthly quota exceeded.' }))
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err).to.be.instanceOf(HttpError)
+      expect(err.statusCode).to.equal(429)
+      expect(err.message).to.equal('Monthly quota exceeded.')
+    })
+
+    it('throws HttpError for a 422 with CodeErrorResponse message field', async () => {
+      fetchStub.resolves(
+        mockResponse(422, { code: 1, message: 'Owner address checksum not valid', arguments: [] })
+      )
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err).to.be.instanceOf(HttpError)
+      expect(err.statusCode).to.equal(422)
+      expect(err.message).to.equal('Owner address checksum not valid')
+    })
+
+    it('preserves the full response body in HttpError.data', async () => {
+      const body = { code: 1, message: 'Owner address checksum not valid', arguments: ['0xabc'] }
+      fetchStub.resolves(mockResponse(422, body))
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err.data).to.deep.equal(body)
+    })
+
+    it('falls back to statusText when error body is not JSON', async () => {
+      fetchStub.resolves({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: () => Promise.resolve('<html>Service Unavailable</html>')
+      })
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err).to.be.instanceOf(HttpError)
+      expect(err.statusCode).to.equal(503)
+      expect(err.message).to.equal('Service Unavailable')
+    })
+
+    it('falls back to statusText when error body has no known field', async () => {
+      fetchStub.resolves(mockResponse(400, { unknown: 'field' }))
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err).to.be.instanceOf(HttpError)
+      expect(err.statusCode).to.equal(400)
+      expect(err.message).to.equal('Bad Request')
+    })
+
+    it('falls back to statusText for empty error body', async () => {
+      fetchStub.resolves(mockResponse(404, ''))
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err).to.be.instanceOf(HttpError)
+      expect(err.statusCode).to.equal(404)
+      expect(err.message).to.equal('Not Found')
+    })
+
+    it('is an instance of Error for backwards compatibility', async () => {
+      fetchStub.resolves(mockResponse(429, { detail: 'Rate limited' }))
+      const err = await sendRequest(request).catch((e) => e)
+      expect(err).to.be.instanceOf(Error)
+    })
+  })
+})

--- a/packages/api-kit/tests/endpoint/index.test.ts
+++ b/packages/api-kit/tests/endpoint/index.test.ts
@@ -49,15 +49,20 @@ let delegatorAddress: string
 let eip3770DelegatorAddress: string
 
 describe('Endpoint tests', () => {
+  let fetchData: sinon.SinonStub
+
   before(async () => {
     ;({ safeApiKit, protocolKit } = await getKits({ signer: PRIVATE_KEY_1, safeAddress }))
     delegatorAddress = (await protocolKit.getSafeProvider().getSignerAddress()) || '0x'
     eip3770DelegatorAddress = `${config.EIP_3770_PREFIX}:${delegatorAddress}`
+    fetchData = sinon
+      .stub(httpRequests, 'sendRequest')
+      .returns(Promise.resolve({ data: { success: true } }))
   })
 
-  const fetchData = sinon
-    .stub(httpRequests, 'sendRequest')
-    .returns(Promise.resolve({ data: { success: true } }))
+  after(() => {
+    sinon.restore()
+  })
 
   afterEach(() => {
     sinon.resetHistory()


### PR DESCRIPTION
## Problem

Developers using `api-kit` with an API key had no way to programmatically
detect rate limit errors (HTTP 429) or any other specific error type. All
errors were thrown as plain `Error` objects with only a string message —
the HTTP status code was discarded entirely.

## Changes

### `HttpError` class

New `HttpError extends Error` exported from the public API with two properties:

- `statusCode: number` — the HTTP status code
- `data: unknown` — the full parsed response body

Backwards compatible: `.message` is preserved, `instanceof Error` still works,
all existing `catch` handlers and `.rejects.toThrow()` tests are unaffected.

```ts
import SafeApiKit, { HttpError } from '@safe-global/api-kit'

try {
  await safeApiKit.getSafeInfo(address)
} catch (error) {
  if (error instanceof HttpError && error.statusCode === 429) {
    // retry with exponential backoff
  }
}
```

### Refactored sendRequest

Replaced the response.json() try-catch control flow with response.text()
and explicit branching:

Error path: JSON is parsed, message extracted from known fields (detail → message → legacy fields), falls back to statusText. All legacy field checks kept for backwards compatibility.
Success path: empty body (204 / 201 no-content) returns undefined explicitly. A non-empty non-JSON body on a 2xx now surfaces as a SyntaxError rather than silently returning undefined.

### Unit tests

New tests/endpoint/httpRequests.test.ts covering all sendRequest paths:
successful JSON, empty body, API key header, 429 detail field, 422
CodeErrorResponse, full body in .data, non-JSON error fallback, empty
error body fallback, and instanceof Error backwards compatibility.
