### PR TITLE
fix: avoid leaking abitype AddressType override

### DIFF
--- a/packages/api-kit/src/abitype.d.ts
+++ b/packages/api-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/api-kit/src/index.ts
+++ b/packages/api-kit/src/index.ts
@@ -4,9 +4,3 @@ export * from './types/safeTransactionServiceTypes'
 export { SafeApiKitConfig }
 export { HttpError } from './utils/httpRequests'
 export default SafeApiKit
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/protocol-kit/src/abitype.d.ts
+++ b/packages/protocol-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/protocol-kit/src/index.ts
+++ b/packages/protocol-kit/src/index.ts
@@ -151,9 +151,3 @@ export {
 export * from './types'
 
 export default Safe
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/relay-kit/src/abitype.d.ts
+++ b/packages/relay-kit/src/abitype.d.ts
@@ -1,0 +1,7 @@
+import 'abitype'
+
+declare module 'abitype' {
+  export interface Register {
+    AddressType: string
+  }
+}

--- a/packages/relay-kit/src/index.ts
+++ b/packages/relay-kit/src/index.ts
@@ -17,9 +17,3 @@ export * from './RelayKitBasePack'
 
 export { GenericFeeEstimator } from './packs/safe-4337/estimators/generic/GenericFeeEstimator'
 export { PimlicoFeeEstimator } from './packs/safe-4337/estimators/pimlico/PimlicoFeeEstimator'
-
-declare module 'abitype' {
-  export interface Register {
-    AddressType: string
-  }
-}

--- a/packages/types-kit/src/index.ts
+++ b/packages/types-kit/src/index.ts
@@ -13,13 +13,3 @@ export * from './contracts/assets'
 export * from './types'
 
 // see docs: https://abitype.dev/config
-declare module 'abitype' {
-  export interface Register {
-    // AddressType: `0x${string}`
-    // BytesType: {
-    //   inputs: `0x${string}` | Uint8Array
-    //   outputs: `0x${string}`
-    // }
-    AddressType: string
-  }
-}


### PR DESCRIPTION
## Summary
- remove exported `abitype` `AddressType: string` module augmentations from package entry points
- keep the override as package-internal `.d.ts` files where it is needed for SDK builds
- prevent consumers of Safe packages from having viem/wagmi `Address` widened globally to `string`

## Testing
- `corepack yarn install --frozen-lockfile`
- `corepack yarn workspace @safe-global/types-kit build`
- `corepack yarn workspace @safe-global/protocol-kit build`
- `corepack yarn workspace @safe-global/api-kit build`
- `corepack yarn workspace @safe-global/relay-kit build`
- `grep -RIn "AddressType: string\|declare module 'abitype'" packages/*/dist` returned no matches\n\nCloses #1323