### PR TITLE
docs: fix awkward grammar in CONTRIBUTING.md CLA sentence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ See our [support guidelines](https://github.com/safe-global/safe-core-sdk/tree/m
 
 ## <a name="i-want-to-contribute">I Want to Contribute</a>
 ### Legal Notice
-You will need to agree to [our CLA](https://safe.global/cla) in order to be possible to consider your contribution.
+You will need to agree to [our CLA](https://safe.global/cla) in order for us to consider your contribution.
 
 ### Starting Guide
 


### PR DESCRIPTION
### What
Fix grammatically incorrect phrase "in order to be possible to consider your contribution" → "in order for us to consider your contribution" in CONTRIBUTING.md.

### Why
The original phrasing is ungrammatical and confusing to read. The corrected version clearly conveys the same intent.

Small, scoped fix from kcolbchain contrib-bot.