### PR TITLE
Fix numeric block id handling

### DIFF
--- a/packages/protocol-kit/src/utils/block.ts
+++ b/packages/protocol-kit/src/utils/block.ts
@@ -4,8 +4,8 @@ export function asBlockId(blockId: number | string | undefined) {
   return typeof blockId === 'number' ? blockNumber(blockId) : blockTag(blockId)
 }
 
-function blockNumber(blockNumber: any) {
-  return { blockNumber: blockNumber.toNumber() }
+function blockNumber(blockNumber: number) {
+  return { blockNumber }
 }
 
 function blockTag(blockTag: any) {

--- a/packages/protocol-kit/tests/unit/block.test.ts
+++ b/packages/protocol-kit/tests/unit/block.test.ts
@@ -1,0 +1,14 @@
+import chai from 'chai'
+import { asBlockId } from '../../src/utils/block'
+
+describe('block utils', () => {
+  describe('asBlockId', () => {
+    it('returns a blockNumber for numeric block ids', () => {
+      chai.expect(asBlockId(123)).to.deep.equal({ blockNumber: 123 })
+    })
+
+    it('returns a blockTag for string block ids', () => {
+      chai.expect(asBlockId('latest')).to.deep.equal({ blockTag: 'latest' })
+    })
+  })
+})


### PR DESCRIPTION
Fixes numeric `blockTag` handling in `SafeProvider` helpers.

`SafeProvider.getBalance`, `getNonce`, `getContractCode`, `isContractDeployed`, and `call` accept `blockTag?: string | number`, but numeric values were passed through `asBlockId()` to `blockNumber()`, which called `.toNumber()` on a JavaScript number. That throws before the viem action is called.

This returns the numeric block id directly and adds a small unit test for numeric and string block ids.

Tested:

```bash
cd packages/protocol-kit
../../node_modules/.bin/mocha -r ts-node/register -r tsconfig-paths/register tests/unit/block.test.ts
```