### PR TITLE
fix(protocol-kit): keep chainId as bigint in EIP-712 hashing

### DIFF
--- a/.changeset/safe-tx-hash-bigint-chainid.md
+++ b/.changeset/safe-tx-hash-bigint-chainid.md
@@ -1,0 +1,6 @@
+---
+'@safe-global/protocol-kit': patch
+'@safe-global/types-kit': patch
+---
+
+Keep `chainId` as a `bigint` in the EIP-712 hashing helpers (`calculateSafeTransactionHash`, `calculateSafeMessageHash`, `preimageSafeTransactionHash`, `preimageSafeMessageHash`) instead of casting it to `number`, which lost precision for chain IDs above `Number.MAX_SAFE_INTEGER`. Because the pinned viem version (2.21.8) drops a `bigint` `chainId` from the EIP-712 domain, `encode.ts` now uses a local `getTypesForEIP712Domain` copy that handles `number | bigint`. This shim can be removed once viem is bumped to >= 2.23.0.

--- a/packages/protocol-kit/src/utils/eip-712/encode.ts
+++ b/packages/protocol-kit/src/utils/eip-712/encode.ts
@@ -4,7 +4,6 @@ import {
   concat,
   AbiParameter,
   encodeAbiParameters,
-  getTypesForEIP712Domain,
   validateTypedData,
   hashDomain,
   toHex,
@@ -12,6 +11,36 @@ import {
   HashTypedDataParameters
 } from 'viem'
 import { asHex } from '../types'
+
+/*
+ * Local copy of viem's `getTypesForEIP712Domain`. The `chainId` is a `bigint` to
+ * avoid precision loss for large chain IDs (> Number.MAX_SAFE_INTEGER), but the
+ * version of viem we are pinned to (2.21.8) only includes `chainId` in the domain
+ * when it is a `number`, so a `bigint` is silently dropped from the hash.
+ *
+ * viem 2.23.0 fixed this (it now accepts `number | bigint`), but we cannot upgrade
+ * yet: newer viem tightens address/calldata params to the `0x${string}` template
+ * type, which the contracts layer (addresses stored as `string`) does not satisfy
+ * and would require a separate, larger migration.
+ *
+ * This shim can be removed once viem is bumped to >= 2.23.0.
+ */
+function getTypesForEIP712Domain({
+  domain
+}: {
+  domain?: Record<string, unknown>
+}): TypedDataTypes[] {
+  return [
+    typeof domain?.name === 'string' && { name: 'name', type: 'string' },
+    domain?.version && { name: 'version', type: 'string' },
+    (typeof domain?.chainId === 'number' || typeof domain?.chainId === 'bigint') && {
+      name: 'chainId',
+      type: 'uint256'
+    },
+    domain?.verifyingContract && { name: 'verifyingContract', type: 'address' },
+    domain?.salt && { name: 'salt', type: 'bytes32' }
+  ].filter(Boolean) as TypedDataTypes[]
+}
 
 /*
  * This whole file was copied (and softly adapted) from viem in order to expose the function that provides just the encoding. The purpose is to expose `encodeTypedData` (viem only exports the hashTypedData)

--- a/packages/protocol-kit/src/utils/signatures/utils.ts
+++ b/packages/protocol-kit/src/utils/signatures/utils.ts
@@ -196,7 +196,7 @@ export const preimageSafeTransactionHash = (
 
   const message = safeTx as unknown as Record<string, unknown>
   return encodeTypedData({
-    domain: { verifyingContract: safeAddress, chainId: Number(chainId) },
+    domain: { verifyingContract: safeAddress, chainId },
     types: { SafeTx: safeTxTypes.SafeTx },
     message
   })
@@ -211,7 +211,7 @@ export const preimageSafeMessageHash = (
   const safeMessageTypes = getEip712MessageTypes(safeVersion)
 
   return encodeTypedData({
-    domain: { verifyingContract: safeAddress, chainId: Number(chainId) },
+    domain: { verifyingContract: safeAddress, chainId },
     types: { SafeMessage: safeMessageTypes.SafeMessage },
     message: { message }
   })
@@ -227,12 +227,12 @@ export const calculateSafeTransactionHash = (
 ): string => {
   const safeTxTypes = getEip712TxTypes(safeVersion)
   const domain: {
-    chainId?: number
+    chainId?: bigint
     verifyingContract: string
   } = { verifyingContract: safeAddress }
 
   if (semverSatisfies(safeVersion, EQ_OR_GT_1_3_0)) {
-    domain.chainId = Number(chainId)
+    domain.chainId = chainId
   }
 
   const message = safeTx as unknown as Record<string, unknown>
@@ -249,7 +249,7 @@ export const calculateSafeMessageHash = (
   const safeMessageTypes = getEip712MessageTypes(safeVersion)
 
   return hashTypedData({
-    domain: { verifyingContract: safeAddress, chainId: Number(chainId) },
+    domain: { verifyingContract: safeAddress, chainId },
     types: { SafeMessage: safeMessageTypes.SafeMessage },
     message: { message }
   })

--- a/packages/types-kit/src/types.ts
+++ b/packages/types-kit/src/types.ts
@@ -177,7 +177,7 @@ export type SigningMethodType = SigningMethod | string
 export interface TypedDataDomain {
   name?: string
   version?: string
-  chainId?: number
+  chainId?: number | bigint
   verifyingContract?: string
   salt?: ArrayLike<number> | string
 }


### PR DESCRIPTION
`calculateSafeTransactionHash`, `calculateSafeMessageHash` and the preimage helpers cast `chainId` to number, losing precision for chain IDs above `Number.MAX_SAFE_INTEGER`. Pass the `bigint` through instead.

viem 2.21.8 drops a bigint chainId from the EIP-712 domain (it only includes chainId when it is a number), so encode.ts uses a local getTypesForEIP712Domain copy that handles number | bigint. We cannot bump to viem 2.23.0 (which fixes this upstream) because newer viem tightens address params to 0x${string}, which the contracts layer does not yet satisfy. The shim can be removed after that migration.

Closes PLA-1667
