### PR TITLE
chore: add botchain (bot) chain support and bump deployments

### DIFF
--- a/.changeset/add-botchain-chain.md
+++ b/.changeset/add-botchain-chain.md
@@ -1,0 +1,5 @@
+---
+'@safe-global/protocol-kit': patch
+---
+
+chore: add botchain (bot) chain support and bump safe-deployments

--- a/.changeset/add-botchain-chain.md
+++ b/.changeset/add-botchain-chain.md
@@ -1,5 +1,6 @@
 ---
 '@safe-global/protocol-kit': patch
+'@safe-global/relay-kit': patch
 ---
 
-chore: add botchain (bot) chain support and bump safe-deployments
+chore: add botchain (bot) chain support and bump safe-deployments and safe-modules-deployments

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -83,8 +83,8 @@
     "tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
-    "@safe-global/safe-deployments": "^1.37.58",
-    "@safe-global/safe-modules-deployments": "^3.0.5",
+    "@safe-global/safe-deployments": "^1.37.59",
+    "@safe-global/safe-modules-deployments": "^3.0.7",
     "@safe-global/types-kit": "workspace:^",
     "abitype": "^1.2.3",
     "semver": "^7.8.0",

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -109,6 +109,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 595n, shortName: 'maca' },
   { chainId: 599n, shortName: 'metis-goerli' },
   { chainId: 648n, shortName: 'ace' },
+  { chainId: 677n, shortName: 'bot' },
   { chainId: 686n, shortName: 'kar' },
   { chainId: 690n, shortName: 'redstone' },
   { chainId: 698n, shortName: 'Matchain' },

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.6.0",
     "@safe-global/protocol-kit": "workspace:^",
-    "@safe-global/safe-modules-deployments": "^3.0.5",
+    "@safe-global/safe-modules-deployments": "^3.0.7",
     "@safe-global/types-kit": "workspace:^",
     "semver": "^7.8.0",
     "viem": "^2.52.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,11 +166,11 @@ importers:
   packages/protocol-kit:
     dependencies:
       '@safe-global/safe-deployments':
-        specifier: ^1.37.58
-        version: 1.37.58
+        specifier: ^1.37.59
+        version: 1.37.59
       '@safe-global/safe-modules-deployments':
-        specifier: ^3.0.5
-        version: 3.0.5
+        specifier: ^3.0.7
+        version: 3.0.7
       '@safe-global/types-kit':
         specifier: workspace:^
         version: link:../types-kit
@@ -249,8 +249,8 @@ importers:
         specifier: workspace:^
         version: link:../protocol-kit
       '@safe-global/safe-modules-deployments':
-        specifier: ^3.0.5
-        version: 3.0.5
+        specifier: ^3.0.7
+        version: 3.0.7
       '@safe-global/types-kit':
         specifier: workspace:^
         version: link:../types-kit
@@ -1298,12 +1298,12 @@ packages:
     peerDependencies:
       ethers: 5.4.0
 
-  '@safe-global/safe-deployments@1.37.58':
-    resolution: {integrity: sha512-OZJamxC1rI4s/EWH9ss+FOMPutbDsSOUHjdtjkSqHXRca+p+/yMERduQSKi3Th3vzLDFqnpdch1+/sx0DJVJHQ==}
+  '@safe-global/safe-deployments@1.37.59':
+    resolution: {integrity: sha512-y1eAviyDJARMqwXctqXylsBGqNkeFIq/q2XJlmkVZ9vSwfQBP31a33sUZkbmwwJuomv0/Yrl04YNDQ2C8CaGWw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.16.0'}
 
-  '@safe-global/safe-modules-deployments@3.0.5':
-    resolution: {integrity: sha512-MycyPiwAwjitVSWnO3nFyfCTXei07RosuACprMVpc0at0gKX1bRIaazWpdLwFSI1FUA6+0o1LbQPGNWjMqq9Zg==}
+  '@safe-global/safe-modules-deployments@3.0.7':
+    resolution: {integrity: sha512-XTloEuDvKBQJCKoySg1Y+NMdVFJWxwhH2fSaziT8R4vIbuEyQYWW9vj4z92+hHPXCBBh0cyi/MBXW+HYjYroew==}
 
   '@safe-global/safe-passkey@0.2.0':
     resolution: {integrity: sha512-B9IpVvwXLvK3m+BRhn9z8kCbEizFmua4YmaUBZ9yr0xM9YsX2PRTnxbFvC7pLph1OQ2u+9O2V3FEmPiS10YEIw==}
@@ -5619,11 +5619,11 @@ snapshots:
     dependencies:
       ethers: 5.4.0
 
-  '@safe-global/safe-deployments@1.37.58':
+  '@safe-global/safe-deployments@1.37.59':
     dependencies:
       semver: 7.8.0
 
-  '@safe-global/safe-modules-deployments@3.0.5': {}
+  '@safe-global/safe-modules-deployments@3.0.7': {}
 
   '@safe-global/safe-passkey@0.2.0(ethers@5.4.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,8 @@ minimumReleaseAge: 10080 # minutes (7 days)
 minimumReleaseAgeExclude:
 # We skip the minimumReleaseAge for this version specifically
 # containing a update to latest chains
-  - "@safe-global/safe-deployments@1.37.58"
+  - "@safe-global/safe-deployments@1.37.59"
+  - "@safe-global/safe-modules-deployments@3.0.7"
 
 # Only packages listed here are allowed to run install scripts.
 # esbuild and nx require native compilation; keccak and secp256k1 are native


### PR DESCRIPTION
Bump safe-deployments to 1.37.59 and safe-modules-deployments to 3.0.7, update EIP-3770 network config with chainId 677 (bot), and add a changeset.