### PR TITLE
Set release wch-sepolia

### DIFF
--- a/.changeset/add-botchain-chain.md
+++ b/.changeset/add-botchain-chain.md
@@ -1,6 +1,0 @@
----
-'@safe-global/protocol-kit': patch
-'@safe-global/relay-kit': patch
----
-
-chore: add botchain (bot) chain support and bump safe-deployments and safe-modules-deployments

--- a/.changeset/bump-safe-deployments.md
+++ b/.changeset/bump-safe-deployments.md
@@ -1,6 +1,0 @@
----
-'@safe-global/protocol-kit': patch
-'@safe-global/relay-kit': patch
----
-
-Add Whitechain Sepolia (wch-sepolia) chain support and bump @safe-global/safe-deployments and @safe-global/safe-modules-deployments to the latest versions

--- a/packages/protocol-kit/CHANGELOG.md
+++ b/packages/protocol-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @safe-global/protocol-kit
 
+## 8.0.4
+
+### Patch Changes
+
+- c265183: Add Whitechain Sepolia (wch-sepolia) chain support and bump @safe-global/safe-deployments and @safe-global/safe-modules-deployments to the latest versions
+
 ## 8.0.3
 
 ### Patch Changes

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/protocol-kit",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "SDK that facilitates the interaction with Safe Smart Accounts",
   "types": "dist/src/index.d.ts",
   "main": "dist/cjs/src/index.cjs",

--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,1 +1,1 @@
-export const getProtocolKitVersion = () => '8.0.3'
+export const getProtocolKitVersion = () => '8.0.4'

--- a/packages/relay-kit/CHANGELOG.md
+++ b/packages/relay-kit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @safe-global/relay-kit
 
+## 6.0.4
+
+### Patch Changes
+
+- c265183: Add Whitechain Sepolia (wch-sepolia) chain support and bump @safe-global/safe-deployments and @safe-global/safe-modules-deployments to the latest versions
+- Updated dependencies [c265183]
+  - @safe-global/protocol-kit@8.0.4
+
 ## 6.0.3
 
 ### Patch Changes

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/relay-kit",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "SDK for Safe Smart Accounts with support for ERC-4337 and Relay",
   "types": "dist/src/index.d.ts",
   "main": "dist/cjs/src/index.cjs",

--- a/packages/relay-kit/src/packs/safe-4337/utils/getRelayKitVersion.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/getRelayKitVersion.ts
@@ -1,1 +1,1 @@
-export const getRelayKitVersion = () => '6.0.3'
+export const getRelayKitVersion = () => '6.0.4'


### PR DESCRIPTION
Bump protocol-kit to 8.0.4 and relay-kit to 6.0.4 via changesets, consuming the wch-sepolia chain-support changeset. Also removes .changeset/add-botchain-chain.md, a stale changeset left over from the prior botchain release whose content was already applied in protocol-kit 8.0.3 / relay-kit 6.0.3.