### PR TITLE
chore: improve api-kit e2e tests execution time

### DIFF
--- a/.github/workflows/api-kit-e2e-test.yml
+++ b/.github/workflows/api-kit-e2e-test.yml
@@ -18,10 +18,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         node-version: [20.x]
-        provider: [ethers, viem]
         safe-version: [v1.3.0, v1.4.1, v1.5.0]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,9 +36,16 @@ jobs:
       - run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Test ${{ matrix.provider }} - Safe ${{ matrix.safe-version }}
+      - name: Test ethers - Safe ${{ matrix.safe-version }}
         env:
           API_KEY: ${{ secrets.API_KEY }}
         run: |
           cd packages/api-kit
-          pnpm test:ci:${{ matrix.provider }}:${{ matrix.safe-version }}
+          pnpm test:ci:ethers:${{ matrix.safe-version }}
+      - name: Test viem - Safe ${{ matrix.safe-version }}
+        if: ${{ !cancelled() }}
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+        run: |
+          cd packages/api-kit
+          pnpm test:ci:viem:${{ matrix.safe-version }}


### PR DESCRIPTION
## What it solves
e2e concurrency dropped to 1 to avoid issues on two libs running tests over the same Safe. Instead we set up secuence only for the tests running over the same Safe version (and specific address) but we avoid queuing 2 other test that could be running in parallel.
