### PR TITLE
chore: add Gravity (grav) chain support

### DIFF
--- a/.changeset/add-gravity-chain-support.md
+++ b/.changeset/add-gravity-chain-support.md
@@ -1,0 +1,6 @@
+---
+'@safe-global/protocol-kit': patch
+'@safe-global/relay-kit': patch
+---
+
+chore: add Gravity (grav) chain support and bump `@safe-global/safe-deployments` and `@safe-global/safe-modules-deployments` to the latest versions

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -83,8 +83,8 @@
     "tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
-    "@safe-global/safe-deployments": "^1.37.60",
-    "@safe-global/safe-modules-deployments": "^3.0.8",
+    "@safe-global/safe-deployments": "^1.37.61",
+    "@safe-global/safe-modules-deployments": "^3.0.9",
     "@safe-global/types-kit": "workspace:^",
     "abitype": "^1.2.3",
     "semver": "^7.8.0",

--- a/packages/protocol-kit/src/utils/eip-3770/config.ts
+++ b/packages/protocol-kit/src/utils/eip-3770/config.ts
@@ -444,6 +444,7 @@ export const networks: NetworkShortName[] = [
   { chainId: 103454n, shortName: 'masatest' },
   { chainId: 105105n, shortName: 'stratis' },
   { chainId: 111188n, shortName: 're-al' },
+  { chainId: 127001n, shortName: 'grav' },
   { chainId: 127823n, shortName: 'etls' },
   { chainId: 128123n, shortName: 'etlt' },
   { chainId: 167000n, shortName: 'tko-mainnet' },

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.6.0",
     "@safe-global/protocol-kit": "workspace:^",
-    "@safe-global/safe-modules-deployments": "^3.0.8",
+    "@safe-global/safe-modules-deployments": "^3.0.9",
     "@safe-global/types-kit": "workspace:^",
     "semver": "^7.8.0",
     "viem": "^2.52.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,11 +166,11 @@ importers:
   packages/protocol-kit:
     dependencies:
       '@safe-global/safe-deployments':
-        specifier: ^1.37.60
-        version: 1.37.60
+        specifier: ^1.37.61
+        version: 1.37.61
       '@safe-global/safe-modules-deployments':
-        specifier: ^3.0.8
-        version: 3.0.8
+        specifier: ^3.0.9
+        version: 3.0.9
       '@safe-global/types-kit':
         specifier: workspace:^
         version: link:../types-kit
@@ -249,8 +249,8 @@ importers:
         specifier: workspace:^
         version: link:../protocol-kit
       '@safe-global/safe-modules-deployments':
-        specifier: ^3.0.8
-        version: 3.0.8
+        specifier: ^3.0.9
+        version: 3.0.9
       '@safe-global/types-kit':
         specifier: workspace:^
         version: link:../types-kit
@@ -1298,12 +1298,12 @@ packages:
     peerDependencies:
       ethers: 5.4.0
 
-  '@safe-global/safe-deployments@1.37.60':
-    resolution: {integrity: sha512-PS+VLRm+FikrUNOutsIEE4Ytbtb+O57SHo8VSzYynR7lcSY1gfZ+7DUnKKLVDGCspoJIgh99jqJWGh9eqfn46Q==}
+  '@safe-global/safe-deployments@1.37.61':
+    resolution: {integrity: sha512-bPjznEFWFN698CJupwGd+ZNI5aBslylV6FjnGt7CBodZs9rZPLfKT/HhI+ppTvMgh+Tgn/KJNGMwKW9aPVIBng==}
     engines: {node: '>=22.0.0', pnpm: '>=10.16.0'}
 
-  '@safe-global/safe-modules-deployments@3.0.8':
-    resolution: {integrity: sha512-RKct6dNFg4KbbpXchyosHmIygy58wLe+1WIATQ2VILGpcivBDcZdyvSl64BoocXCL2CroCBMJMzy0mW4iwZ0Zg==}
+  '@safe-global/safe-modules-deployments@3.0.9':
+    resolution: {integrity: sha512-tgW/ln4if6dLohAQVUT51/a+tTUMuTm3dKvGPgXmHaLUFS8P3f28+cs671rsyMlMa4A/zXJKOdFgBsfCTyfw0A==}
 
   '@safe-global/safe-passkey@0.2.0':
     resolution: {integrity: sha512-B9IpVvwXLvK3m+BRhn9z8kCbEizFmua4YmaUBZ9yr0xM9YsX2PRTnxbFvC7pLph1OQ2u+9O2V3FEmPiS10YEIw==}
@@ -5622,11 +5622,11 @@ snapshots:
     dependencies:
       ethers: 5.4.0
 
-  '@safe-global/safe-deployments@1.37.60':
+  '@safe-global/safe-deployments@1.37.61':
     dependencies:
       semver: 7.8.0
 
-  '@safe-global/safe-modules-deployments@3.0.8': {}
+  '@safe-global/safe-modules-deployments@3.0.9': {}
 
   '@safe-global/safe-passkey@0.2.0(ethers@5.4.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ minimumReleaseAge: 10080 # minutes (7 days)
 minimumReleaseAgeExclude:
 # We skip the minimumReleaseAge for this version specifically
 # containing a update to latest chains
-  - "@safe-global/safe-deployments@1.37.60"
-  - "@safe-global/safe-modules-deployments@3.0.8"
+  - "@safe-global/safe-deployments@1.37.61"
+  - "@safe-global/safe-modules-deployments@3.0.9"
 
 # Only packages listed here are allowed to run install scripts.
 # esbuild and nx require native compilation; keccak and secp256k1 are native


### PR DESCRIPTION
Bump safe-deployments to 1.37.61 and safe-modules-deployments to 3.0.9 so the new chain deployments resolve, and register chainId 127001 in the EIP-3770 config.