### PR TITLE
chore: bump safe-deployments

### DIFF
--- a/.changeset/bump-safe-deployments.md
+++ b/.changeset/bump-safe-deployments.md
@@ -1,0 +1,5 @@
+---
+'@safe-global/protocol-kit': patch
+---
+
+Bump `@safe-global/safe-deployments` to the latest version

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -83,7 +83,7 @@
     "tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
-    "@safe-global/safe-deployments": "^1.37.61",
+    "@safe-global/safe-deployments": "^1.37.62",
     "@safe-global/safe-modules-deployments": "^3.0.9",
     "@safe-global/types-kit": "workspace:^",
     "abitype": "^1.2.3",

--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,1 +1,1 @@
-export const getProtocolKitVersion = () => '8.0.4'
+export const getProtocolKitVersion = () => '8.0.5'

--- a/packages/relay-kit/src/packs/safe-4337/utils/getRelayKitVersion.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/getRelayKitVersion.ts
@@ -1,1 +1,1 @@
-export const getRelayKitVersion = () => '6.0.4'
+export const getRelayKitVersion = () => '6.0.5'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   packages/protocol-kit:
     dependencies:
       '@safe-global/safe-deployments':
-        specifier: ^1.37.61
-        version: 1.37.61
+        specifier: ^1.37.62
+        version: 1.37.62
       '@safe-global/safe-modules-deployments':
         specifier: ^3.0.9
         version: 3.0.9
@@ -1314,8 +1314,8 @@ packages:
     peerDependencies:
       ethers: 5.4.0
 
-  '@safe-global/safe-deployments@1.37.61':
-    resolution: {integrity: sha512-bPjznEFWFN698CJupwGd+ZNI5aBslylV6FjnGt7CBodZs9rZPLfKT/HhI+ppTvMgh+Tgn/KJNGMwKW9aPVIBng==}
+  '@safe-global/safe-deployments@1.37.62':
+    resolution: {integrity: sha512-EJMdtIsK0g89hedZDNhbQiyWGfLACKjeOLMlSOpMA7drIgAkht6wva/Qfv3DeJT7tAMFQAkgkwMnPxKZWn/6Pw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.16.0'}
 
   '@safe-global/safe-modules-deployments@3.0.9':
@@ -5684,7 +5684,7 @@ snapshots:
     dependencies:
       ethers: 5.4.0
 
-  '@safe-global/safe-deployments@1.37.61':
+  '@safe-global/safe-deployments@1.37.62':
     dependencies:
       semver: 7.8.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ minimumReleaseAge: 10080 # minutes (7 days)
 minimumReleaseAgeExclude:
 # We skip the minimumReleaseAge for this version specifically
 # containing a update to latest chains
-  - "@safe-global/safe-deployments@1.37.61"
+  - "@safe-global/safe-deployments@1.37.62"
   - "@safe-global/safe-modules-deployments@3.0.9"
 
 # Only packages listed here are allowed to run install scripts.


### PR DESCRIPTION
Picks up the latest deployment registry so newly deployed networks resolve without a manual config change.