### PR TITLE
chore: set release

### DIFF
--- a/.changeset/bump-safe-deployments.md
+++ b/.changeset/bump-safe-deployments.md
@@ -1,5 +1,0 @@
----
-'@safe-global/protocol-kit': patch
----
-
-Bump `@safe-global/safe-deployments` to the latest version

--- a/packages/protocol-kit/CHANGELOG.md
+++ b/packages/protocol-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @safe-global/protocol-kit
 
+## 8.0.6
+
+### Patch Changes
+
+- 1f9dae0: Bump `@safe-global/safe-deployments` to the latest version
+
 ## 8.0.5
 
 ### Patch Changes

--- a/packages/protocol-kit/package.json
+++ b/packages/protocol-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/protocol-kit",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "SDK that facilitates the interaction with Safe Smart Accounts",
   "types": "dist/src/index.d.ts",
   "main": "dist/cjs/src/index.cjs",

--- a/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
+++ b/packages/protocol-kit/src/utils/getProtocolKitVersion.ts
@@ -1,1 +1,1 @@
-export const getProtocolKitVersion = () => '8.0.5'
+export const getProtocolKitVersion = () => '8.0.6'


### PR DESCRIPTION
Consumes the pending changeset so the safe-deployments bump reaches consumers as a published protocol-kit patch.