### PR TITLE
chore(relay-kit): deprecate GelatoRelayPack

### DIFF
--- a/.changeset/deprecate-gelato-relay-pack.md
+++ b/.changeset/deprecate-gelato-relay-pack.md
@@ -1,0 +1,9 @@
+---
+'@safe-global/relay-kit': minor
+---
+
+Deprecate the Gelato relay integration. `GelatoRelayPack` will be removed in the next major version of `@safe-global/relay-kit`.
+
+- `GelatoRelayPack` and the `GelatoOptions`, `GelatoEstimateFeeProps`, `GelatoEstimateFeeResult`, `GelatoCreateTransactionProps` and `GelatoExecuteTransactionProps` types are now marked `@deprecated`.
+- The `GelatoRelayPack` constructor logs a deprecation notice through `console.warn` once per process. Nothing throws and no behavior changes, so existing code keeps working.
+- Migrate to `Safe4337Pack`, which supports both sponsored and ERC-20-paid transaction execution: https://docs.safe.global/sdk/relay-kit/guides/gelato-relay

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayPack.deprecation.test.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayPack.deprecation.test.ts
@@ -1,0 +1,36 @@
+import Safe from '@safe-global/protocol-kit'
+
+import { GelatoRelayPack } from './GelatoRelayPack'
+
+jest.mock('@gelatonetwork/relay-sdk', () => ({
+  GelatoRelay: jest.fn().mockImplementation(() => ({}))
+}))
+
+jest.mock('@safe-global/protocol-kit')
+
+// TODO: Remove @deprecated Gelato code when the pack is removed in the next major version
+describe('GelatoRelayPack deprecation notice', () => {
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('should warn once per process when the pack is instantiated', () => {
+    const protocolKit = new Safe()
+
+    new GelatoRelayPack({ protocolKit })
+    new GelatoRelayPack({ protocolKit })
+    new GelatoRelayPack({ apiKey: 'api-key', protocolKit })
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('`GelatoRelayPack` is deprecated')
+    )
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('will be removed in the next major version')
+    )
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('`Safe4337Pack`'))
+  })
+})
+// END of @deprecated Gelato code

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts
@@ -36,6 +36,28 @@ import {
   GelatoOptions
 } from './types'
 
+// TODO: Remove @deprecated Gelato code when the pack is removed in the next major version
+let hasWarnedGelatoDeprecation = false
+
+function warnGelatoDeprecation(): void {
+  if (hasWarnedGelatoDeprecation) {
+    return
+  }
+
+  hasWarnedGelatoDeprecation = true
+
+  console.warn(
+    '@safe-global/relay-kit: `GelatoRelayPack` is deprecated and will be removed in the next major version. Migrate to `Safe4337Pack`: https://docs.safe.global/sdk/relay-kit/guides/gelato-relay'
+  )
+}
+// END of @deprecated Gelato code
+
+/**
+ * @deprecated `GelatoRelayPack` will be removed in the next major version of
+ * `@safe-global/relay-kit`. Migrate to `Safe4337Pack`, which supports both sponsored and
+ * ERC-20-paid transaction execution.
+ * @see https://docs.safe.global/sdk/relay-kit/guides/gelato-relay
+ */
 export class GelatoRelayPack extends RelayKitBasePack<{
   EstimateFeeProps: GelatoEstimateFeeProps
   EstimateFeeResult: GelatoEstimateFeeResult
@@ -49,6 +71,7 @@ export class GelatoRelayPack extends RelayKitBasePack<{
 
   constructor({ apiKey, protocolKit }: GelatoOptions) {
     super(protocolKit)
+    warnGelatoDeprecation()
     this.#gelatoRelay = new GelatoNetworkRelay()
 
     this.#apiKey = apiKey

--- a/packages/relay-kit/src/packs/gelato/types.ts
+++ b/packages/relay-kit/src/packs/gelato/types.ts
@@ -5,19 +5,31 @@ import {
   SafeTransaction
 } from '@safe-global/types-kit'
 
+/**
+ * @deprecated Will be removed in the next major version. Use `Safe4337Pack` instead.
+ */
 export type GelatoOptions = {
   apiKey?: string
   protocolKit: Safe
 }
 
+/**
+ * @deprecated Will be removed in the next major version. Use `Safe4337Pack` instead.
+ */
 export type GelatoEstimateFeeProps = {
   chainId: bigint
   gasLimit: string
   gasToken?: string
 }
 
+/**
+ * @deprecated Will be removed in the next major version. Use `Safe4337Pack` instead.
+ */
 export type GelatoEstimateFeeResult = string
 
+/**
+ * @deprecated Will be removed in the next major version. Use `Safe4337Pack` instead.
+ */
 export type GelatoCreateTransactionProps = {
   transactions: MetaTransactionData[]
   /** options - The transaction array optional properties */
@@ -26,6 +38,9 @@ export type GelatoCreateTransactionProps = {
   onlyCalls?: boolean
 }
 
+/**
+ * @deprecated Will be removed in the next major version. Use `Safe4337Pack` instead.
+ */
 export type GelatoExecuteTransactionProps = {
   executable: SafeTransaction
   options?: MetaTransactionOptions

--- a/playground/README.md
+++ b/playground/README.md
@@ -158,6 +158,8 @@ pnpm play userop-api-kit-interoperability
 
 #### Relay a transaction using Gelato
 
+> **Deprecated:** `GelatoRelayPack` will be removed in the next major version of the relay-kit. Use the `Safe4337Pack` scripts above instead.
+
 In case you want to execute the transaction via a transaction relay, this script allows to do that, where the fees are extracted from the Safe balance:
 
 ```bash
@@ -165,6 +167,8 @@ pnpm play gelato-paid-transaction
 ```
 
 #### Relay an sponsored transaction using Gelato
+
+> **Deprecated:** `GelatoRelayPack` will be removed in the next major version of the relay-kit. Use the `Safe4337Pack` scripts above instead.
 
 In case you want to execute the transaction via a transaction relay, this script allows to to that, where the fees are extracted from a third party account balance that sponsors the transaction:
 

--- a/playground/relay-kit/gelato-paid-transaction.ts
+++ b/playground/relay-kit/gelato-paid-transaction.ts
@@ -11,6 +11,9 @@ import {
   SafeTransaction
 } from '@safe-global/types-kit'
 
+// DEPRECATED: `GelatoRelayPack` will be removed in the next major version of the relay-kit.
+// See the userop-*.ts playground scripts for the Safe4337Pack equivalents.
+
 // Check the status of a transaction after it is relayed:
 // https://relay.gelato.digital/tasks/status/<TASK_ID>
 

--- a/playground/relay-kit/gelato-sponsored-transaction.ts
+++ b/playground/relay-kit/gelato-sponsored-transaction.ts
@@ -11,6 +11,9 @@ import {
   SafeTransaction
 } from '@safe-global/types-kit'
 
+// DEPRECATED: `GelatoRelayPack` will be removed in the next major version of the relay-kit.
+// See the userop-*.ts playground scripts for the Safe4337Pack equivalents.
+
 // Fund the 1Balance account that will sponsor the transaction and get the API key:
 // https://relay.gelato.network/
 


### PR DESCRIPTION
## What it solves

Resolves PLA-1726

This PR is the **deprecation half** of a two-step retirement. A follow-up PR does the major bump (7.0.0) that deletes the pack, the `@gelatonetwork/relay-sdk` dependency, and the playground scripts.

## How this PR fixes it

**`packages/relay-kit/src/packs/gelato/`**

- `@deprecated` JSDoc on `GelatoRelayPack` and on all five exported types (`GelatoOptions`, `GelatoEstimateFeeProps`, `GelatoEstimateFeeResult`, `GelatoCreateTransactionProps`, `GelatoExecuteTransactionProps`). All five are in the public barrel and appear in real consumer signatures, so tagging only some would send a mixed signal.
- A `console.warn` from the constructor, guarded to fire **once per process**. JSDoc alone only surfaces in an editor or a fresh typecheck — a team with green CI would see nothing. The constructor is the right and only place: the class has no static members, no factory and no other construction site, and both private fields are assigned there, so no method is reachable without it.
- The guard matters because `GelatoOptions.protocolKit` is a per-Safe instance, so constructing one pack per inbound request is idiomatic; unguarded, that is one log line per request forever. It also keeps the existing 609-line suite from emitting ~16 identical blocks.
- Both the helper and the new test are wrapped in `// TODO: Remove @deprecated Gelato code ...` / `// END of @deprecated Gelato code` fences, mirroring the api-kit `getPendingTransactions` precedent, so the 7.0.0 deletion is mechanical.

**New files**

- `GelatoRelayPack.deprecation.test.ts` — asserts the notice fires exactly once and mentions `Safe4337Pack`. It is a separate file on purpose: the existing suite constructs the pack at module scope (line 102) before any `it()` runs, so with the once-guard a spy installed there could never observe the call and the test would pass vacuously.
- `.changeset/deprecate-gelato-relay-pack.md`.

**Playground** (unpublished, so no changeset entry): a deprecation comment in each of the two Gelato scripts and a note under each README section.

### Deliberately not in this PR

- Removing `@gelatonetwork/relay-sdk` from `dependencies` — changes the install graph, belongs in 7.0.0.
- Deleting the pack, the playground scripts, or `src/constants.ts` (the `GELATO_*` values are already unreachable for consumers: nothing re-exports that file and `package.json` `exports` has no wildcard).
- No env-var suppression and no date-conditional logic. Nothing throws.

### Verification

`pnpm --filter @safe-global/relay-kit test` — 20/20 Gelato tests pass (19 existing + 1 new), and the warning appears exactly once across the existing suite, confirming the guard.