### PR TITLE
fix(protocol-kit): add isSignedBy for checksum-safe signature lookup

### DIFF
--- a/.changeset/isSignedBy-checksum-fix.md
+++ b/.changeset/isSignedBy-checksum-fix.md
@@ -1,0 +1,6 @@
+---
+"@safe-global/protocol-kit": patch
+"@safe-global/types-kit": patch
+---
+
+Add `isSignedBy(signer)` to `SafeTransaction`/`SafeMessage` for checksum-safe signature lookups. The `signatures` Map stores signer addresses lowercased internally, so `signatures.has(checksummedAddress)` always returned `false` unless the caller passed an already-lowercased address - `isSignedBy` normalizes the input before checking.

--- a/packages/protocol-kit/src/utils/messages/SafeMessage.ts
+++ b/packages/protocol-kit/src/utils/messages/SafeMessage.ts
@@ -17,6 +17,10 @@ class EthSafeMessage implements SafeMessage {
     this.signatures.set(signature.signer.toLowerCase(), signature)
   }
 
+  isSignedBy(signer: string): boolean {
+    return this.signatures.has(signer.toLowerCase())
+  }
+
   encodedSignatures(): string {
     return buildSignatureBytes(Array.from(this.signatures.values()))
   }

--- a/packages/protocol-kit/src/utils/transactions/SafeTransaction.ts
+++ b/packages/protocol-kit/src/utils/transactions/SafeTransaction.ts
@@ -17,6 +17,10 @@ class EthSafeTransaction implements SafeTransaction {
     this.signatures.set(signature.signer.toLowerCase(), signature)
   }
 
+  isSignedBy(signer: string): boolean {
+    return this.signatures.has(signer.toLowerCase())
+  }
+
   encodedSignatures(): string {
     return buildSignatureBytes(Array.from(this.signatures.values()))
   }

--- a/packages/protocol-kit/tests/unit/SafeMessage.test.ts
+++ b/packages/protocol-kit/tests/unit/SafeMessage.test.ts
@@ -1,0 +1,43 @@
+import chai from 'chai'
+import EthSafeMessage from '@safe-global/protocol-kit/utils/messages/SafeMessage'
+import { SafeSignature } from '@safe-global/types-kit'
+
+// A signer address with mixed-case characters, matching how a checksummed
+// address (EIP-55) actually looks in practice.
+const CHECKSUMMED_SIGNER = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+
+const makeSignature = (signer: string): SafeSignature => ({
+  signer,
+  data: '0x' + '00'.repeat(65),
+  isContractSignature: false,
+  staticPart: () => '0x' + '00'.repeat(65),
+  dynamicPart: () => ''
+})
+
+describe('EthSafeMessage', () => {
+  describe('addSignature/isSignedBy checksum handling', () => {
+    it('recognizes a signer via isSignedBy regardless of address casing', () => {
+      const message = new EthSafeMessage('test message')
+      message.addSignature(makeSignature(CHECKSUMMED_SIGNER))
+
+      chai.expect(message.isSignedBy(CHECKSUMMED_SIGNER)).to.be.true
+      chai.expect(message.isSignedBy(CHECKSUMMED_SIGNER.toLowerCase())).to.be.true
+      chai.expect(message.isSignedBy(CHECKSUMMED_SIGNER.toUpperCase().replace('0X', '0x'))).to.be
+        .true
+    })
+
+    it('isSignedBy returns false for an address that never signed', () => {
+      const message = new EthSafeMessage('test message')
+      message.addSignature(makeSignature(CHECKSUMMED_SIGNER))
+
+      chai.expect(message.isSignedBy('0x0000000000000000000000000000000000dEaD')).to.be.false
+    })
+
+    it('the raw signatures Map still uses lowercase keys internally', () => {
+      const message = new EthSafeMessage('test message')
+      message.addSignature(makeSignature(CHECKSUMMED_SIGNER))
+
+      chai.expect(message.signatures.has(CHECKSUMMED_SIGNER.toLowerCase())).to.be.true
+    })
+  })
+})

--- a/packages/protocol-kit/tests/unit/SafeTransaction.test.ts
+++ b/packages/protocol-kit/tests/unit/SafeTransaction.test.ts
@@ -1,0 +1,55 @@
+import chai from 'chai'
+import EthSafeTransaction from '@safe-global/protocol-kit/utils/transactions/SafeTransaction'
+import { SafeSignature, SafeTransactionData } from '@safe-global/types-kit'
+
+const TX_DATA: SafeTransactionData = {
+  to: '0x0000000000000000000000000000000000000000',
+  value: '0',
+  data: '0x',
+  operation: 0,
+  safeTxGas: '0',
+  baseGas: '0',
+  gasPrice: '0',
+  gasToken: '0x0000000000000000000000000000000000000000',
+  refundReceiver: '0x0000000000000000000000000000000000000000',
+  nonce: 0
+}
+
+// A signer address with mixed-case characters, matching how a checksummed
+// address (EIP-55) actually looks in practice.
+const CHECKSUMMED_SIGNER = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+
+const makeSignature = (signer: string): SafeSignature => ({
+  signer,
+  data: '0x' + '00'.repeat(65),
+  isContractSignature: false,
+  staticPart: () => '0x' + '00'.repeat(65),
+  dynamicPart: () => ''
+})
+
+describe('EthSafeTransaction', () => {
+  describe('addSignature/isSignedBy checksum handling', () => {
+    it('recognizes a signer via isSignedBy regardless of address casing', () => {
+      const tx = new EthSafeTransaction(TX_DATA)
+      tx.addSignature(makeSignature(CHECKSUMMED_SIGNER))
+
+      chai.expect(tx.isSignedBy(CHECKSUMMED_SIGNER)).to.be.true
+      chai.expect(tx.isSignedBy(CHECKSUMMED_SIGNER.toLowerCase())).to.be.true
+      chai.expect(tx.isSignedBy(CHECKSUMMED_SIGNER.toUpperCase().replace('0X', '0x'))).to.be.true
+    })
+
+    it('isSignedBy returns false for an address that never signed', () => {
+      const tx = new EthSafeTransaction(TX_DATA)
+      tx.addSignature(makeSignature(CHECKSUMMED_SIGNER))
+
+      chai.expect(tx.isSignedBy('0x0000000000000000000000000000000000dEaD')).to.be.false
+    })
+
+    it('the raw signatures Map still uses lowercase keys internally', () => {
+      const tx = new EthSafeTransaction(TX_DATA)
+      tx.addSignature(makeSignature(CHECKSUMMED_SIGNER))
+
+      chai.expect(tx.signatures.has(CHECKSUMMED_SIGNER.toLowerCase())).to.be.true
+    })
+  })
+})

--- a/packages/types-kit/src/types.ts
+++ b/packages/types-kit/src/types.ts
@@ -57,6 +57,7 @@ export interface SafeTransaction {
   getSignature(signer: string): SafeSignature | undefined
   addSignature(signature: SafeSignature): void
   encodedSignatures(): string
+  isSignedBy(signer: string): boolean
 }
 
 export interface SafeMessage {
@@ -65,6 +66,7 @@ export interface SafeMessage {
   getSignature(signer: string): SafeSignature | undefined
   addSignature(signature: SafeSignature): void
   encodedSignatures(): string
+  isSignedBy(signer: string): boolean
 }
 
 export type Transaction = TransactionBase & TransactionOptions


### PR DESCRIPTION
closes #495

tl;dr `addSignature()` stores signer addresses lowercased in the `signatures` Map internally, but that Map is exposed publicly - so `signatures.has(checksummedAddress)` silently returns `false` unless the caller happens to pass an already-lowercased address. `getSignature(signer)` already normalizes its own input (`signer.toLowerCase()`) before comparing, so it was never actually broken for checksummed lookups - only direct Map access was.

## the fix

Adds `isSignedBy(signer: string): boolean` to `EthSafeTransaction` and `EthSafeMessage` (and their shared `SafeTransaction`/`SafeMessage` interfaces in `types-kit`), matching the API shape suggested in the issue itself. Internally it's just `this.signatures.has(signer.toLowerCase())` - correct because lowercasing an EIP-55 checksummed address never changes which underlying address it represents (checksum casing is a display/validation layer on top of the same 20 bytes), so there's no risk of two different addresses colliding via lowercase comparison.

Didn't touch the raw `signatures` Map's key casing itself (kept lowercase) rather than changing it, to avoid any risk to existing code that might already rely on the current lowercase-key behavior when iterating the Map directly.

## one thing worth a maintainer call

`isSignedBy` was added to the public `SafeTransaction`/`SafeMessage` interfaces in `types-kit`, not just the concrete classes. Within this repo only `EthSafeTransaction`/`EthSafeMessage` implement them, so nothing here breaks - but if there's any external code implementing these interfaces directly (rather than extending these classes), this would be a new required method for them too. Flagging in case that matters for your semver conventions; happy to adjust the approach if so.

## receipts

New unit tests (checksummed address, already-lowercased address, all-uppercase address, and a non-signer address all correctly recognized/rejected):

```
$ npx mocha -r ts-node/register -r tsconfig-paths/register tests/unit/SafeTransaction.test.ts tests/unit/SafeMessage.test.ts

  EthSafeTransaction
    addSignature/isSignedBy checksum handling
      ✔ recognizes a signer via isSignedBy regardless of address casing
      ✔ isSignedBy returns false for an address that never signed
      ✔ the raw signatures Map still uses lowercase keys internally

  EthSafeMessage
    addSignature/isSignedBy checksum handling
      ✔ recognizes a signer via isSignedBy regardless of address casing
      ✔ isSignedBy returns false for an address that never signed
      ✔ the raw signatures Map still uses lowercase keys internally

  6 passing (3ms)
```

Full `protocol-kit` unit suite, no regressions:

```
$ npx mocha -r ts-node/register -r tsconfig-paths/register 'tests/unit/**/*.ts'
  46 passing (22ms)
```

`protocol-kit` and `types-kit` typecheck (`build:types`) clean, `eslint` clean on all changed files.

Risk: low - purely additive method, no existing behavior changed.