### PR TITLE
fix(protocol-kit): signTransaction reads the wrong object for SAFE_SIGNATURE preimage

### DIFF
--- a/.changeset/thirty-cats-sign.md
+++ b/.changeset/thirty-cats-sign.md
@@ -1,0 +1,5 @@
+---
+'@safe-global/protocol-kit': patch
+---
+
+Fix `signTransaction` throwing a `TypeError` when signing a contract (nested Safe) signature for a `SafeMultisigTransactionResponse` input on Safe versions `>=1.3.0 <1.5.0`. The `>=1.3.0` `SigningMethod.SAFE_SIGNATURE` branch computed the EIP-712 preimage from the raw input's `.data` field instead of the already-converted `SafeTransaction`, so a `SafeMultisigTransactionResponse` (whose `.data` is a calldata hex string, not a `SafeTransactionData` object) crashed instead of producing a signature.

--- a/packages/protocol-kit/src/Safe.ts
+++ b/packages/protocol-kit/src/Safe.ts
@@ -12,7 +12,6 @@ import {
   MetaTransactionData,
   Transaction,
   EIP712TypedData,
-  SafeTransactionData,
   CompatibilityFallbackHandlerContractType,
   SigningMethod,
   SigningMethodType
@@ -891,7 +890,7 @@ class Safe {
       ) {
         const txHashData = preimageSafeTransactionHash(
           preimageSafeAddress,
-          safeTransaction.data as SafeTransactionData,
+          transaction.data,
           safeVersion,
           chainId
         )

--- a/packages/protocol-kit/tests/e2e/eip1271-contract-signatures.test.ts
+++ b/packages/protocol-kit/tests/e2e/eip1271-contract-signatures.test.ts
@@ -165,6 +165,104 @@ describe('The EIP1271 implementation', () => {
       }
     )
 
+    // Regression test: signTransaction(tx, SigningMethod.SAFE_SIGNATURE, preimageSafeAddress) used to
+    // read `.data` off the *raw* input parameter instead of the converted `transaction` local when the
+    // input was a SafeMultisigTransactionResponse (i.e. `.data` is a calldata hex string, not a
+    // SafeTransactionData object) - this only affects Safe versions in [1.3.0, 1.5.0) since >=1.5.0 uses
+    // a different (correct) code path.
+    itif(safeVersionDeployed >= '1.3.0' && safeVersionDeployed < '1.5.0')(
+      'should allow contract signatures for a SafeMultisigTransactionResponse-shaped input',
+      async () => {
+        const { safeAddress, accounts, signerSafeAddress1_1, contractNetworks, provider } =
+          await setupTests()
+        const [, , account3] = accounts
+
+        const safeTransactionData: SafeTransactionDataPartial = {
+          to: safeAddress,
+          value: '0',
+          data: '0x'
+        }
+
+        // Reference: build + sign the SAME transaction as a proper SafeTransaction (the already-working
+        // code path), to compare the resulting signature against.
+        const referenceProtocolKit = await Safe.init({
+          provider,
+          safeAddress: signerSafeAddress1_1,
+          signer: account3.address,
+          contractNetworks
+        })
+        let referenceTx = await referenceProtocolKit.createTransaction({
+          transactions: [safeTransactionData]
+        })
+        referenceTx = await referenceProtocolKit.signTransaction(
+          referenceTx,
+          SigningMethod.SAFE_SIGNATURE,
+          safeAddress
+        )
+        const referenceSignature = Array.from(referenceTx.signatures.values())[0].data
+
+        // Now build the SAME logical transaction, but shaped as a SafeMultisigTransactionResponse -
+        // the shape returned by the Safe transaction service - which is what isSafeMultisigTransactionResponse
+        // detects via `.isExecuted !== undefined`, and drives the buggy `>=1.3.0 && <1.5.0` branch.
+        const responseShapedProtocolKit = await Safe.init({
+          provider,
+          safeAddress: signerSafeAddress1_1,
+          signer: account3.address,
+          contractNetworks
+        })
+        const nonce = await responseShapedProtocolKit.getNonce()
+        const responseShapedTx = {
+          safe: signerSafeAddress1_1,
+          to: safeAddress,
+          value: '0',
+          data: '0x',
+          operation: 0,
+          gasToken: '0x0000000000000000000000000000000000000000',
+          safeTxGas: '0',
+          baseGas: '0',
+          gasPrice: '0',
+          refundReceiver: '0x0000000000000000000000000000000000000000',
+          nonce: nonce.toString(),
+          executionDate: null,
+          submissionDate: new Date().toISOString(),
+          modified: new Date().toISOString(),
+          blockNumber: null,
+          transactionHash: null,
+          safeTxHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          executor: null,
+          proposer: null,
+          proposedByDelegate: null,
+          isExecuted: false,
+          isSuccessful: null,
+          ethGasPrice: null,
+          maxFeePerGas: null,
+          maxPriorityFeePerGas: null,
+          gasUsed: null,
+          fee: null,
+          origin: '',
+          confirmationsRequired: 1,
+          confirmations: [],
+          trusted: true,
+          signatures: null
+        }
+
+        // Before the fix, this rejects with a TypeError deep inside the EIP-712 encoder (undefined.length
+        // / undefined.to) - the response's raw `.data` string gets treated as the whole SafeTransactionData
+        // object. After the fix it resolves, and produces the IDENTICAL signature as the reference
+        // SafeTransaction path above, proving the fix doesn't just avoid the crash but computes the
+        // correct preimage hash.
+        const signedResponseShapedTx = await responseShapedProtocolKit.signTransaction(
+          responseShapedTx,
+          SigningMethod.SAFE_SIGNATURE,
+          safeAddress
+        )
+        const responseShapedSignature = Array.from(signedResponseShapedTx.signatures.values())[0]
+          .data
+
+        chai.expect(responseShapedSignature).to.equal(referenceSignature)
+      }
+    )
+
     itif(safeVersionDeployed >= '1.3.0')(
       'should allow to sign and validate typed messages',
       async () => {


### PR DESCRIPTION
## the bug

`Safe.signTransaction`'s `SigningMethod.SAFE_SIGNATURE` + `preimageSafeAddress` branch for Safe versions `>=1.3.0 <1.5.0` computes the EIP-712 preimage from the wrong object:

```ts
// packages/protocol-kit/src/Safe.ts:892-897 (before this PR)
const txHashData = preimageSafeTransactionHash(
  preimageSafeAddress,
  safeTransaction.data as SafeTransactionData,   // <- raw input param, not the converted `transaction`
  safeVersion,
  chainId
)
```

`signTransaction` accepts `SafeTransaction | SafeMultisigTransactionResponse` and, right at the top of the function, converts whichever shape it received into a canonical `SafeTransaction` local:

```ts
const transaction = isSafeMultisigTransactionResponse(safeTransaction)
  ? await this.toSafeTransactionType(safeTransaction)
  : safeTransaction
```

`SafeTransaction.data` is a `SafeTransactionData` object (`to`/`value`/`data`/`operation`/`safeTxGas`/... - see `types-kit/src/types.ts:54-55`). `SafeMultisigTransactionResponse.data`, on a `SafeMultisigTransactionResponse` **input**, is a bare calldata hex `string` (`types-kit/src/types.ts:244-248`). The buggy line reads `.data` off the *raw input parameter* instead of the converted `transaction` local, so when a caller passes a `SafeMultisigTransactionResponse` (an explicitly supported input, pulled from the Safe transaction service - exactly the shape used in the Safe-owns-Safe / EIP-1271 nested-signer flow), `safeTransaction.data` is a plain string, and the `as SafeTransactionData` cast is a lie that only silences `tsc` - no conversion happens on that line.

The sibling `>=1.5.0` branch 16 lines above already reads `transaction.data` correctly:

```ts
const txHashData = calculateSafeTransactionHash(
  preimageSafeAddress,
  transaction.data,   // correct
  safeVersion,
  chainId
)
```

Downstream, `preimageSafeTransactionHash` does `const message = safeTx as unknown as Record<string, unknown>` and hands it to the local EIP-712 encoder (`utils/eip-712/encode.ts`), copied out of viem specifically to expose the message-encoding step. `validateTypedData` (from viem) does not catch a wrong-shaped message here - its checks are all guarded on `typeof value === 'string' | 'number' | 'bigint'`, so `undefined` field reads sail through unchecked. The crash lands a few frames later in `encodeField`/`encodeData`, as a `TypeError: Cannot read properties of undefined (reading 'length')` (or `'to'` for a `data: undefined` plain transfer).

## reachability

`SigningMethod.SAFE_SIGNATURE` + `preimageSafeAddress` supplied + Safe version in `[1.3.0, 1.5.0)` + the transaction passed in as a `SafeMultisigTransactionResponse` (fetched from the transaction service, not built locally via `createTransaction()`). That's the Safe-owns-Safe (EIP-1271 nested signer) flow on a tx pulled from the service.

## severity

This is a hard crash with an opaque `TypeError` - **not** a silently-wrong signature. It cannot produce a bad signature, it aborts before one is created. I didn't find a specific live caller hitting this exact input combination in the wild; the bug's existence and mechanism are proven, its real-world frequency isn't something I can measure from here.

## the fix

`safeTransaction.data as SafeTransactionData` → `transaction.data`, matching the working `>=1.5.0` branch exactly. Dropped the now-unnecessary `SafeTransactionData` import along with the cast that was hiding the mismatch.

## receipts

Reproduced through the real call path before touching any code (ran directly against unfixed `main`, `packages/protocol-kit`, Node 20.18.2 matching CI):

```
$ npx ts-node -r tsconfig-paths/register repro.ts
--- buggy path: preimageSafeTransactionHash fed a raw SafeMultisigTransactionResponse.data string ---
THREW (as expected, this is the bug): TypeError - Cannot read properties of undefined (reading 'length')

--- also buggy: safeTransaction.data undefined (a plain ETH transfer via the API has data: undefined) ---
THREW (as expected, this is the bug): TypeError - Cannot read properties of undefined (reading 'to')
```

Added a real e2e regression test (`tests/e2e/eip1271-contract-signatures.test.ts`) that drives `Safe.signTransaction()` through the actual call path with a hand-built `SafeMultisigTransactionResponse`-shaped input, gated to the exact `[1.3.0, 1.5.0)` range this bug lives in, and asserts the resulting signature is **byte-identical** to the signature produced by the already-working `SafeTransaction` path for the same logical transaction - so it proves the fix computes the *correct* hash, not just that it avoids crashing.

Confirmed genuine red-before/green-after by temporarily reverting just the `Safe.ts` fix and rebuilding:

```
# unfixed code, same new test:
1) should allow contract signatures for a SafeMultisigTransactionResponse-shaped input:
   TypeError: Cannot read properties of undefined (reading 'length')
    at encodeField (.../utils/eip-712/encode.ts:36:27)
    at encodeData (.../utils/eip-712/encode.ts:134:27)
    at hashStruct (.../utils/eip-712/encode.ts:156:19)
    at encodeTypedData (.../utils/eip-712/encode.ts:207:7)
    at preimageSafeTransactionHash (.../utils/signatures/utils.ts:198:25)
    at Safe.signTransaction (.../Safe.ts:892:55)
  2 passing, 1 failing

# fixed code, same test:
  ✔ should allow contract signatures for a SafeMultisigTransactionResponse-shaped input (49ms)
  3 passing
```

Full suite, fixed code, Safe v1.3.0, real local hardhat chain (`testing-kit deploy` + `testing-kit test`):

```
$ SAFE_VERSION=1.3.0 ETH_LIB=ethers TEST_NETWORK=hardhat npx testing-kit test 'tests/e2e/*.test.*'
  295 passing (35s)
  68 pending   # version-gated itif() skips for other Safe version matrices, expected for a single-version run
```

`tests/e2e/eip1271.test.ts` (the other file exercising `SAFE_SIGNATURE`) separately: 12/12 passing. Unit suite (`tests/unit/**`): 53/53 passing. `eslint` on changed files: clean. `tsc -p tsconfig.build.json`: clean.

Checked for the same bug pattern elsewhere in the file: `isValidTransaction` (`:1624`) and `executeTransaction` (`:1673`) do the identical `isSafeMultisigTransactionResponse ? toSafeTransactionType(...) : safeTransaction` conversion and both correctly read `transaction.data` afterward - `signTransaction`'s `>=1.3.0` branch was the only place still reading the raw parameter.

## codex review

Ran Codex (`gpt-5.6-sol`) synchronously as an adversarial second reviewer; it did not return output within the timeout window, so I killed it and did a thorough self-review instead of claiming a pass I didn't get. Self-review confirmed, by reading the type declarations directly (`types-kit/src/types.ts:54-55`), that `SafeTransaction.data` really is a `SafeTransactionData` object (not the calldata string) - so `transaction.data` has the exact shape both `preimageSafeTransactionHash` and the sibling `calculateSafeTransactionHash` expect in every case, independent of which union member the caller originally passed in.

## changeset

Added, `@safe-global/protocol-kit` patch.
