### PR TITLE
fix: hashSafeMessage produces a content-independent hash when primaryType is omitted

### DIFF
--- a/packages/protocol-kit/src/utils/eip-712/encode.ts
+++ b/packages/protocol-kit/src/utils/eip-712/encode.ts
@@ -161,10 +161,46 @@ function hashStruct({
   return keccak256(encoded)
 }
 
-function deducePrimaryType(types: TypedMessageTypes) {
-  // In ethers the primaryType is assumed to be the first yielded by a forEach of the types keys
-  // https://github.com/ethers-io/ethers.js/blob/a4b1d1f43fca14f2e826e3c60e0d45f5b6ef3ec4/src.ts/hash/typed-data.ts#L278C13-L278C20
-  return Object.keys(types)[0]
+/**
+ * Deduces the `primaryType` of an EIP-712 typed data payload when one is not explicitly
+ * provided, by finding the root of the type dependency graph — the one non-domain type
+ * that is not itself referenced as a field type by any other type.
+ *
+ * This mirrors ethers' actual deduction algorithm (encodeType/getPrimaryType in
+ * https://github.com/ethers-io/ethers.js/blob/main/src.ts/hash/typed-data.ts), NOT the
+ * naive "first key in the object" approach this function previously used. Object key
+ * order is not part of the EIP-712 spec and, for the conventional `{ EIP712Domain, ... }`
+ * ordering, taking the first key silently resolved to `'EIP712Domain'` itself — which
+ * causes the caller to skip hashing the message struct entirely (see `encodeTypedData`
+ * below), producing a hash that is identical for every message under the same domain
+ * regardless of content.
+ *
+ * Throws if the graph has zero or more than one root, since primaryType is then
+ * genuinely ambiguous and guessing would silently produce a wrong hash.
+ */
+function deducePrimaryType(types: TypedMessageTypes): string {
+  const referencedTypes = new Set<string>()
+  for (const typeName of Object.keys(types)) {
+    if (typeName === 'EIP712Domain') continue
+    for (const field of types[typeName]) {
+      const baseType = field.type.replace(/\[.*$/u, '')
+      if (types[baseType] !== undefined) referencedTypes.add(baseType)
+    }
+  }
+
+  const candidates = Object.keys(types).filter(
+    (typeName) => typeName !== 'EIP712Domain' && !referencedTypes.has(typeName)
+  )
+
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Unable to deduce primaryType: ambiguous or unused types (candidates: ${
+        candidates.join(', ') || 'none'
+      }). Please provide an explicit primaryType.`
+    )
+  }
+
+  return candidates[0]
 }
 
 export function hashTypedData(typedData: EIP712TypedData): string {

--- a/packages/protocol-kit/tests/unit/eip-712.test.ts
+++ b/packages/protocol-kit/tests/unit/eip-712.test.ts
@@ -1,10 +1,13 @@
 import { SafeTransactionData, OperationType, EIP712TypedData } from '@safe-global/types-kit'
 import chai from 'chai'
+import { hashTypedData as viemHashTypedData } from 'viem'
 import {
   EIP712_DOMAIN,
   EIP712_DOMAIN_BEFORE_V130,
   generateTypedData,
-  getEip712TxTypes
+  getEip712TxTypes,
+  hashSafeMessage,
+  hashTypedData
 } from '@safe-global/protocol-kit/utils'
 
 const safeAddress = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
@@ -308,6 +311,115 @@ describe('EIP-712 sign typed data', () => {
           message: '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2'
         }
       })
+    })
+  })
+
+  describe('hashTypedData / hashSafeMessage with omitted primaryType', () => {
+    // Regression test for a hash-collision bug: when `primaryType` is not supplied,
+    // `deducePrimaryType` used to take `Object.keys(types)[0]`, which for the
+    // conventional `{ EIP712Domain, Mail }` key ordering resolved to `'EIP712Domain'`
+    // itself. `encodeTypedData` then skips hashing the message struct entirely
+    // (`if (primaryType !== 'EIP712Domain') hashStruct(...)`), so every distinct
+    // message under the same domain produced the identical, content-independent hash.
+    const domain = {
+      chainId: 1,
+      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
+    }
+    // Matches the raw shape of a real eth_signTypedData_v4 JSON payload (e.g. as
+    // produced by MetaMask/wallets and most dapp SDKs), which includes `EIP712Domain`
+    // as an explicit key in `types` alongside the message type. With this ordering,
+    // `Object.keys(types)[0]` (the old, buggy deduction) resolves to `'EIP712Domain'`
+    // itself, which is exactly the failure mode this test guards against — a `types`
+    // object that happens to have the message type listed first would not trigger it.
+    const types = {
+      EIP712Domain: [
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' }
+      ],
+      Mail: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'contents', type: 'string' }
+      ]
+    }
+
+    const messageA: EIP712TypedData = {
+      domain,
+      types,
+      message: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x2222222222222222222222222222222222222222',
+        contents: '1 ETH'
+      }
+    }
+    const messageB: EIP712TypedData = {
+      domain,
+      types,
+      message: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x2222222222222222222222222222222222222222',
+        contents: '10000 ETH'
+      }
+    }
+
+    it('should produce distinct hashes for distinct messages when primaryType is omitted', () => {
+      // Deep-clone: encodeTypedData mutates typedData.primaryType in place.
+      const hashA = hashTypedData(structuredClone(messageA))
+      const hashB = hashTypedData(structuredClone(messageB))
+
+      chai.expect(hashA).to.not.eq(hashB)
+    })
+
+    it('should match viem hashTypedData with an explicit correct primaryType', () => {
+      const deduced = hashTypedData(structuredClone(messageA))
+      // `as any`: bypasses viem's stricter generic inference for this ground-truth
+      // comparison call only; matches the existing `as any` pattern already used in
+      // encode.ts's own encodeTypedData for the same reason.
+      const explicit = viemHashTypedData({
+        domain,
+        types,
+        primaryType: 'Mail',
+        message: messageA.message
+      } as any)
+
+      chai.expect(deduced).to.eq(explicit)
+    })
+
+    it('should route hashSafeMessage for typed-data input through the same fixed deduction', () => {
+      const hashA = hashSafeMessage(structuredClone(messageA))
+      const hashB = hashSafeMessage(structuredClone(messageB))
+
+      chai.expect(hashA).to.not.eq(hashB)
+    })
+
+    it('should throw when the types graph has more than one root (genuinely ambiguous)', () => {
+      const ambiguous: EIP712TypedData = {
+        domain,
+        types: {
+          Mail: types.Mail,
+          Unrelated: [{ name: 'x', type: 'uint256' }]
+        },
+        message: messageA.message
+      }
+
+      chai.expect(() => hashTypedData(ambiguous)).to.throw(/ambiguous|unused/i)
+    })
+
+    it('should still respect an explicitly supplied primaryType', () => {
+      const explicit: EIP712TypedData = {
+        ...structuredClone(messageA),
+        primaryType: 'Mail'
+      }
+
+      const hash = hashTypedData(explicit)
+      const viemHash = viemHashTypedData({
+        domain,
+        types,
+        primaryType: 'Mail',
+        message: messageA.message
+      } as any)
+
+      chai.expect(hash).to.eq(viemHash)
     })
   })
 })


### PR DESCRIPTION
## What it says on the box

`hashSafeMessage()` / `hashTypedData()` on EIP-712 typed data without an explicit `primaryType` return a hash that commits to **no message content at all** — every distinct message under the same domain produces the identical hash.

## The bug

`packages/protocol-kit/src/utils/eip-712/encode.ts:164-168` (before this PR):

```ts
function deducePrimaryType(types: TypedMessageTypes) {
  // In ethers the primaryType is assumed to be the first yielded by a forEach of the types keys
  return Object.keys(types)[0]
}
```

For the conventional `{ EIP712Domain, Mail }` key ordering — the standard shape of a raw `eth_signTypedData_v4` JSON payload — this returns `'EIP712Domain'` itself. A few lines below, `encodeTypedData` has:

```ts
if (primaryType !== 'EIP712Domain')
  parts.push(hashStruct({ data: message, primaryType, types }))
```

So when the deduced `primaryType` is `'EIP712Domain'`, `hashStruct` (the part that actually hashes the message content) is **skipped entirely**, and the result is just `keccak256(0x1901 ‖ domainSeparator)` — the same value for every message signed under that domain, regardless of content.

The comment cites ethers as the source of this logic, but real ethers does the opposite: it computes the unique root of the types dependency graph and **throws** on ambiguity (`"ambiguous primary types or unused types"`). It doesn't take `Object.keys(types)[0]`.

## Reachability

`primaryType` is declared optional on `EIP712TypedData` (`packages/types-kit/src/types.ts:198`), and this path is reachable from `Safe.signMessage()` (`Safe.ts:741,748`) — used for on-chain EIP-1271 message approvals via `signMessageLib.signMessage(hashSafeMessage(message.data))`.

## Repro

Ran a verbatim port of the buggy code against real, unmodified `viem` (the same major version pinned in this repo):

```
=== BUGGY (current deducePrimaryType) ===
SDK msgA ('1 ETH')     : 0x3f45f273a0148669e7581f516cb9d779959fae2afb0893c10b90e49a928cdf6a
SDK msgB ('10000 ETH') : 0x3f45f273a0148669e7581f516cb9d779959fae2afb0893c10b90e49a928cdf6a
COLLISION: true

=== real viem hashTypedData, explicit primaryType (ground truth) ===
correct A: 0x2dc78725747f8233e1888c43c861a01970e5aea05093e933ba36f94634a88447
correct B: 0x6d75e96f72eaec71923291bae05119c3ff9aa09c7a7782bebbe12990b1aea2e4
buggy A === correct A? false   <- the buggy hash isn't just "different from ethers' convention", it's wrong for BOTH messages

=== FIXED (this PR) ===
fixed A === correct A? true
fixed B === correct B? true
fixed A !== fixed B (no more collision)? true
```

## Honest scoping

I've verified the **mechanism** — any two distinct messages under the conventional key ordering collide to an identical, content-independent hash. I have not observed a live deployed Safe or a real dapp integration that omits `primaryType` in production. Rate this as: a silently wrong, message-independent hash on a documented-optional input with zero prior test coverage. The EIP-1271-replay-across-every-message-in-a-domain implication follows logically from the mechanism, but wasn't exercised against a live contract.

## The fix

Replaced the naive first-key guess with the actual DAG-root algorithm: the one non-`EIP712Domain` type in `types` that is not itself referenced as a field type by any other type. Throws a clear error on genuine ambiguity (zero or more than one root candidate) instead of silently guessing wrong — so a caller who omits `primaryType` on a genuinely ambiguous payload now gets an actionable error instead of a corrupted hash.

## Testing

`tests/unit/eip-712.test.ts` previously never imported `hashSafeMessage`/`encodeTypedData` at all, and every `primaryType` reference in the file supplied it explicitly — the `!typedData?.primaryType` branch had zero coverage. Added:
- distinct messages → distinct hashes when `primaryType` is omitted (matches the real EIP-712-payload shape, `types: { EIP712Domain, Mail }`)
- the deduced hash matches real viem's `hashTypedData` with an explicit correct `primaryType`
- `hashSafeMessage` routes typed-data input through the same fixed deduction
- throws on a genuinely ambiguous types graph (2 root candidates)
- explicit `primaryType` still respected, unaffected by the fix

Confirmed genuine red-before/green-after by stashing just the source fix and re-running: 4 of the 5 new tests fail against unfixed code with the exact predicted symptoms (including the collision assertion showing both hashes literally identical), the unaffected "explicit primaryType" test still passes either way.

```
$ npx mocha ... tests/unit/eip-712.test.ts   # full file, fixed code
  17 passing (18ms)

$ npx mocha ... tests/unit/eip-712.test.ts   # full file, unfixed code (fix stashed)
  13 passing
  4 failing   # exactly the 4 tests targeting this bug
```

Full `protocol-kit` unit suite: 45/45 passing, no regressions. `tsc --noEmit`: 57 pre-existing errors, identical count before and after this change (all in unrelated `tests/e2e/**` files needing an unbuilt sibling package — none touch `eip-712`). `eslint`: 0 errors, 8 warnings (6 pre-existing `no-explicit-any` in untouched parts of `encode.ts`, 2 new in the test file's ground-truth viem comparison calls, matching the existing `as any` pattern already used in `encode.ts` itself).

## Risk

Low — this only changes behavior on the previously-broken path (no explicit `primaryType`). Any caller supplying `primaryType` explicitly is unaffected. A well-formed real-world payload (single message type, or a small tree of nested composite types) has exactly one DAG root and passes through the fix identically to what the correct hash would be; only genuinely ambiguous inputs (which previously produced a silently wrong hash) now throw instead.

## Receipts

- 17/17 in `eip-712.test.ts`, 45/45 full unit suite, 0 typecheck regressions, 0 lint errors — all above, real command output.
