### PR TITLE
fix(protocol-kit): extractSignature drops byteOffset for pooled Uint8Array signatures

### DIFF
--- a/packages/protocol-kit/src/utils/passkeys/PasskeyClient.ts
+++ b/packages/protocol-kit/src/utils/passkeys/PasskeyClient.ts
@@ -204,7 +204,9 @@ function extractClientDataFields(clientDataJSON: ArrayBuffer): Hex {
  * @returns {[bigint, bigint]} A tuple containing two BigInt values, r and s, which are the numeric values extracted from the signature.
  * @throws {Error} Throws an error if the signature encoding is invalid or does not meet expected conditions.
  */
-function extractSignature(signature: ArrayBuffer | Uint8Array | Array<number>): [bigint, bigint] {
+export function extractSignature(
+  signature: ArrayBuffer | Uint8Array | Array<number>
+): [bigint, bigint] {
   const check = (x: boolean) => {
     if (!x) {
       throw new Error('invalid signature encoding')
@@ -214,25 +216,29 @@ function extractSignature(signature: ArrayBuffer | Uint8Array | Array<number>): 
   // Decode the DER signature. Note that we assume that all lengths fit into 8-bit integers,
   // which is true for the kinds of signatures we are decoding but generally false. I.e. this
   // code should not be used in any serious application.
-  const view = new DataView(
-    signature instanceof ArrayBuffer
+  //
+  // Normalize to a single Uint8Array up front and read from it directly (rather than wrapping
+  // it in a DataView backed by `.buffer`), so a Uint8Array/Buffer view with a non-zero
+  // byteOffset (e.g. Buffer.from(base64, 'base64'), which is commonly pooled) is decoded
+  // correctly instead of reading past its bounds into unrelated memory.
+  const bytes =
+    signature instanceof Uint8Array
       ? signature
-      : signature instanceof Uint8Array
-        ? signature.buffer
-        : new Uint8Array(signature).buffer
-  )
+      : signature instanceof ArrayBuffer
+        ? new Uint8Array(signature)
+        : new Uint8Array(signature)
 
   // check that the sequence header is valid
-  check(view.getUint8(0) === 0x30)
-  check(view.getUint8(1) === view.byteLength - 2)
+  check(bytes[0] === 0x30)
+  check(bytes[1] === bytes.byteLength - 2)
 
   // read r and s
   const readInt = (offset: number) => {
-    check(view.getUint8(offset) === 0x02)
-    const len = view.getUint8(offset + 1)
+    check(bytes[offset] === 0x02)
+    const len = bytes[offset + 1]
     const start = offset + 2
     const end = start + len
-    const n = fromBytes(new Uint8Array(view.buffer.slice(start, end)), 'bigint')
+    const n = fromBytes(bytes.slice(start, end), 'bigint')
     check(n < maxUint256)
     return [n, end] as const
   }

--- a/packages/protocol-kit/tests/unit/utils/extractSignature.test.ts
+++ b/packages/protocol-kit/tests/unit/utils/extractSignature.test.ts
@@ -1,0 +1,80 @@
+import chai from 'chai'
+import { extractSignature } from '@safe-global/protocol-kit/utils'
+
+const { expect } = chai
+
+/**
+ * Builds a minimal DER-encoded ECDSA signature: SEQUENCE { INTEGER r, INTEGER s }
+ */
+function buildDerSignature(rHex: string, sHex: string): Uint8Array {
+  const hexToBytes = (hex: string) => Uint8Array.from(Buffer.from(hex, 'hex'))
+  const rBytes = hexToBytes(rHex)
+  const sBytes = hexToBytes(sHex)
+  const body = new Uint8Array([0x02, rBytes.length, ...rBytes, 0x02, sBytes.length, ...sBytes])
+  return new Uint8Array([0x30, body.length, ...body])
+}
+
+describe('extractSignature', () => {
+  const rHex = '11'.repeat(32)
+  const sHex = '22'.repeat(32)
+
+  it('extracts r and s from a fresh, zero-offset Uint8Array', () => {
+    const sig = buildDerSignature(rHex, sHex)
+    const [r, s] = extractSignature(sig)
+    expect(r).to.equal(BigInt('0x' + rHex))
+    expect(s).to.equal(BigInt('0x' + sHex))
+  })
+
+  it('extracts r and s from an ArrayBuffer', () => {
+    const sig = buildDerSignature(rHex, sHex)
+    const [r, s] = extractSignature(sig.buffer)
+    expect(r).to.equal(BigInt('0x' + rHex))
+    expect(s).to.equal(BigInt('0x' + sHex))
+  })
+
+  it('extracts r and s from an Array<number>', () => {
+    const sig = Array.from(buildDerSignature(rHex, sHex))
+    const [r, s] = extractSignature(sig)
+    expect(r).to.equal(BigInt('0x' + rHex))
+    expect(s).to.equal(BigInt('0x' + sHex))
+  })
+
+  it('extracts r and s correctly from a pooled/offset Uint8Array view (e.g. Buffer.from(base64, "base64"))', () => {
+    const derBytes = buildDerSignature(rHex, sHex)
+    const b64 = Buffer.from(derBytes).toString('base64')
+    // Node's Buffer.from(base64, 'base64') commonly returns a view into a shared pooled
+    // ArrayBuffer with a non-zero byteOffset - this is the real-world shape that broke
+    // before this fix (a naive DataView-over-.buffer read ignores the offset entirely).
+    const pooled = Buffer.from(b64, 'base64')
+    expect(pooled.byteOffset).to.not.equal(0)
+
+    const [r, s] = extractSignature(pooled)
+    expect(r).to.equal(BigInt('0x' + rHex))
+    expect(s).to.equal(BigInt('0x' + sHex))
+  })
+
+  it('extracts r and s correctly from a Uint8Array subarray view with a non-zero offset', () => {
+    const derBytes = buildDerSignature(rHex, sHex)
+    const padded = new Uint8Array(derBytes.length + 10)
+    padded.set(derBytes, 10)
+    const view = padded.subarray(10)
+    expect(view.byteOffset).to.equal(10)
+
+    const [r, s] = extractSignature(view)
+    expect(r).to.equal(BigInt('0x' + rHex))
+    expect(s).to.equal(BigInt('0x' + sHex))
+  })
+
+  it('throws on an invalid sequence header', () => {
+    const sig = buildDerSignature(rHex, sHex)
+    sig[0] = 0x31
+    expect(() => extractSignature(sig)).to.throw('invalid signature encoding')
+  })
+
+  it('throws when r exceeds maxUint256', () => {
+    // 33-byte integer (leading non-zero byte + 32 bytes) exceeds uint256 range
+    const bigR = '11'.repeat(33)
+    const sig = buildDerSignature(bigR, sHex)
+    expect(() => extractSignature(sig)).to.throw('invalid signature encoding')
+  })
+})


### PR DESCRIPTION
## What it says on the box

`extractSignature` (used to decode a DER-encoded WebAuthn passkey signature) drops `byteOffset`/`byteLength` for the `Uint8Array` input case, so a pooled or offset `Uint8Array` — e.g. `Buffer.from(base64Sig, 'base64')`, a completely standard way to decode a base64 signature — throws `invalid signature encoding` instead of decoding correctly.

```ts
const view = new DataView(
  signature instanceof ArrayBuffer
    ? signature
    : signature instanceof Uint8Array
      ? signature.buffer     // <- drops byteOffset/byteLength; reads the WHOLE underlying buffer
      : new Uint8Array(signature).buffer
)
```

This is a partial-fix situation: merged #1094 (for #1054, *"passkey data isn't an ArrayBuffer"*) fixed the `Array<number>` input shape (which already allocates a fresh exactly-sized buffer) but left the `Uint8Array` shape broken.

## Reachability

`passkey.getFn` (`types/passkeys.ts`) is the public React Native escape hatch — RN has no `navigator.credentials`, so an RN consumer must construct `assertionResponse.signature` themselves, and `Buffer.from(base64Sig, 'base64')` is the standard way to do that decode. No specific real Bitwarden/RN consumer's exact signature object shape was directly observed by me — what's proven is that the entire "pooled/offset view" half of the input class is still broken on current `main`, in a reachable, documented code path.

## The landmine — why this isn't a one-line fix

Naively fixing only the `DataView` construction (`new DataView(sig.buffer, sig.byteOffset, sig.byteLength)`) would make things **worse**, not better — a second, independent read further down:

```ts
const n = fromBytes(new Uint8Array(view.buffer.slice(start, end)), 'bigint')
```

still indexes the raw, full, unshifted underlying buffer using offsets computed for the now-correctly-scoped view. Verified this exact landmine with a standalone repro before writing the real fix — a naive partial fix produces plausible-looking-but-wrong `r`/`s` bytes instead of a clean throw:

```
pooled Buffer.from(b64,'base64'): byteOffset=616, byteLength=70, underlying buffer=8192 bytes

current code (fails closed):        THREW: invalid signature encoding
naive DataView-only fix (LANDMINE): r = 0x1111111111...  (wrong, no error)
                                     s = 0x1111222222...  (wrong, no error)
real fix (this PR):                 r = 0x1111111111...111 (correct)
                                     s = 0x2222222222...222 (correct)
```

## The fix

Normalizes the input to a single `Uint8Array` once at the top of the function and reads directly from it everywhere (header checks and `r`/`s` extraction alike), eliminating the `DataView`-over-`buffer` pattern entirely so there's no second read left to fall out of sync.

Side effect (a correctness improvement, not just neutral): the sequence-length check `bytes[1] === bytes.byteLength - 2` is now also more correct — `byteLength` on the normalized view reflects the view's own length, where the old `view.byteLength` (on a `DataView` built with no explicit length) reflected the *full underlying buffer's* length instead.

`extractSignature` is now exported (it wasn't before) so it can be unit tested directly — there's no existing lightweight test harness for the passkey signing path, and testing indirectly through `createPasskeyClient`/`sign` would require a full e2e contract setup for what is otherwise pure DER-parsing logic.

## Note, out of scope for this fix

A DER integer of length 0 (`r` or `s`) still reaches `fromBytes()` with an empty byte array and throws a raw, uncaught `SyntaxError` rather than this function's own controlled `invalid signature encoding` error. This is **pre-existing behavior, identical before and after this change** (verified) — not something introduced or worsened here.

## Third sighting

This is the third time this exact defect class — a `DataView` (or equivalent) constructed over `.buffer` instead of the view's own `byteOffset`/`byteLength` window — has turned up recently: `cowprotocol/cow-sdk`'s `extractOrderUidParams` had the identical bug shape. Worth watching for elsewhere in codebases that decode over raw `ArrayBuffer`/`DataView`.

## Receipts

Full unit suite, run under Node 20 (matching this repo's CI pin — a clean sandbox on Node 23 hits an unrelated environment issue with self-referencing package exports resolution, confirmed present even on unmodified `tests/unit/eip-3770.test.ts`, so tested against the pinned version instead):

```
$ node --version
v20.18.3
$ npx mocha -r ts-node/register -r tsconfig-paths/register tests/unit/**/*.ts
  ...
  extractSignature
    ✔ extracts r and s from a fresh, zero-offset Uint8Array
    ✔ extracts r and s from an ArrayBuffer
    ✔ extracts r and s from an Array<number>
    ✔ extracts r and s correctly from a pooled/offset Uint8Array view (e.g. Buffer.from(base64, "base64"))
    ✔ extracts r and s correctly from a Uint8Array subarray view with a non-zero offset
    ✔ throws on an invalid sequence header
    ✔ throws when r exceeds maxUint256

  47 passing (22ms)
```

Genuine red-before/green-after: swapped in the buggy-but-exported implementation (export kept, logic reverted to `signature.buffer` + `view.buffer.slice`), reran just the new test file — the two pooled/offset tests fail with `Error: invalid signature encoding` (exactly the current fail-closed symptom), the other five pass. Restored the real fix, all 47 pass again.

`tsc -p tsconfig.build.json` clean (via `lerna run build`, which also confirms `@safe-global/types-kit` builds fine as a dependency). `eslint`/`prettier` clean on both changed files (one prettier formatting nit auto-fixed before commit; pre-commit hook itself re-ran `eslint --fix`/`prettier --write` and made no further changes).

Codex adversarial review attempted synchronously — it made real progress (checked CI's Node 20 pin, confirmed the mismatch with my sandbox's Node 23, ran `git status`) but crashed with an internal stack overflow before reaching a verdict. Killed only its own tracked PID (not a broad pattern-match kill) and substituted a thorough self-review instead, covering: correctness across all three input types, confirming no remaining raw `.buffer` reads anywhere in the function, the sequence-length check's semantics, non-vacuousness of the new tests (proven via the red-before/green-after above), the zero-length-integer edge case (found, confirmed pre-existing and unchanged, documented above rather than silently fixed or ignored), and the export-surface widening (a plain pure-logic decoder function, no state, no side effects — low risk to export).
