### PR TITLE
fix(relay-kit): compare 4337 entrypoint, module and fallback handler addresses case-insensitively

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -219,6 +219,38 @@ describe('Safe4337Pack', () => {
       )
     })
 
+    it('should recognize a custom entrypoint address regardless of its casing', async () => {
+      const safe4337Pack = await createSafe4337Pack({
+        options: {
+          owners: [fixtures.OWNER_1],
+          threshold: 1
+        },
+        customContracts: {
+          entryPointAddress: fixtures.ENTRYPOINT_ADDRESS_V07.toLowerCase()
+        },
+        safeModulesVersion: '0.3.0'
+      })
+
+      expect(await safe4337Pack.protocolKit.getAddress()).toBe(fixtures.PREDICTED_SAFE_ADDRESS)
+    })
+
+    it('should throw a clear error if the custom entrypoint address is not a recognized entrypoint', async () => {
+      const unknownEntryPointAddress = '0x0000000000000000000000000000000000000000'
+
+      await expect(
+        createSafe4337Pack({
+          options: {
+            owners: [fixtures.OWNER_1],
+            threshold: 1
+          },
+          customContracts: { entryPointAddress: unknownEntryPointAddress },
+          safeModulesVersion: '0.3.0'
+        })
+      ).rejects.toThrow(
+        `The selected entrypoint ${unknownEntryPointAddress} is not a recognized entrypoint`
+      )
+    })
+
     it('should throw an error if the owners or threshold are not specified', async () => {
       await expect(
         createSafe4337Pack({

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -189,6 +189,22 @@ describe('Safe4337Pack', () => {
 
       expect(await safe4337Pack.protocolKit.getFallbackHandler()).toEqual(safe4337ModuleAddress)
     })
+
+    it('should recognize an already-enabled custom 4337 module and fallback handler regardless of casing', async () => {
+      const safe4337Pack = await createSafe4337Pack({
+        customContracts: {
+          safe4337ModuleAddress: safe4337ModuleAddress.toLowerCase() as viem.Hash
+        },
+        options: {
+          safeAddress: fixtures.SAFE_ADDRESS_v1_4_1_WITH_0_3_0_MODULE
+        },
+        safeModulesVersion: '0.3.0'
+      })
+
+      expect(await safe4337Pack.protocolKit.getAddress()).toBe(
+        fixtures.SAFE_ADDRESS_v1_4_1_WITH_0_3_0_MODULE
+      )
+    })
   })
 
   describe('When the Safe Account does not exists', () => {

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -47,7 +47,8 @@ import {
   createBundlerClient,
   userOperationToHexValues,
   getRelayKitVersion,
-  createUserOperation
+  createUserOperation,
+  sameString
 } from '@safe-global/relay-kit/packs/safe-4337/utils'
 import { PimlicoFeeEstimator } from '@safe-global/relay-kit/packs/safe-4337/estimators/pimlico/PimlicoFeeEstimator'
 
@@ -199,7 +200,9 @@ export class Safe4337Pack extends RelayKitBasePack<{
       }
 
       const safeModules = (await protocolKit.getModules()) as string[]
-      const is4337ModulePresent = safeModules.some((module) => module === safe4337ModuleAddress)
+      const is4337ModulePresent = safeModules.some((module) =>
+        sameString(module, safe4337ModuleAddress)
+      )
 
       if (!is4337ModulePresent) {
         throw new Error(
@@ -208,7 +211,7 @@ export class Safe4337Pack extends RelayKitBasePack<{
       }
 
       const safeFallbackhandler = await protocolKit.getFallbackHandler()
-      const is4337FallbackhandlerPresent = safeFallbackhandler === safe4337ModuleAddress
+      const is4337FallbackhandlerPresent = sameString(safeFallbackhandler, safe4337ModuleAddress)
 
       if (!is4337FallbackhandlerPresent) {
         throw new Error(

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -355,6 +355,11 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
     if (customContracts?.entryPointAddress) {
       const requiredSafeModulesVersion = entryPointToSafeModules(customContracts?.entryPointAddress)
+      if (!requiredSafeModulesVersion) {
+        throw new Error(
+          `The selected entrypoint ${customContracts?.entryPointAddress} is not a recognized entrypoint`
+        )
+      }
       if (!semverSatisfies(safeModulesVersion, requiredSafeModulesVersion))
         throw new Error(
           `The selected entrypoint ${customContracts?.entryPointAddress} is not compatible with version ${safeModulesVersion} of Safe modules`
@@ -372,7 +377,9 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
       selectedEntryPoint = supportedEntryPoints.find((entryPoint: string) => {
         const requiredSafeModulesVersion = entryPointToSafeModules(entryPoint)
-        return semverSatisfies(safeModulesVersion, requiredSafeModulesVersion)
+        return requiredSafeModulesVersion
+          ? semverSatisfies(safeModulesVersion, requiredSafeModulesVersion)
+          : false
       })
 
       if (!selectedEntryPoint) {

--- a/packages/relay-kit/src/packs/safe-4337/utils/entrypoint.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/entrypoint.test.ts
@@ -1,0 +1,40 @@
+import {
+  entryPointToSafeModules,
+  isEntryPointV6,
+  isEntryPointV7,
+  sameString,
+  EQ_OR_GT_0_3_0
+} from './entrypoint'
+import { ENTRYPOINT_ADDRESS_V06, ENTRYPOINT_ADDRESS_V07 } from '../constants'
+
+describe('entryPointToSafeModules', () => {
+  it('resolves the required Safe modules version for a checksummed entrypoint address', () => {
+    expect(entryPointToSafeModules(ENTRYPOINT_ADDRESS_V06)).toBe('0.2.0')
+    expect(entryPointToSafeModules(ENTRYPOINT_ADDRESS_V07)).toBe(EQ_OR_GT_0_3_0)
+  })
+
+  it('resolves the required Safe modules version for a lower-cased entrypoint address', () => {
+    expect(entryPointToSafeModules(ENTRYPOINT_ADDRESS_V07.toLowerCase())).toBe(EQ_OR_GT_0_3_0)
+    expect(entryPointToSafeModules(ENTRYPOINT_ADDRESS_V06.toLowerCase())).toBe('0.2.0')
+  })
+
+  it('returns undefined for an entrypoint address that does not match any known entrypoint', () => {
+    expect(entryPointToSafeModules('0x0000000000000000000000000000000000000000')).toBeUndefined()
+  })
+})
+
+describe('sameString', () => {
+  it('compares strings case-insensitively', () => {
+    expect(sameString('0xAbC', '0xabc')).toBe(true)
+    expect(sameString('0xAbC', '0xdef')).toBe(false)
+  })
+})
+
+describe('isEntryPointV6 / isEntryPointV7', () => {
+  it('recognizes checksummed and lower-cased entrypoint addresses alike', () => {
+    expect(isEntryPointV6(ENTRYPOINT_ADDRESS_V06)).toBe(true)
+    expect(isEntryPointV6(ENTRYPOINT_ADDRESS_V06.toLowerCase())).toBe(true)
+    expect(isEntryPointV7(ENTRYPOINT_ADDRESS_V07)).toBe(true)
+    expect(isEntryPointV7(ENTRYPOINT_ADDRESS_V07.toLowerCase())).toBe(true)
+  })
+})

--- a/packages/relay-kit/src/packs/safe-4337/utils/entrypoint.ts
+++ b/packages/relay-kit/src/packs/safe-4337/utils/entrypoint.ts
@@ -13,13 +13,19 @@ export function sameString(str1: string, str2: string): boolean {
   return str1.toLowerCase() === str2.toLowerCase()
 }
 
-export function entryPointToSafeModules(entryPoint: string) {
+export function entryPointToSafeModules(
+  entryPoint: string
+): typeof EQ_0_2_0 | typeof EQ_OR_GT_0_3_0 | undefined {
   const moduleVersionToEntryPoint: Record<string, typeof EQ_0_2_0 | typeof EQ_OR_GT_0_3_0> = {
     [ENTRYPOINT_ADDRESS_V06]: EQ_0_2_0,
     [ENTRYPOINT_ADDRESS_V07]: EQ_OR_GT_0_3_0
   }
 
-  return moduleVersionToEntryPoint[entryPoint]
+  const matchingEntryPoint = Object.keys(moduleVersionToEntryPoint).find((candidate) =>
+    sameString(candidate, entryPoint)
+  )
+
+  return matchingEntryPoint ? moduleVersionToEntryPoint[matchingEntryPoint] : undefined
 }
 
 export function isEntryPointV6(address: string): boolean {


### PR DESCRIPTION
## What it solves

`entryPointToSafeModules` (`packages/relay-kit/src/packs/safe-4337/utils/entrypoint.ts:16-23`) did an exact `Record` lookup keyed by the checksummed `ENTRYPOINT_ADDRESS_V06`/`ENTRYPOINT_ADDRESS_V07` constants, while its two siblings in the same file — `isEntryPointV6`/`isEntryPointV7` — already compare via the case-insensitive `sameString` helper defined right above it.

A lowercase (or any non-checksummed-casing) entryPoint address reaches this function from two directions with zero normalization:
- `Safe4337Options.customContracts.entryPointAddress` — a caller-supplied plain `string`.
- A bundler's `SUPPORTED_ENTRY_POINTS` response — nothing in ERC-4337 requires checksummed casing (`geth` itself commonly returns lowercase).

Either way, the exact-match lookup silently fails and returns `undefined`. `semver`'s `satisfies(version, undefined)` swallows that internally and returns `false` rather than throwing:

```
> semverSatisfies('0.3.0', undefined)
false
```

So the failure gets laundered into the exact same `The selected entrypoint ${address} is not compatible with version ${safeModulesVersion} of Safe modules` error a genuine version mismatch produces — even though the entrypoint address itself is perfectly valid, just cased differently than the constant.

**Widened scope**: this PR now also fixes the identical bug class at a second site — `Safe4337Pack.init`'s existing-Safe compatibility checks (`packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts:202,211`) compared the caller-supplied `customContracts.safe4337ModuleAddress` (also a raw, unnormalized string) against `protocolKit.getModules()`/`getFallbackHandler()` results using bare `===`. Those results are decoded via viem's `decodeAbiParameters` for the `address` type, which always returns a checksummed address regardless of input casing — so a valid but differently-cased custom module address was incorrectly rejected as "not enabled", for both the module-presence check and the fallback-handler check. This exact comparison pattern already exists correctly elsewhere in the codebase: `moduleManager.ts`'s `validateModuleIsEnabled` and `fallbackHandlerManager.ts`'s `validateFallbackHandlerIsNotEnabled` (both in `protocol-kit`) already use `sameString` for the identical kind of comparison.

Confirmed this second site doesn't bite on the *default* path — `safe-modules-deployments` ships checksummed addresses, so the default (non-custom) `safe4337ModuleAddress` already agrees in casing with the checksummed decode. It only misfires on a caller-supplied non-checksummed `customContracts.safe4337ModuleAddress`, confirmed with a direct repro (a lowercase caller-supplied address matching a checksummed installed module fails both bare `===` checks, succeeds with `sameString`).

## How this PR fixes it

- `entryPointToSafeModules` now resolves the matching map key via `sameString`, matching the pattern its two siblings already use, and its return type is widened to `... | undefined` so a genuinely-unrecognized address can no longer be silently coerced through.
- Both call sites in `Safe4337Pack.init` now handle that explicit `undefined`:
  - The `customContracts.entryPointAddress` path throws a clear, distinct `is not a recognized entrypoint` error instead of the misleading version-incompatibility message.
  - The bundler `.find()` predicate now treats `undefined` as "this candidate doesn't match" (skip it) instead of passing `undefined` into `semverSatisfies`.
- The two bare `===` comparisons in `Safe4337Pack.init`'s existing-Safe compatibility checks (module-presence and fallback-handler) are replaced with `sameString`, matching the pattern used elsewhere in the codebase for the same kind of comparison.

## Verification

Reproduced end-to-end through the real `Safe4337Pack.init` before touching anything, for both sites: a checksummed EntryPoint v0.7 address initializes fine on unmodified code, the identical address lowercased is rejected with the misleading incompatible-version message; a lowercase custom module address matching an installed checksummed module is rejected as "not enabled" and "fallback handler not attached" on unmodified code.

Genuine red-before/green-after at multiple levels, all via `git stash` on the source fix with the new tests already in place:

```
# isolated unit level (entrypoint.test.ts, new file)
FAIL (unfixed) -> 2 failed / 4 passed  (lowercase lookup returns undefined)
PASS (fixed)   -> 5 passed / 5 total

# Safe4337Pack integration level (Safe4337Pack.test.ts, 3 new cases)
✕ should recognize a custom entrypoint address regardless of its casing   (unfixed)
✕ should throw a clear error if the custom entrypoint address is not a recognized entrypoint   (unfixed)
✕ should recognize an already-enabled custom 4337 module and fallback handler regardless of casing   (unfixed)
✓ all three pass (fixed)
```

Full `relay-kit` suite (with a dummy `PASSKEY_PRIVATE_KEY` env var, since the sandbox this was built in doesn't have the real CI secret): 70 passed / 5 failed, identical 5 pre-existing failures on unmodified `main` with the same dummy key (all `There is no signer address available to sign the SafeOperation`, an artifact of the dummy key not deriving a fixture-matching signer — unrelated to this change, confirmed identical before/after). `tsc` build, `eslint`, and `prettier --check` all clean on every changed file, for both commits.

Ran Codex adversarially before opening this PR, and again after widening it. On the first pass it caught a real bug in my initial "uppercase" unit test case, which used `.toUpperCase()` on the whole address string, uppercasing the `0x` prefix to `0X` — an input viem's own `isAddress` rejects outright (confirmed independently: `isAddress('0X...')` → `false`, and a fully-uppercase-hex address with a correct `0x` prefix also fails viem's default strict checksum validation, since it isn't a valid EIP-55 checksum casing either). That test case wasn't testing a realistic input shape, so I removed it rather than adding address-normalization logic to make an unrealistic case pass — the actually-relevant real-world variant this bug affects is all-lowercase, which is fully covered. Codex also flagged that the two `Safe4337Pack.init` entrypoint call-site behaviors weren't covered by a pack-level test — added both as new cases in `Safe4337Pack.test.ts`. On the second pass (reviewing the widened-scope commit), Codex returned a clean SHIP with no blocking findings, having independently confirmed `sameString` performs no normalization beyond lowercasing, that the new regression test genuinely exercises both changed comparisons (not vacuously), and that existing checksummed callers see no behavior change.

## Note on introducing-commit provenance

The initial report attributed the `entryPointToSafeModules` bug to PR #822, but git blame shows this exact file shape (`sameString` + `entryPointToSafeModules` + `isEntryPointV6`, all case-insensitive except `entryPointToSafeModules`) was introduced as-is by #939 (a `chore: rename safe-kit to sdk-starter-kit` workspace-move commit carrying the file's prior history forward) — flagging the correction here rather than repeating an unverified number.

## Risk

Low, for both sites. Each affected function is small, has few callers, and every changed comparison is covered by both the original diff and a genuine red-before/green-after regression test. Existing checksummed-address callers get identical behavior to before on all changed paths (verified for each). The only behavior change is that previously-rejected differently-cased-but-valid addresses now resolve/match correctly, and previously-silent unrecognized entrypoints now get an accurate, distinct error message instead of a misleading one.