### PR TITLE
fix(protocol-kit): correct generateHash docs and de-vacuous test

### DIFF
--- a/packages/protocol-kit/src/utils/on-chain-tracking/generateOnChainIdentifier.ts
+++ b/packages/protocol-kit/src/utils/on-chain-tracking/generateOnChainIdentifier.ts
@@ -3,13 +3,25 @@ import { keccak256, toHex } from 'viem'
 /**
  * Generates a hash from the given input string and truncates it to the specified size.
  *
+ * NOTE: for the `size` values actually used by identifier version `00` (3 and 20, see
+ * generateOnChainIdentifier below), `size` is the number of hex CHARACTERS (nibbles) taken
+ * from the end of the keccak256 digest, not bytes. `fullHash` is a hex string, so
+ * `.slice(-size)` takes `size` characters, and the subsequent `toHex()` call re-encodes those
+ * ASCII characters (i.e. '0'-'9', 'a'-'f') as bytes rather than reinterpreting the underlying
+ * hash bytes. For those `size` values the returned string is `size` bytes long, but each byte
+ * only ever takes one of 16 possible ASCII hex-digit values, so the result has at most
+ * `16 ** size` possible values, not the `256 ** size` a byte-accurate truncation would allow.
+ * This is the current, already-shipped, already-on-chain behavior and must not change without
+ * a new `identifierVersion` (see generateOnChainIdentifier below) to avoid altering the format
+ * of previously-published on-chain identifiers.
+ *
  * @param {string} input - The input string to be hashed.
- * @param {number} size - The number of bytes to take from the end of the hash.
+ * @param {number} size - The number of hex characters (not bytes) to take from the end of the hash.
  * @returns {string} A hexadecimal string representation of the truncated hash, without the `0x` prefix.
  */
 export function generateHash(input: string, size: number): string {
   const fullHash = keccak256(toHex(input))
-  return toHex(fullHash.slice(-size)).replace('0x', '') // Take the last X bytes
+  return toHex(fullHash.slice(-size)).replace('0x', '') // Take the last `size` hex characters
 }
 
 export type OnChainIdentifierParamsType = {
@@ -46,10 +58,10 @@ function generateOnChainIdentifier({
 }: OnChainIdentifierParamsType): string {
   const identifierPrefix = '5afe'
   const identifierVersion = '00' // first version
-  const projectHash = generateHash(project, 20) // Take the last 20 bytes
-  const platformHash = generateHash(platform, 3) // Take the last 3 bytes
-  const toolHash = generateHash(tool, 3) // Take the last 3 bytes
-  const toolVersionHash = generateHash(toolVersion, 3) // Take the last 3 bytes
+  const projectHash = generateHash(project, 20) // Take the last 20 hex characters
+  const platformHash = generateHash(platform, 3) // Take the last 3 hex characters
+  const toolHash = generateHash(tool, 3) // Take the last 3 hex characters
+  const toolVersionHash = generateHash(toolVersion, 3) // Take the last 3 hex characters
 
   return `${identifierPrefix}${identifierVersion}${projectHash}${platformHash}${toolHash}${toolVersionHash}`
 }

--- a/packages/protocol-kit/tests/e2e/onChainIdentifier.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainIdentifier.test.ts
@@ -32,12 +32,38 @@ describe('On-chain analytics', () => {
       const identifierPrefix = '5afe'
       const identifierVersion = '00'
 
+      // These are pinned as hard-coded constants (independently computed from the real
+      // keccak256 digest) rather than by re-calling generateHash, which would make this
+      // assertion vacuous against its own implementation and unable to catch a regression
+      // in generateHash's behavior. See generateHash's doc comment for why these values look
+      // like ASCII hex digits rather than raw hash bytes: that's a known, already-shipped
+      // (not byte-accurate) truncation behavior this test intentionally pins as-is.
+      const projectHash = '3861653435366632366138366164643038373864'
+      const platformHash = '646561'
+      const toolHash = '393238'
+      const toolVersionHash = '373263'
+
       chai.expect(onChainIdentifier.startsWith(identifierPrefix)).to.be.true
       chai.expect(onChainIdentifier.substring(4, 6)).to.equals(identifierVersion)
-      chai.expect(onChainIdentifier.substring(6, 46)).to.equals(generateHash(project, 20))
-      chai.expect(onChainIdentifier.substring(46, 52)).to.equals(generateHash(platform, 3))
-      chai.expect(onChainIdentifier.substring(52, 58)).to.equals(generateHash(tool, 3))
-      chai.expect(onChainIdentifier.substring(58, 64)).to.equals(generateHash(toolVersion, 3))
+      chai.expect(onChainIdentifier.substring(6, 46)).to.equals(projectHash)
+      chai.expect(onChainIdentifier.substring(46, 52)).to.equals(platformHash)
+      chai.expect(onChainIdentifier.substring(52, 58)).to.equals(toolHash)
+      chai.expect(onChainIdentifier.substring(58, 64)).to.equals(toolVersionHash)
+
+      // Exact aggregate equality pins the complete format (including that there's no
+      // trailing data beyond what the substring assertions above check individually).
+      chai
+        .expect(onChainIdentifier)
+        .to.equals(
+          `${identifierPrefix}${identifierVersion}${projectHash}${platformHash}${toolHash}${toolVersionHash}`
+        )
+
+      // Cross-check against generateHash directly, so a change to either the aggregate
+      // identifier assembly or the hash function itself is caught by at least one assertion.
+      chai.expect(generateHash(project, 20)).to.equals(projectHash)
+      chai.expect(generateHash(platform, 3)).to.equals(platformHash)
+      chai.expect(generateHash(tool, 3)).to.equals(toolHash)
+      chai.expect(generateHash(toolVersion, 3)).to.equals(toolVersionHash)
     })
   })
 


### PR DESCRIPTION
Non-breaking documentation + test-integrity fix for `generateHash`'s truncation behavior. **No runtime behavior change** — `generateHash`'s actual output is byte-for-byte identical before and after this PR.

## What's actually wrong

`generateHash`'s JSDoc says `size` is "the number of bytes to take from the end of the hash". It isn't:

```ts
export function generateHash(input: string, size: number): string {
  const fullHash = keccak256(toHex(input))
  return toHex(fullHash.slice(-size)).replace('0x', '') // Take the last X bytes
}
```

`keccak256()` returns a hex **string**. `.slice(-size)` therefore takes `size` **characters** (nibbles), not bytes. `toHex()` applied to a string does `stringToHex` — it UTF-8-encodes those ASCII characters as bytes, rather than reinterpreting the underlying hash bytes. The result is `size` bytes long, but each byte can only ever be an ASCII hex-digit byte (`'0'`-`'9'`, `'a'`-`'f'`) — 16 possible values, not 256.

I verified this with a real run against the pinned viem version:

```
fullHash        = 0x5cf9c0e95198ffeb9ef583d208e91798eb10bbf881ec2526939f24f8049e7556
slice(-20)      = "2526939f24f8049e7556"   (20 characters)
generateHash    = 3235323639333966323466383034396537353536   (40 hex chars = 20 bytes)
as ASCII        = "2526939f24f8049e7556"   <- matches the sliced characters exactly
```

That last line is the proof — the output literally decodes back to readable ASCII text, which is not what a hash truncation should look like.

**Entropy impact**, confirmed with real numbers: for `size=3` (used for `platformHash`/`toolHash`/`toolVersionHash`), the field carries `16^3 = 2^12` possible values, not the `256^3 = 2^24` the docs claim. For `size=20` (`projectHash`), `16^20 = 2^80`, not `2^160`.

Collision math for the 12-bit `toolVersionHash` field, which increments across releases (computed independently, not restated from anywhere):

```
P(≥1 collision) by the 80th distinct toolVersion, 12-bit space (current):  0.5422
P(≥1 collision) by the 80th distinct toolVersion, 24-bit space (claimed): 0.000191
```

## Why this PR doesn't fix the runtime behavior

`generateHash`'s output is written into on-chain transaction data via `generateOnChainIdentifier` (`identifierPrefix + identifierVersion + <hashes>`), and real identifiers using the current (buggy) truncation are already published on-chain. Making `generateHash` genuinely byte-accurate would silently change the bit pattern of every future identifier for the same logical inputs relative to what's already on-chain — that's not something to ship quietly in a doc-fix PR.

The identifier format already has an `identifierVersion` byte (currently hardcoded `'00' // first version`), which is exactly the mechanism for shipping a byte-accurate `size` interpretation under a new version without touching already-published data. I'm filing that as a separate issue for a maintainer to weigh in on, rather than bundling a breaking change here.

## What this PR actually does

1. Corrects `generateHash`'s JSDoc and inline comments to describe the real behavior (hex characters, not bytes; scoped to the `size` values the identifier format actually uses).
2. Fixes `tests/e2e/onChainIdentifier.test.ts`'s `'should return the correct on-chain identifier format'` test, which previously asserted `generateHash`'s output against **a fresh call to `generateHash` itself** — vacuous by construction, since it could never detect a regression in the function it's meant to be guarding. Replaced with hard-coded constants, independently computed (cross-checked against a separate `ethers`-based keccak256 calculation, not just re-deriving them from the same code path) and verified two ways:
   - All 5 e2e tests in the file pass unmodified against current `generateHash` (confirms the constants match real, current behavior — zero drift).
   - With `generateHash`'s slice offset deliberately perturbed, all 4 relevant assertions correctly fail with the exact predicted mismatch — then restored to green. This is the proof the new test is non-vacuous; the old one would have stayed green through the same perturbation.

## receipts

Real hardhat e2e run, not simulated:
```
$ TEST_NETWORK=hardhat ETH_LIB=viem SAFE_VERSION=1.4.1 yarn testing-kit test tests/e2e/onChainIdentifier.test.ts

  On-chain analytics
    generateOnChainIdentifier fn
      ✔ should return the correct on-chain identifier format
    getOnchainIdentifier method
      ✔ should return the on-chain identifier when provided (999ms)
      ✔ should return an empty string when no onchain Analiticts is provided
    Tracking Safe Deployment on-chain via the transaction data field
      ✔ should append the on-chain identifier to the deployment transaction data field
    Tracking Safe transactions on-chain via the transaction data field
      ✔ should append the on-chain identifier to the execTransaction data field

  5 passing (1s)
```

`yarn build` (full monorepo), `eslint`, and `prettier --check` all clean on the two changed files.

## risk

None functionally — `generateHash`'s actual return value is unchanged for every input. This is comments + one test's assertion strategy.
