### PR TITLE
fix: keep TransactionOptions.nonce 0 when converting execution options

### DIFF
--- a/.changeset/tx-options-nonce-zero.md
+++ b/.changeset/tx-options-nonce-zero.md
@@ -1,0 +1,5 @@
+---
+'@safe-global/protocol-kit': patch
+---
+
+Preserve `TransactionOptions.nonce = 0` when converting execution options so a caller-supplied zero nonce is not dropped.

--- a/packages/protocol-kit/src/utils/transactions/utils.ts
+++ b/packages/protocol-kit/src/utils/transactions/utils.ts
@@ -285,7 +285,7 @@ export function createLegacyTxOptions(
     converted.gasPrice = BigInt(options.gasPrice)
   }
 
-  if (options?.nonce) {
+  if (typeof options?.nonce !== 'undefined') {
     converted.nonce = options.nonce
   }
 
@@ -310,7 +310,7 @@ export function createTxOptions(options?: TransactionOptions): Partial<WalletTra
     converted.maxPriorityFeePerGas = BigInt(options.maxPriorityFeePerGas)
   }
 
-  if (options?.nonce) {
+  if (typeof options?.nonce !== 'undefined') {
     converted.nonce = options.nonce
   }
 

--- a/packages/protocol-kit/tests/unit/tx-options.test.ts
+++ b/packages/protocol-kit/tests/unit/tx-options.test.ts
@@ -1,0 +1,45 @@
+import chai from 'chai'
+import {
+  convertTransactionOptions,
+  createLegacyTxOptions,
+  createTxOptions
+} from '../../src/utils/transactions/utils'
+
+describe('createTxOptions', () => {
+  it('keeps nonce 0', () => {
+    chai.expect(createTxOptions({ nonce: 0 }).nonce).to.equal(0)
+  })
+
+  it('keeps a non-zero nonce', () => {
+    chai.expect(createTxOptions({ nonce: 123 }).nonce).to.equal(123)
+  })
+
+  it('omits nonce when it is not provided', () => {
+    chai.expect(createTxOptions({}).nonce).to.equal(undefined)
+    chai.expect(createTxOptions().nonce).to.equal(undefined)
+  })
+})
+
+describe('createLegacyTxOptions', () => {
+  it('keeps nonce 0', () => {
+    chai.expect(createLegacyTxOptions({ nonce: 0, gasPrice: 1 }).nonce).to.equal(0)
+  })
+
+  it('keeps a non-zero nonce', () => {
+    chai.expect(createLegacyTxOptions({ nonce: 123, gasPrice: 1 }).nonce).to.equal(123)
+  })
+
+  it('omits nonce when it is not provided', () => {
+    chai.expect(createLegacyTxOptions({ gasPrice: 1 }).nonce).to.equal(undefined)
+  })
+})
+
+describe('convertTransactionOptions', () => {
+  it('keeps nonce 0 on the EIP-1559 path', () => {
+    chai.expect(convertTransactionOptions({ nonce: 0 }).nonce).to.equal(0)
+  })
+
+  it('keeps nonce 0 on the legacy path', () => {
+    chai.expect(convertTransactionOptions({ nonce: 0, gasPrice: 1 }).nonce).to.equal(0)
+  })
+})


### PR DESCRIPTION
## What it solves
Resolves #1425

`TransactionOptions.nonce = 0` is a valid EOA nonce (fresh signer, local/dev chain, first tx). Protocol Kit was dropping it because the conversion helpers treated `0` as falsy, so `executeTransaction(..., { nonce: 0 })` never reached viem and the wallet/provider picked a nonce instead.

## How this PR fixes it

Public execution still spreads caller options into `execTransaction`:

```ts
async executeTransaction(
  safeTransaction: SafeTransaction | SafeMultisigTransactionResponse,
  options?: TransactionOptions
): Promise<TransactionResult>
```

`BaseContract` maps those options with `convertTransactionOptions(options)` in `packages/protocol-kit/src/utils/transactions/utils.ts`. That helper dispatches on `isLegacyTransaction` (`!!options?.gasPrice`) to either `createLegacyTxOptions` or `createTxOptions`. Both used:

```ts
if (options?.nonce) {
  converted.nonce = options.nonce
}
```

Non-zero values worked — the existing e2e already checks `{ nonce: 123456789 }` (`Nonce too high`). `{ nonce: 0 }` was omitted. The same helpers feed `toTransactionRequest` and `toEstimateGasParameters`, so gas estimation and the wallet tx request had the same hole.

Fix: copy nonce with an existence check in both helpers.

```ts
if (typeof options?.nonce !== 'undefined') {
  converted.nonce = options.nonce
}
```

- `{ nonce: 0 }` is kept
- `{ nonce: 123 }` is unchanged
- omitted `nonce` stays omitted (wallet/provider still chooses)

Left alone on purpose:
- `gasLimit` / `gasPrice` / `maxFeePerGas` / `maxPriorityFeePerGas` still use truthiness. `0` is not a useful gas value.
- `isLegacyTransaction` still keys off `gasPrice`, so `{ nonce: 0 }` without `gasPrice` stays on the EIP-1559 path.
- The existing non-zero nonce e2e is not touched.

Unit tests in `packages/protocol-kit/tests/unit/tx-options.test.ts`:
- `createTxOptions({ nonce: 0 }).nonce === 0`
- `createTxOptions({ nonce: 123 }).nonce === 123`
- omitted nonce is `undefined` (`{}` and no-arg)
- same for `createLegacyTxOptions` (with `gasPrice` so the legacy helper is the one under test)
- `convertTransactionOptions({ nonce: 0 })` on both EIP-1559 and legacy paths

Patch changeset on `@safe-global/protocol-kit`.