### PR TITLE
docs: document MultiSend batching for protocol-kit and starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you want to develop using Safe Smart Accounts in a Javascript/Typescript app,
 | Title | Description |
 | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Integrating the Safe{Core} SDK](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md) | This guide shows how to use the [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) and [API Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/api-kit). |
+| [Batch transactions with MultiSend](https://github.com/safe-global/safe-core-sdk/blob/main/guides/multisend-transactions.md) | How the Protocol Kit and SDK Starter Kit build MultiSend batches when you pass multiple transactions to `createTransaction` / `send`. |
 
 ## Need Help or Have Questions?
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -44,3 +44,5 @@ We'll assume that you are familiar with TypeScript (JavaScript), Ethereum and ha
 If you need help, please follow our support guidelines: https://github.com/safe-global/safe-core-sdk/tree/main/SUPPORT.md.
 
 Let's jump into the guide: [Integrating the Safe Core SDK](/guides/integrating-the-safe-core-sdk.md)
+
+For batching multiple calls in one Safe transaction, see [Batch transactions with MultiSend](/guides/multisend-transactions.md).

--- a/guides/integrating-the-safe-core-sdk.md
+++ b/guides/integrating-the-safe-core-sdk.md
@@ -170,11 +170,11 @@ console.log('Safe Threshold:', await protocolKit.getThreshold())
 
 ## <a name="create-transaction">4. Create a transaction</a>
 
-The Protocol Kit supports the execution of single Safe transactions but also MultiSend transactions. We can create a transaction object by calling the method `createTransaction` in our `Safe` instance.
+The Protocol Kit supports single Safe transactions and MultiSend batches. Create a transaction object by calling `createTransaction` on the `Safe` instance.
 
-This method takes an array of `MetaTransactionData` objects that represent the individual transactions we want to include in our MultiSend transaction. If we want to specify some of the optional properties in our MultiSend transaction, we can pass a second argument to the method `createTransaction` with the `SafeTransactionOptionalProps` object.
+Pass an array of `MetaTransactionData` objects. If the array has more than one item, the kit encodes a MultiSend (or MultiSendCallOnly) transaction automatically. Optional Safe transaction fields go in `options` on the same object. When the array contains only one transaction, it is not wrapped in MultiSend.
 
-When the array contains only one transaction, it is not wrapped in the MultiSend.
+For a dedicated walkthrough (including `onlyCalls` and the Starter Kit), see [Batch transactions with MultiSend](./multisend-transactions.md).
 
 ```js
 import { SafeTransactionOptionalProps } from '@safe-global/protocol-kit'

--- a/guides/multisend-transactions.md
+++ b/guides/multisend-transactions.md
@@ -1,0 +1,148 @@
+# Guide: Batch transactions with MultiSend
+
+Safe can execute several actions in a single Safe transaction by wrapping them with the [MultiSend](https://github.com/safe-global/safe-smart-account) library. The Protocol Kit does this for you when you pass more than one transaction to `createTransaction`. You do not need to call `encodeMultiSendData` yourself in normal application code.
+
+## Table of contents
+
+1. [How MultiSend works in the Protocol Kit](#how-multisend-works)
+2. [Create a MultiSend transaction](#create-multisend)
+3. [MultiSend vs MultiSendCallOnly](#multisend-vs-callonly)
+4. [Propose, sign, and execute](#propose-sign-execute)
+5. [SDK Starter Kit](#starter-kit)
+6. [Helpers: encodeMultiSendData / decodeMultiSendData](#helpers)
+
+## <a name="how-multisend-works">1. How MultiSend works in the Protocol Kit</a>
+
+`createTransaction` always receives an array of `MetaTransactionData` objects:
+
+- **One transaction** in the array: the Safe executes that call directly. No MultiSend wrapper is used.
+- **Two or more transactions**: the Protocol Kit encodes them with MultiSend (or MultiSendCallOnly) and builds one Safe transaction that points at the MultiSend contract with a `DelegateCall` operation.
+
+That single Safe transaction still needs the usual threshold of owner signatures before it can be executed.
+
+## <a name="create-multisend">2. Create a MultiSend transaction</a>
+
+```js
+import Safe from '@safe-global/protocol-kit'
+import { MetaTransactionData, OperationType } from '@safe-global/types-kit'
+
+const protocolKit = await Safe.init({
+  provider,
+  signer,
+  safeAddress
+})
+
+const transactions: MetaTransactionData[] = [
+  {
+    to: '0x...',
+    value: '0',
+    data: '0x...', // encoded calldata
+    operation: OperationType.Call // optional, defaults to Call
+  },
+  {
+    to: '0x...',
+    value: '0',
+    data: '0x...',
+    operation: OperationType.Call
+  }
+]
+
+const safeTransaction = await protocolKit.createTransaction({
+  transactions
+})
+```
+
+Optional gas and nonce fields can be passed through `options`:
+
+```js
+const safeTransaction = await protocolKit.createTransaction({
+  transactions,
+  options: {
+    safeTxGas, // optional
+    baseGas, // optional
+    gasPrice, // optional
+    gasToken, // optional
+    refundReceiver, // optional
+    nonce // optional
+  }
+})
+```
+
+For a longer end-to-end flow (propose via the API Kit, collect signatures, execute), see [Integrating the Safe Core SDK](./integrating-the-safe-core-sdk.md) and the [`createTransaction` reference](https://docs.safe.global/reference-sdk-protocol-kit/transactions/createtransaction).
+
+## <a name="multisend-vs-callonly">3. MultiSend vs MultiSendCallOnly</a>
+
+By default, `onlyCalls` is `true`. Batches then use the **MultiSendCallOnly** contract, which only allows `Call` operations inside the batch. That is the safer default for most apps.
+
+If any inner transaction uses `OperationType.DelegateCall`, set `onlyCalls: false` so the kit uses the full **MultiSend** contract:
+
+```js
+const safeTransaction = await protocolKit.createTransaction({
+  transactions,
+  onlyCalls: false
+})
+```
+
+If `onlyCalls` stays `true` and a transaction uses `DelegateCall`, `createTransaction` throws.
+
+## <a name="propose-sign-execute">4. Propose, sign, and execute</a>
+
+A MultiSend batch is still one Safe transaction. The propose / sign / execute steps are the same as for a single call:
+
+```js
+import SafeApiKit from '@safe-global/api-kit'
+
+const apiKit = new SafeApiKit({ chainId })
+
+const safeTxHash = await protocolKit.getTransactionHash(safeTransaction)
+const senderSignature = await protocolKit.signHash(safeTxHash)
+
+await apiKit.proposeTransaction({
+  safeAddress,
+  safeTransactionData: safeTransaction.data,
+  safeTxHash,
+  senderAddress,
+  senderSignature: senderSignature.data
+})
+
+// After enough owners have confirmed:
+const proposedTx = await apiKit.getTransaction(safeTxHash)
+const executeTxResponse = await protocolKit.executeTransaction(proposedTx)
+```
+
+On a 1-of-1 Safe you can skip the service and call `signTransaction` / `executeTransaction` directly on the Protocol Kit instance.
+
+## <a name="starter-kit">5. SDK Starter Kit</a>
+
+[`@safe-global/sdk-starter-kit`](https://github.com/safe-global/safe-core-sdk/tree/main/packages/sdk-starter-kit) wraps the same path. Pass several transactions to `send` and the client builds a MultiSend batch through the Protocol Kit:
+
+```js
+import { createSafeClient } from '@safe-global/sdk-starter-kit'
+
+const safeClient = await createSafeClient({
+  provider,
+  signer,
+  safeAddress,
+  apiKey
+})
+
+const txResult = await safeClient.send({
+  transactions: [
+    { to: '0x...', value: '0', data: '0x...' },
+    { to: '0x...', value: '0', data: '0x...' }
+  ]
+})
+```
+
+If the Safe threshold is greater than one, other owners confirm with `safeClient.confirm({ safeTxHash })`.
+
+## <a name="helpers">6. Helpers: encodeMultiSendData / decodeMultiSendData</a>
+
+`encodeMultiSendData` and `decodeMultiSendData` are exported from `@safe-global/protocol-kit` for advanced or tooling use (for example inspecting already-encoded MultiSend calldata). Day-to-day apps should prefer `createTransaction` (Protocol Kit) or `send` (Starter Kit), which call the encoder internally and select the correct MultiSend contract.
+
+```js
+import { encodeMultiSendData, decodeMultiSendData } from '@safe-global/protocol-kit'
+
+const encoded = encodeMultiSendData(transactions)
+const decoded = decodeMultiSendData(multiSendCalldata)
+```

--- a/packages/protocol-kit/README.md
+++ b/packages/protocol-kit/README.md
@@ -11,6 +11,7 @@ Software development kit that facilitates the interaction with [Safe Smart Accou
 - [Documentation](#documentation)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [MultiSend / batch transactions](#multisend--batch-transactions)
 - [Need Help or Have Questions?](#need-help-or-have-questions)
 - [Contributing](#contributing)
 - [License](#license)
@@ -61,6 +62,38 @@ const protocolKit = await Safe.init({
   predictedSafe
 })
 ```
+
+## MultiSend / batch transactions
+
+Safe can run several calls in one Safe transaction using MultiSend. Pass more than one item in the `transactions` array to `createTransaction` and the Protocol Kit builds the MultiSend (or MultiSendCallOnly) transaction for you:
+
+```js
+import { MetaTransactionData, OperationType } from '@safe-global/types-kit'
+
+const transactions: MetaTransactionData[] = [
+  {
+    to: '0x...',
+    value: '0',
+    data: '0x...',
+    operation: OperationType.Call // optional
+  },
+  {
+    to: '0x...',
+    value: '0',
+    data: '0x...',
+    operation: OperationType.Call
+  }
+]
+
+const safeTransaction = await protocolKit.createTransaction({
+  transactions
+  // onlyCalls: true by default (MultiSendCallOnly). Set false to allow DelegateCall.
+})
+```
+
+A single-element array is executed as a normal Safe transaction (no MultiSend wrapper). You usually do not need `encodeMultiSendData` directly; it is used internally by `createTransaction`.
+
+For a full walkthrough, see the [MultiSend guide](https://github.com/safe-global/safe-core-sdk/blob/main/guides/multisend-transactions.md) and the [`createTransaction` reference](https://docs.safe.global/reference-sdk-protocol-kit/transactions/createtransaction).
 
 ## Need Help or Have Questions?
 

--- a/packages/sdk-starter-kit/README.md
+++ b/packages/sdk-starter-kit/README.md
@@ -4,11 +4,13 @@
 [![GitHub Release](https://img.shields.io/github/release/safe-global/safe-core-sdk.svg?style=flat)](https://github.com/safe-global/safe-core-sdk/releases)
 [![GitHub](https://img.shields.io/github/license/safe-global/safe-core-sdk)](https://github.com/safe-global/safe-core-sdk/blob/main/LICENSE.md)
 
-Description TBD
+Higher-level client that wraps the [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) and [API Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/api-kit) so you can create, propose, confirm, and execute Safe transactions with less boilerplate.
 
 ## Table of contents
 
 - [Installation](#installation)
+- [Quick Start](#quick-start)
+- [MultiSend / batch transactions](#multisend--batch-transactions)
 - [Need Help or Have Questions?](#need-help-or-have-questions)
 - [Contributing](#contributing)
 - [License](#license)
@@ -21,6 +23,50 @@ Install the package with yarn or npm:
 yarn add @safe-global/sdk-starter-kit
 npm install @safe-global/sdk-starter-kit
 ```
+
+## Quick Start
+
+```js
+import { createSafeClient } from '@safe-global/sdk-starter-kit'
+
+const safeClient = await createSafeClient({
+  provider,
+  signer,
+  safeAddress,
+  apiKey // Safe{Core} API key when using the Transaction Service
+})
+
+const txResult = await safeClient.send({
+  transactions: [
+    {
+      to: '0x...',
+      value: '0',
+      data: '0x...'
+    }
+  ]
+})
+```
+
+If the Safe threshold is greater than one, other owners confirm the pending transaction:
+
+```js
+await safeClient.confirm({ safeTxHash: txResult.transactions.safeTxHash })
+```
+
+## MultiSend / batch transactions
+
+`send` accepts an array of transactions. When the array has more than one item, the Starter Kit uses the Protocol Kit to wrap them in a MultiSend batch automatically (same behaviour as `protocolKit.createTransaction({ transactions })`):
+
+```js
+const txResult = await safeClient.send({
+  transactions: [
+    { to: '0x...', value: '0', data: '0x...' },
+    { to: '0x...', value: '0', data: '0x...' }
+  ]
+})
+```
+
+See the [MultiSend guide](https://github.com/safe-global/safe-core-sdk/blob/main/guides/multisend-transactions.md) for details on MultiSend vs MultiSendCallOnly and the lower-level Protocol Kit API.
 
 ## Need Help or Have Questions?
 


### PR DESCRIPTION
## Summary

MultiSend was easy to miss in the package docs. This adds a dedicated guide plus README sections for Protocol Kit and the SDK Starter Kit.

- New guide: how `createTransaction` / `send` build MultiSend batches when the transactions array has more than one item
- Clarifies MultiSend vs MultiSendCallOnly (`onlyCalls`)
- Notes that `encodeMultiSendData` is a helper, not the primary API
- Cross-links from the root README and the integrating guide

Fixes #1182

## Test plan

- [ ] Skim `guides/multisend-transactions.md` for accuracy against current `createTransaction` behaviour
- [ ] Confirm Protocol Kit and Starter Kit README examples match existing doc style
- [ ] Check links from root README Guides table and `guides/README.md`