### PR TITLE
fix(protocol-kit): truncate generateHash by bytes and bump identifier to v01

### DIFF
--- a/packages/protocol-kit/src/utils/on-chain-tracking/generateOnChainIdentifier.ts
+++ b/packages/protocol-kit/src/utils/on-chain-tracking/generateOnChainIdentifier.ts
@@ -9,7 +9,8 @@ import { keccak256, toHex } from 'viem'
  */
 export function generateHash(input: string, size: number): string {
   const fullHash = keccak256(toHex(input))
-  return toHex(fullHash.slice(-size)).replace('0x', '') // Take the last X bytes
+  // Take the last `size` bytes (2 hex characters per byte). fullHash is 0x-prefixed.
+  return fullHash.slice(-size * 2)
 }
 
 export type OnChainIdentifierParamsType = {
@@ -45,7 +46,8 @@ function generateOnChainIdentifier({
   toolVersion
 }: OnChainIdentifierParamsType): string {
   const identifierPrefix = '5afe'
-  const identifierVersion = '00' // first version
+  // Version 01: byte-accurate hash truncation (see #1424). Version 00 used nibble/hex-char truncation.
+  const identifierVersion = '01'
   const projectHash = generateHash(project, 20) // Take the last 20 bytes
   const platformHash = generateHash(platform, 3) // Take the last 3 bytes
   const toolHash = generateHash(tool, 3) // Take the last 3 bytes

--- a/packages/protocol-kit/tests/e2e/onChainIdentifier.test.ts
+++ b/packages/protocol-kit/tests/e2e/onChainIdentifier.test.ts
@@ -30,14 +30,26 @@ describe('On-chain analytics', () => {
       const onChainIdentifier = generateOnChainIdentifier({ project, platform, tool, toolVersion })
 
       const identifierPrefix = '5afe'
-      const identifierVersion = '00'
+      const identifierVersion = '01'
+
+      // Hard-coded expected hashes (byte-accurate truncation, identifier version 01)
+      const expectedProjectHash = 'b239ef6cc45f806ddf9a8ae456f26a86add0878d'
+      const expectedPlatformHash = '193dea'
+      const expectedToolHash = 'bfe928'
+      const expectedToolVersionHash = 'b2972c'
 
       chai.expect(onChainIdentifier.startsWith(identifierPrefix)).to.be.true
       chai.expect(onChainIdentifier.substring(4, 6)).to.equals(identifierVersion)
-      chai.expect(onChainIdentifier.substring(6, 46)).to.equals(generateHash(project, 20))
-      chai.expect(onChainIdentifier.substring(46, 52)).to.equals(generateHash(platform, 3))
-      chai.expect(onChainIdentifier.substring(52, 58)).to.equals(generateHash(tool, 3))
-      chai.expect(onChainIdentifier.substring(58, 64)).to.equals(generateHash(toolVersion, 3))
+      chai.expect(onChainIdentifier.substring(6, 46)).to.equals(expectedProjectHash)
+      chai.expect(onChainIdentifier.substring(46, 52)).to.equals(expectedPlatformHash)
+      chai.expect(onChainIdentifier.substring(52, 58)).to.equals(expectedToolHash)
+      chai.expect(onChainIdentifier.substring(58, 64)).to.equals(expectedToolVersionHash)
+
+      // Also confirm generateHash itself matches the byte-accurate vectors
+      chai.expect(generateHash(project, 20)).to.equals(expectedProjectHash)
+      chai.expect(generateHash(platform, 3)).to.equals(expectedPlatformHash)
+      chai.expect(generateHash(tool, 3)).to.equals(expectedToolHash)
+      chai.expect(generateHash(toolVersion, 3)).to.equals(expectedToolVersionHash)
     })
   })
 
@@ -60,7 +72,7 @@ describe('On-chain analytics', () => {
         onchainAnalytics
       })
 
-      const onChainIdentifier = '5afe003861653435366632366138366164643038373864646561393238653366'
+      const onChainIdentifier = '5afe01b239ef6cc45f806ddf9a8ae456f26a86add0878d193deabfe928a73e3f'
 
       chai.expect(onChainIdentifier).to.equals(protocolKit.getOnchainIdentifier())
       stub.restore()
@@ -113,7 +125,7 @@ describe('On-chain analytics', () => {
       const toolHash = generateHash(toolVersion, 3)
 
       const onChainIdentifier =
-        '5afe003861653435366632366138366164643038373864646561393238' + toolHash
+        '5afe01b239ef6cc45f806ddf9a8ae456f26a86add0878d193deabfe928' + toolHash
 
       chai.expect(onChainIdentifier).to.equals(protocolKit.getOnchainIdentifier())
       chai.expect(deploymentTransaction.data.endsWith(onChainIdentifier)).to.be.true
@@ -163,7 +175,7 @@ describe('On-chain analytics', () => {
       const toolHash = generateHash(toolVersion, 3)
 
       const onChainIdentifier =
-        '5afe003861653435366632366138366164643038373864646561393238' + toolHash
+        '5afe01b239ef6cc45f806ddf9a8ae456f26a86add0878d193deabfe928' + toolHash
 
       chai.expect(onChainIdentifier).to.equals(protocolKit.getOnchainIdentifier())
       chai.expect(transaction.input.endsWith(onChainIdentifier)).to.be.true


### PR DESCRIPTION
## Summary

Fixes #1424.

`generateHash` documents `size` as a byte count, but it was slicing the keccak hex **string** by character count and then running `toHex()` on those ASCII characters. That re-encodes hex digits as bytes, so each field only ever holds ASCII `'0'`-`'9'` / `'a'`-`'f'` values - about half the claimed entropy (for example `2^12` instead of `2^24` for the 3-byte fields).

## What changed

1. **Byte-accurate truncation** - take the last `size * 2` hex characters from the `0x`-prefixed digest (real bytes), and stop re-encoding with `toHex()`:
   ```ts
   return fullHash.slice(-size * 2)
   ```
2. **Bump `identifierVersion` from `00` to `01`** - so new identifiers are explicitly versioned and stay distinguishable from identifiers already published on-chain with the old nibble-based truncation. Off-chain analytics that key on the current format can keep treating `00` as before.
3. **Tests** - update e2e expectations to version `01` and assert against hard-coded byte-accurate hash vectors (not a fresh call to `generateHash` alone), so regressions in truncation are actually caught.

## Why the version bump

A silent fix to `generateHash` would change the bit pattern of every future identifier for the same project/platform/tool/toolVersion inputs relative to what is already on-chain. The format already has an `identifierVersion` byte for this kind of change, so bumping it to `01` is the safe way to ship the corrected truncation.

This path is analytics / attribution metadata appended to transaction data only - not a signature, fund-safety, or fail-open verification path. Collisions under the old entropy mainly make distinct tool versions (or platforms/projects) harder to tell apart in on-chain analytics.

## Example (size = 20)

For digest
`0x5cf9c0e95198ffeb9ef583d208e91798eb10bbf881ec2526939f24f8049e7556`:

| Step | Old (buggy) | New (byte-accurate) |
|------|-------------|---------------------|
| Slice | last 20 **chars**: `2526939f24f8049e7556` | last 20 **bytes**: `08e91798eb10bbf881ec2526939f24f8049e7556` |
| Output | `32353236...` (ASCII of those chars) | the 40 hex chars above |

## Test plan

- [ ] `yarn testing-kit test tests/e2e/onChainIdentifier.test.ts` (or equivalent protocol-kit e2e for on-chain identifier)
- [ ] Confirm identifiers now start with `5afe01`
- [ ] Confirm `generateHash(input, n)` length is always `2 * n` and is not ASCII-decodable back to a short hex substring of the digest
- [ ] Maintainers: confirm version-gated ship (`01` for new writes) matches the intended rollout for analytics consumers

Happy to adjust the versioning/compatibility shape if maintainers prefer a different approach (for example keeping a legacy helper for reproducing `00` identifiers in tests only).